### PR TITLE
add dqm sequences to express and promptreco, fixes #3926

### DIFF
--- a/src/python/T0/RunConfig/RunConfigAPI.py
+++ b/src/python/T0/RunConfig/RunConfigAPI.py
@@ -227,19 +227,24 @@ def configureRunStream(tier0Config, run, stream, specDirectory, lfnBase, dqmUplo
                                               'eventContent' : "DQM",
                                               'primaryDataset' : specialDataset } )
 
-            writeSkims = None
+            alcaSkim = None
             if "ALCARECO" in streamConfig.Express.DataTiers:
-                if len(streamConfig.Express.Producers) > 0:
+                if len(streamConfig.Express.AlcaSkims) > 0:
                     outputModuleDetails.append( { 'dataTier' : "ALCARECO",
                                                   'eventContent' : "ALCARECO",
                                                   'primaryDataset' : specialDataset } )
-                    writeSkims = ",".join(streamConfig.Express.Producers)
+                    alcaSkim = ",".join(streamConfig.Express.AlcaSkims)
+
+            dqmSeq = None
+            if len(streamConfig.Express.DqmSequences) > 0:
+                dqmSeq = ",".join(streamConfig.Express.DqmSequences)
 
             bindsExpressConfig = { 'RUN' : run,
                                    'STREAM' : stream,
                                    'PROC_VER' : streamConfig.Express.ProcessingVersion,
                                    'WRITE_TIERS' : ",".join(streamConfig.Express.DataTiers),
-                                   'WRITE_SKIMS' : writeSkims,
+                                   'ALCA_SKIM' : alcaSkim,
+                                   'DQM_SEQ' : dqmSeq,
                                    'GLOBAL_TAG' : streamConfig.Express.GlobalTag }
 
 
