### PR TITLE
fix repack/promptreco task archive problems

### DIFF
--- a/src/python/T0/RunConfig/RunConfigAPI.py
+++ b/src/python/T0/RunConfig/RunConfigAPI.py
@@ -394,7 +394,8 @@ def configureRunStream(tier0Config, run, stream, specDirectory, lfnBase, dqmUplo
                                                      'RECODELAY' : promptRecoDelay[primds],
                                                      'RECODELAYOFFSET' : promptRecoDelayOffset[primds] } )
                 insertRecoReleaseConfigDAO.execute(bindsRecoReleaseConfig, conn = myThread.transaction.conn, transaction = True)
-            markWorkflowsInjectedDAO.execute([workflowName], injected = True, conn = myThread.transaction.conn, transaction = True)
+            else:
+                markWorkflowsInjectedDAO.execute([workflowName], injected = True, conn = myThread.transaction.conn, transaction = True)
         except:
             myThread.transaction.rollback()
             raise

--- a/src/python/T0/WMBS/Oracle/Create.py
+++ b/src/python/T0/WMBS/Oracle/Create.py
@@ -553,7 +553,8 @@ class Create(DBCreator):
             """ALTER TABLE reco_release_config
                  ADD CONSTRAINT rec_rel_con_fil_id_fk
                  FOREIGN KEY (fileset)
-                 REFERENCES wmbs_fileset(id)"""
+                 REFERENCES wmbs_fileset(id)
+                 ON DELETE CASCADE"""
 
         self.constraints[len(self.constraints)] = \
             """ALTER TABLE stream_special_primds_assoc

--- a/src/python/T0/WMBS/Oracle/Tier0Feeder/MarkRepackInjected.py
+++ b/src/python/T0/WMBS/Oracle/Tier0Feeder/MarkRepackInjected.py
@@ -1,0 +1,41 @@
+"""
+_MarkRepackInjected_
+
+Oracle implementation of MarkRepackInjected
+
+Check that all datasets for a workflow (ie. stream)
+have had their PromptReco released and then mark
+the repack workflow as injected
+"""
+
+from WMCore.Database.DBFormatter import DBFormatter
+
+class MarkRepackInjected(DBFormatter):
+
+    def execute(self, conn = None, transaction = False):
+
+        sql = """UPDATE wmbs_workflow
+                 SET injected = 1
+                 WHERE name in (
+                   SELECT wmbs_workflow.name
+                   FROM run_stream_fileset_assoc
+                     INNER JOIN wmbs_subscription ON
+                       wmbs_subscription.fileset = run_stream_fileset_assoc.fileset
+                     INNER JOIN wmbs_workflow ON
+                       wmbs_workflow.id = wmbs_subscription.workflow AND
+                       wmbs_workflow.injected = 0
+                     INNER JOIN run_primds_stream_assoc ON
+                       run_primds_stream_assoc.run_id = run_stream_fileset_assoc.run_id AND
+                       run_primds_stream_assoc.stream_id =   run_stream_fileset_assoc.stream_id
+                     LEFT OUTER JOIN reco_config ON
+                       reco_config.run_id = run_stream_fileset_assoc.run_id AND
+                       reco_config.primds_id = run_primds_stream_assoc.primds_id
+                   GROUP BY wmbs_workflow.name
+                   HAVING COUNT(reco_config.run_id) = COUNT(*)
+                 )
+                 """
+
+        self.dbi.processData(sql, binds = {}, conn = conn,
+                             transaction = transaction)
+
+        return

--- a/src/python/T0Component/Tier0Feeder/Tier0FeederPoller.py
+++ b/src/python/T0Component/Tier0Feeder/Tier0FeederPoller.py
@@ -84,6 +84,7 @@ class Tier0FeederPoller(BaseWorkerThread):
         findNewExpressRunsDAO = self.daoFactory(classname = "Tier0Feeder.FindNewExpressRuns")
         releaseExpressDAO = self.daoFactory(classname = "Tier0Feeder.ReleaseExpress")
         feedStreamersDAO = self.daoFactory(classname = "Tier0Feeder.FeedStreamers")
+        markRepackInjectedDAO = self.daoFactory(classname = "Tier0Feeder.MarkRepackInjected")
 
         tier0Config = None
         try:
@@ -170,6 +171,13 @@ class Tier0FeederPoller(BaseWorkerThread):
                                        self.specDirectory,
                                        self.lfnBase,
 				       self.dqmUploadProxy)
+
+        #
+        # check if all datasets for a stream had their PromptReco released
+        # then mark the repack workflow as injected (if we don't wait, the
+        # task archiver will cleanup too early)
+        #
+        markRepackInjectedDAO.execute(transaction = False)
 
         #
         # close stream/lumis for run/streams that are active (fileset exists and open)


### PR DESCRIPTION
There is currently a race condition between
Repack, PromptReco and the TaskArchiver. If
repacking is done before PromptReco is
configured, it looks like everything is
finished and the TaskArchiver will try to
cleanup repacking, including the fileset
that is the input for PromptReco.

To prevent the TaskArvchiver from seeing the
repack workflow, only mark that workflow
as injected after all primary datasets
for the stream that is repacked have had
their PromptReco configured and released.

Also included a CASCADE DELETE in the Tier0
schema on the assoc table that holds the
input fileset for PromptReco.
