### PR TITLE
schema change to support task archiving

### DIFF
--- a/src/python/T0/WMBS/Oracle/Create.py
+++ b/src/python/T0/WMBS/Oracle/Create.py
@@ -534,7 +534,8 @@ class Create(DBCreator):
             """ALTER TABLE run_stream_fileset_assoc
                  ADD CONSTRAINT run_str_fil_fil_id_fk
                  FOREIGN KEY (fileset)
-                 REFERENCES wmbs_fileset(id)"""
+                 REFERENCES wmbs_fileset(id)
+                 ON DELETE CASCADE"""
 
         self.constraints[len(self.constraints)] = \
             """ALTER TABLE reco_release_config


### PR DESCRIPTION
The run_stream_fileset_assoc table in the Tier0 schema
holds a foreign key reference to the wmbs_fileset id
for the top level filesets for repack, express and
promptreco. When the TaskArchiver tries to delete
the subscription on that fileset, it also tries to
delete the fileset, which fails due to a foreign
key error.

I modified the Tier0 schema to cascade delete the
row in run_stream_fileset_assoc when the corresponding
fileset is deleted.
