### PR TITLE
add error dataset support to repack, fixes #3579

### DIFF
--- a/src/python/T0/JobSplitting/RepackMerge.py
+++ b/src/python/T0/JobSplitting/RepackMerge.py
@@ -271,8 +271,12 @@ class RepackMerge(JobFactory):
 
         self.newJob(name = "%s-%s" % (self.jobNamePrefix, makeUUID()))
 
+        if errorDataset:
+            self.currentJob.addBaggageParameter("useErrorDataset", True)
+
         for fileInfo in fileList:
             f = File(id = fileInfo['id'],
                      lfn = fileInfo['lfn'])
             f.setLocation(fileInfo['location'], immediateSave = False)
             self.currentJob.addFile(f)
+

--- a/src/python/T0/WMSpec/StdSpecs/Repack.py
+++ b/src/python/T0/WMSpec/StdSpecs/Repack.py
@@ -150,6 +150,12 @@ class RepackWorkloadFactory(StdBase):
                              filterName = getattr(parentOutputModule, "filterName"),
                              forceMerged = True)
 
+        self.addOutputModule(mergeTask, "MergedError",
+                             primaryDataset = getattr(parentOutputModule, "primaryDataset") + "-Error",
+                             dataTier = getattr(parentOutputModule, "dataTier"),
+                             filterName = getattr(parentOutputModule, "filterName"),
+                             forceMerged = True)
+
         self.addCleanupTask(parentTask, parentOutputModuleName)
 
         return mergeTask


### PR DESCRIPTION
Add an extra output to the RepackMerge step in the Repack spec and pass a useErrorDataset parameter with the job baggage in the RepackMerge job splitter if needed. The needed changes in the runtime code to configure the merge job for the correct output is already in WMCore.