@@ -326,7 +331,8 @@ def configureRunStream(tier0Config, run, stream, specDirectory, lfnBase, dqmUplo
             specArguments['ProcScenario'] = streamConfig.Express.Scenario
             specArguments['GlobalTag'] = streamConfig.Express.GlobalTag
             specArguments['GlobalTagTransaction'] = "Express_%d" % run
-            specArguments['AlcaSkims'] = streamConfig.Express.Producers
+            specArguments['AlcaSkims'] = streamConfig.Express.AlcaSkims
+            specArguments['DqmSequences'] = streamConfig.Express.DqmSequences
             specArguments['UnmergedLFNBase'] = "%s/t0temp/express" % lfnBase
             specArguments['MergedLFNBase'] = "%s/express" % lfnBase
             specArguments['DQMUploadProxy'] = dqmUploadProxy
@@ -464,9 +470,13 @@ def releasePromptReco(tier0Config, specDirectory, lfnBase, dqmUploadProxy = None
 
         bindsCMSSWVersion.append( { 'VERSION' : datasetConfig.Reco.CMSSWVersion } )
 
-        writeSkims = None
-        if len(datasetConfig.Alca.Producers) > 0:
-            writeSkims = ",".join(datasetConfig.Alca.Producers)
+        alcaSkim = None
+        if len(datasetConfig.Reco.AlcaSkims) > 0:
+            alcaSkim = ",".join(datasetConfig.Reco.AlcaSkims)
+
+        dqmSeq = None
+        if len(datasetConfig.Reco.DqmSequences) > 0:
+            dqmSeq = ",".join(datasetConfig.Reco.DqmSequences)
 
         bindsRecoConfig.append( { 'RUN' : run,
                                   'PRIMDS' : dataset,
@@ -477,7 +487,8 @@ def releasePromptReco(tier0Config, specDirectory, lfnBase, dqmUploadProxy = None
                                   'WRITE_DQM' : int(datasetConfig.Reco.WriteDQM),
                                   'WRITE_AOD' : int(datasetConfig.Reco.WriteAOD),
                                   'PROC_VER' : datasetConfig.Reco.ProcessingVersion,
-                                  'WRITE_SKIMS' : writeSkims,
+                                  'ALCA_SKIM' : alcaSkim,
+                                  'DQM_SEQ' : dqmSeq,
                                   'GLOBAL_TAG' : datasetConfig.Reco.GlobalTag } )
 
         requestOnly = "y"
@@ -536,7 +547,7 @@ def releasePromptReco(tier0Config, specDirectory, lfnBase, dqmUploadProxy = None
             writeTiers.append("AOD")
         if datasetConfig.Reco.WriteDQM:
             writeTiers.append("DQM")
-        if len(datasetConfig.Alca.Producers) > 0:
+        if len(datasetConfig.Reco.AlcaSkims) > 0:
             writeTiers.append("ALCARECO")
 
         if datasetConfig.Reco.DoReco and len(writeTiers) > 0:
@@ -561,7 +572,8 @@ def releasePromptReco(tier0Config, specDirectory, lfnBase, dqmUploadProxy = None
             specArguments['InputDataset'] = "/%s/%s-%s/RAW" % (dataset, acqEra, repackProcVer)
 
             specArguments['WriteTiers'] = writeTiers
-            specArguments['AlcaSkims'] = datasetConfig.Alca.Producers
+            specArguments['AlcaSkims'] = datasetConfig.Reco.AlcaSkims
+            specArguments['DqmSequences'] = datasetConfig.Reco.DqmSequences
 
             specArguments['UnmergedLFNBase'] = "%s/t0temp/data" % lfnBase
             specArguments['MergedLFNBase'] = "%s/data" % lfnBase

--- a/src/python/T0/RunConfig/Tier0Config.py
+++ b/src/python/T0/RunConfig/Tier0Config.py
@@ -11,7 +11,9 @@ Tier0Configuration - Global configuration object
 | |       |       stream or dataset and can be applied to an entire run.
 | |       |
 | |       |--> Version - The CVS revision of the config
+| |       |
 | |       |--> AcquisitionEra - The acquisition era for the run
+| |       |
 | |       |--> PhEDExSubscriptions - Dictionary of PhEDEx subscriptions where the
 | |                                  primary dataset id is the key and the storage
 | |                                  node name is the value
@@ -39,7 +41,9 @@ Tier0Configuration - Global configuration object
 |             |     |
 |             |     |--> GlobalTag - Global tag used for processing
 |             |     |
-|             |     |--> Producers - List of alca producers active for this stream.
+|             |     |--> AlcaSkims - List of alca skims active for this stream.
+|             |     |
+|             |     |--> DqmSequences - List of dqm sequences active for this stream.
 |             |     |
 |             |     |--> ProcessingVersion - processing version
 |             |
@@ -75,13 +79,20 @@ Tier0Configuration - Global configuration object
       |
       |--> DATASETNAME
             |--> Name - Name of the dataset.
+            |
             |--> Scenario - Processing scenario for this dataset.
+            |
             |--> RecoDelay - PromptReco delay
+            |
             |--> RecoDelayOffset - Time before PromptReco release for which
             |                      settings are locked in and reco looks released
+            |
             |--> CustodialNode - The custodial PhEDEx storage node for this dataset
+            |
             |--> ArchivalNode - The archival PhEDEx node, always CERN.
+            |
             |--> CustodialPriority - The priority of the custodial subscription
+            |
             |--> CustodialAutoApprove - Determine whether or not the custodial
             |                           subscription will be auto approved.
             |
@@ -92,27 +103,36 @@ Tier0Configuration - Global configuration object
             |     |
             |     |--> DoReco - Either True or False.  Determines whether prompt
             |     |             reconstruction is preformed on this dataset.
+            |     |
             |     |--> GlobalTag - The global tag that will be used to prompt
             |     |                reconstruction.  Only used if DoReco is true.
-            |     |--> CMSSWVersion - Framework version to be used for prompt
-            |                         reconstruction.  This only needs to be filled
-            |                         in if DoReco is True and will default to
-            |                         Undefined if not set.
-            |
-            |--> Alca - Configuration section to hold settings related to alca production.
             |     |
-            |     |--> Producers - List of alca producers active for this dataset.
+            |     |--> CMSSWVersion - Framework version to be used for prompt
+            |     |                   reconstruction.  This only needs to be filled
+            |     |                   in if DoReco is True and will default to
+            |     |                   Undefined if not set.
+            |     |
+            |     |--> AlcaSkims - List of alca skims active for this dataset.
+            |     |
+            |     |--> DqmSequences - List of dqm sequences active for this dataset.
             |
             |--> Tier1Skims - List of configuration section objects to hold Tier1 skims for
                   |           this dataset.
                   |
                   |--> DataTier - The tier of the input data.
+                  |
                   |--> PrimaryDataset - The primary dataset of the input data.
+                  |
                   |--> GlobalTag - The global tag to use with the skim.
+                  |
                   |--> CMSSWVersion - The framework version to use with the skim.
+                  |
                   |--> SkimName - The name of the skim.  Used for generating more descriptive job names.
+                  |
                   |--> ConfigURL - A URL to the framework config for the config.
+                  |
                   |--> ProcessingVersion - The processing version of the skim.
+                  |
                   |--> TwoFileRead - Bool that determines if this is a two file read skim.
 """
 
@@ -279,8 +299,8 @@ def addDataset(config, datasetName, **settings):
     datasetConfig.Reco.WriteRECO = settings.get("write_reco", True)
     datasetConfig.Reco.WriteDQM = settings.get("write_dqm", True)
     datasetConfig.Reco.WriteAOD = settings.get("write_aod", True)
-
-    datasetConfig.Alca.Producers = settings.get("alca_producers", [])
+    datasetConfig.Reco.AlcaSkims = settings.get("alca_producers", [])
+    datasetConfig.Reco.DqmSequences = settings.get("dqm_sequences", [])
 
     datasetConfig.CustodialNode = settings.get("custodial_node", None)
     datasetConfig.CustodialPriority = settings.get("custodial_priority", "high")
@@ -382,8 +402,10 @@ def addExpressConfig(config, streamName, **options):
     streamConfig.Express.DataTiers = data_tiers
     streamConfig.Express.GlobalTag = global_tag
 
-    streamConfig.Express.Producers = options.get("alca_producers", [])
+    streamConfig.Express.AlcaSkims = options.get("alca_producers", [])
+    streamConfig.Express.DqmSequences = options.get("dqm_sequences", [])
     streamConfig.Express.ProcessingVersion = options.get("proc_ver", 1)
+
     return
 
 def addRegistrationConfig(config, streamName, **options):

--- a/src/python/T0/WMBS/Oracle/Create.py
+++ b/src/python/T0/WMBS/Oracle/Create.py
@@ -252,7 +252,8 @@ class Create(DBCreator):
                  stream_id      int           not null,
                  proc_version   int           not null,
                  write_tiers    varchar(255)  not null,
-                 write_skims    varchar(1000),
+                 alca_skim      varchar(1000),
+                 dqm_seq        varchar(1000),
                  global_tag     varchar(255),
                  primary key (run_id, stream_id)
                )"""
@@ -268,7 +269,8 @@ class Create(DBCreator):
                   write_dqm      int           not null,
                   write_aod      int           not null,
                   proc_version   int           not null,
-                  write_skims    varchar(1000),
+                  alca_skim      varchar(1000),
+                  dqm_seq        varchar(1000),
                   global_tag     varchar(255),
                   primary key (run_id, primds_id)
                )"""

--- a/src/python/T0/WMBS/Oracle/RunConfig/GetExpressConfig.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/GetExpressConfig.py
@@ -14,7 +14,8 @@ class GetExpressConfig(DBFormatter):
         sql = """SELECT express_config.proc_version AS proc_ver,
                         cmssw_version.name AS cmssw,
                         express_config.write_tiers AS write_tiers,
-                        express_config.write_skims AS write_skims,
+                        express_config.alca_skim AS alca_skim,
+                        express_config.dqm_seq AS dqm_seq,
                         express_config.global_tag AS global_tag,
                         event_scenario.name AS scenario
                  FROM express_config

--- a/src/python/T0/WMBS/Oracle/RunConfig/GetRecoConfig.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/GetRecoConfig.py
@@ -24,7 +24,8 @@ class GetRecoConfig(DBFormatter):
                         reco_config.write_aod,
                         reco_config.write_dqm,
                         reco_config.proc_version,
-                        reco_config.write_skims,
+                        reco_config.alca_skim,
+                        reco_config.dqm_seq,
                         reco_config.global_tag,
                         event_scenario.name
                  FROM reco_config
@@ -67,8 +68,9 @@ class GetRecoConfig(DBFormatter):
             resultDict[primds]['write_aod'] = result[5]
             resultDict[primds]['write_dqm'] = result[6]
             resultDict[primds]['proc_ver'] = result[7]
-            resultDict[primds]['write_skims'] = result[8]
-            resultDict[primds]['global_tag'] = result[9]
-            resultDict[primds]['scenario'] = result[10]
+            resultDict[primds]['alca_skim'] = result[8]
+            resultDict[primds]['dqm_seq'] = result[9]
+            resultDict[primds]['global_tag'] = result[10]
+            resultDict[primds]['scenario'] = result[11]
 
         return resultDict

--- a/src/python/T0/WMBS/Oracle/RunConfig/InsertExpressConfig.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/InsertExpressConfig.py
@@ -13,12 +13,13 @@ class InsertExpressConfig(DBFormatter):
 
         sql = """INSERT INTO express_config
                  (RUN_ID, STREAM_ID, PROC_VERSION,
-                  WRITE_TIERS, WRITE_SKIMS, GLOBAL_TAG)
+                  WRITE_TIERS, ALCA_SKIM, DQM_SEQ, GLOBAL_TAG)
                  VALUES (:RUN,
                          (SELECT id FROM stream WHERE name = :STREAM),
                          :PROC_VER,
                          :WRITE_TIERS,
-                         :WRITE_SKIMS,
+                         :ALCA_SKIM,
+                         :DQM_SEQ,
                          :GLOBAL_TAG)
                  """
 

--- a/src/python/T0/WMBS/Oracle/RunConfig/InsertRecoConfig.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/InsertRecoConfig.py
@@ -13,7 +13,7 @@ class InsertRecoConfig(DBFormatter):
 
         sql = """INSERT INTO reco_config
                  (RUN_ID, PRIMDS_ID, DO_RECO, CMSSW_ID, RECO_SPLIT, WRITE_RECO,
-                  WRITE_DQM, WRITE_AOD, PROC_VERSION, WRITE_SKIMS, GLOBAL_TAG)
+                  WRITE_DQM, WRITE_AOD, PROC_VERSION, ALCA_SKIM, DQM_SEQ, GLOBAL_TAG)
                  VALUES (:RUN,
                          (SELECT id FROM primary_dataset WHERE name = :PRIMDS),
                          :DO_RECO,
@@ -23,7 +23,8 @@ class InsertRecoConfig(DBFormatter):
                          :WRITE_DQM,
                          :WRITE_AOD,
                          :PROC_VER,
-                         :WRITE_SKIMS,
+                         :ALCA_SKIM,
+                         :DQM_SEQ,
                          :GLOBAL_TAG)
                  """
 

--- a/src/python/T0/WMSpec/StdSpecs/Express.py
+++ b/src/python/T0/WMSpec/StdSpecs/Express.py
@@ -40,7 +40,8 @@ def getTestArguments():
         "GlobalTag" : None,
         "GlobalTagTransaction" : None,
         "Outputs" : None,
-        "AlcaSkims" : None,
+        "AlcaSkims" : [ "TkAlCosmics0T", "MuAlGlobalCosmics", "HcalCalHOCosmics" ],
+        "DqmSequences" : [ "@common", "@jetmet" ],
 
         # optional for now
         "Multicore" : None,
@@ -100,6 +101,7 @@ class ExpressWorkloadFactory(StdBase):
                                                   scenarioArgs = { 'globalTag' : self.globalTag,
                                                                    'globalTagTransaction' : self.globalTagTransaction,
                                                                    'skims' : self.alcaSkims,
+                                                                   'dqmSeq' : self.dqmSequences,
                                                                    'outputs' : self.outputs },
                                                   splitAlgo = "Express",
                                                   splitArgs = mySplitArgs,
@@ -222,6 +224,7 @@ class ExpressWorkloadFactory(StdBase):
 	self.globalTagTransaction = arguments["GlobalTagTransaction"]
         self.procScenario = arguments['ProcScenario']
         self.alcaSkims = arguments['AlcaSkims']
+        self.dqmSequences = arguments['DqmSequences']
         self.outputs = arguments['Outputs']
         self.dqmUploadProxy = arguments['DQMUploadProxy']
 


### PR DESCRIPTION
Some internal changes in schema and code to cleanup handling of alca skims.
Add support for configuring DQM sequences for express and promptreco.
