### PR TITLE
add PCL support to Express, fixes #3567

### DIFF
--- a/src/python/T0/JobSplitting/Condition.py
+++ b/src/python/T0/JobSplitting/Condition.py
@@ -1,0 +1,67 @@
+"""
+_Condition_
+
+Splitting algorithm for PCL condition handling
+"""
+
+import logging
+import threading
+import time
+
+from WMCore.WMBS.File import File
+
+from WMCore.JobSplitting.JobFactory import JobFactory
+from WMCore.DAOFactory import DAOFactory
+
+
+class Condition(JobFactory):
+    """
+    Split jobs by set of files
+
+    """
+    def algorithm(self, groupInstance = None, jobInstance = None,
+                  *args, **kwargs):
+        """
+        _algorithm_
+
+        Different from any other job splitters in that
+        we don't ever create any jobs.
+
+        We just look at available files, process the information,
+        store it in a different T0AST table and then mark the
+        files as complete.
+
+        Some other component will pick up from the info we wrote.
+
+        """
+        myThread = threading.currentThread()
+        daoFactory = DAOFactory(package = "T0.WMBS",
+                                logger = logging,
+                                dbinterface = myThread.dbi)
+
+        # only deal with closed fileset
+        fileset = self.subscription.getFileset()
+        fileset.load()
+        if fileset.open:
+            return
+
+        # data discovery
+        getFilesDAO = daoFactory(classname = "Subscriptions.GetAvailableConditionFiles")
+        availableFiles = getFilesDAO.execute(self.subscription["id"])
+
+        # nothing to do, stop immediately
+        if len(availableFiles) == 0:
+            return
+
+        bindVarList = []
+        for availableFile in availableFiles:
+            bindVarList.append( { 'SUBSCRIPTION' : self.subscription["id"],
+                                  'FILEID' : availableFile['id'],
+                                  'RUN_ID' : availableFile['run_id'],
+                                  'STREAM_ID' : availableFile['stream_id'] } )
+
+        # save the information in T0AST and mark files complete
+        insertPromptCalibrationFileDAO = daoFactory(classname = "JobSplitting.InsertPromptCalibrationFile")
+        insertPromptCalibrationFileDAO.execute(bindVarList)
+
+        return

--- a/src/python/T0/WMBS/Oracle/Create.py
+++ b/src/python/T0/WMBS/Oracle/Create.py
@@ -247,6 +247,22 @@ class Create(DBCreator):
                )"""
 
         self.create[len(self.create)] = \
+            """CREATE TABLE prompt_calib (
+                 run_id         int   not null,
+                 stream_id      int   not null,
+                 finished       int   default 0 not null,
+                 primary key (run_id, stream_id)
+               )"""
+
+        self.create[len(self.create)] = \
+            """CREATE TABLE prompt_calib_file (
+                 run_id         int   not null,
+                 stream_id      int   not null,
+                 fileid         int   not null,
+                 primary key (run_id, stream_id, fileid)
+               )"""
+
+        self.create[len(self.create)] = \
             """CREATE TABLE express_config (
                  run_id         int           not null,
                  stream_id      int           not null,
@@ -400,6 +416,9 @@ class Create(DBCreator):
 
         self.indexes[len(self.indexes)] = \
             """CREATE INDEX idx_streamer_3 ON streamer (checkForZeroOneState(deleted))"""
+
+        self.indexes[len(self.indexes)] = \
+            """CREATE INDEX idx_prompt_calib_1 ON prompt_calib (checkForZeroState(finished))"""
 
         self.indexes[len(self.indexes)] = \
             """CREATE INDEX idx_reco_release_config_1 ON reco_release_config (checkForZeroState(released))"""
@@ -639,6 +658,37 @@ class Create(DBCreator):
                  ADD CONSTRAINT rep_con_str_id_fk
                  FOREIGN KEY (stream_id)
                  REFERENCES stream(id)"""
+
+        self.constraints[len(self.constraints)] = \
+            """ALTER TABLE prompt_calib
+                 ADD CONSTRAINT pro_cal_run_id_fk
+                 FOREIGN KEY (run_id)
+                 REFERENCES run(run_id)"""
+
+        self.constraints[len(self.constraints)] = \
+            """ALTER TABLE prompt_calib
+                 ADD CONSTRAINT pro_cal_str_id_fk
+                 FOREIGN KEY (stream_id)
+                 REFERENCES stream(id)"""
+
+        self.constraints[len(self.constraints)] = \
+            """ALTER TABLE prompt_calib_file
+                 ADD CONSTRAINT pro_cal_fil_run_id_fk
+                 FOREIGN KEY (run_id)
+                 REFERENCES run(run_id)"""
+
+        self.constraints[len(self.constraints)] = \
+            """ALTER TABLE prompt_calib_file
+                 ADD CONSTRAINT pro_cal_fil_str_id_fk
+                 FOREIGN KEY (stream_id)
+                 REFERENCES stream(id)"""
+
+        self.constraints[len(self.constraints)] = \
+            """ALTER TABLE prompt_calib_file
+                 ADD CONSTRAINT pro_cal_fil_fil_id_fk
+                 FOREIGN KEY (fileid)
+                 REFERENCES wmbs_file_details(id)
+                 ON DELETE CASCADE"""
 
         self.constraints[len(self.constraints)] = \
             """ALTER TABLE express_config

--- a/src/python/T0/WMBS/Oracle/JobSplitting/InsertPromptCalibrationFile.py
+++ b/src/python/T0/WMBS/Oracle/JobSplitting/InsertPromptCalibrationFile.py
@@ -1,0 +1,36 @@
+"""
+_InsertPromptCalibrationFile_
+
+Oracle implementation of InsertPromptCalibrationFile
+
+"""
+
+from WMCore.Database.DBFormatter import DBFormatter
+
+class InsertPromptCalibrationFile(DBFormatter):
+
+    def execute(self, binds, conn = None, transaction = False):
+
+        sql = """INSERT ALL
+                   INTO prompt_calib_file (RUN_ID, STREAM_ID, FILEID)
+                     VALUES (:RUN_ID, :STREAM_ID, :FILEID)
+                   INTO wmbs_sub_files_acquired (SUBSCRIPTION, FILEID)
+                     VALUES (:SUBSCRIPTION, :FILEID)
+                 SELECT * FROM DUAL
+                 """
+
+        self.dbi.processData(sql, binds, conn = conn,
+                             transaction = transaction)
+
+        for bind in binds:
+            del bind['RUN_ID']
+            del bind['STREAM_ID']
+
+        sql = """DELETE FROM wmbs_sub_files_available
+                 WHERE subscription = :SUBSCRIPTION
+                 AND fileid = :FILEID"""
+
+        self.dbi.processData(sql, binds, conn = conn,
+                             transaction = transaction)
+
+        return

--- a/src/python/T0/WMBS/Oracle/RunConfig/InsertPromptCalibration.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/InsertPromptCalibration.py
@@ -1,0 +1,23 @@
+"""
+_InsertPromptCalibration_
+
+Oracle implementation of InsertPromptCalibration
+
+"""
+
+from WMCore.Database.DBFormatter import DBFormatter
+
+class InsertPromptCalibration(DBFormatter):
+
+    def execute(self, binds, conn = None, transaction = False):
+
+        sql = """INSERT INTO prompt_calib
+                 (RUN_ID, STREAM_ID)
+                 VALUES (:RUN,
+                         (SELECT id FROM stream WHERE name = :STREAM))
+                 """
+
+        self.dbi.processData(sql, binds, conn = conn,
+                             transaction = transaction)
+
+        return

--- a/src/python/T0/WMBS/Oracle/Subscriptions/GetAvailableConditionFiles.py
+++ b/src/python/T0/WMBS/Oracle/Subscriptions/GetAvailableConditionFiles.py
@@ -1,0 +1,37 @@
+"""
+_GetAvailableConditionFiles_
+
+Oracle implementation of GetAvailableRepackFiles
+
+Similar to Subscriptions.GetAvailableFiles, 
+except it only returns file ids, nothing else
+"""
+
+from WMCore.Database.DBFormatter import DBFormatter
+
+class GetAvailableConditionFiles(DBFormatter):
+
+    def execute(self, subscription, conn = None, transaction = False):
+
+        sql = """SELECT wmbs_sub_files_available.fileid AS id,
+                        streamer.run_id AS run_id,
+                        streamer.stream_id AS stream_id
+                 FROM wmbs_sub_files_available
+                 INNER JOIN wmbs_file_parent a ON
+                   a.child = wmbs_sub_files_available.fileid
+                 INNER JOIN wmbs_file_parent b ON
+                   b.child = a.parent
+                 INNER JOIN wmbs_file_parent c ON
+                   c.child = b.parent
+                 INNER JOIN streamer ON
+                   streamer.id = c.parent
+                 WHERE wmbs_sub_files_available.subscription = :subscription
+                 GROUP BY wmbs_sub_files_available.fileid,
+                          streamer.run_id,
+                          streamer.stream_id
+                 """
+
+        results = self.dbi.processData(sql, { 'subscription' : subscription },
+                                       conn = conn, transaction = transaction)
+
+        return self.formatDict(results)

--- a/src/python/T0Component/Tier0Feeder/Tier0FeederPoller.py
+++ b/src/python/T0Component/Tier0Feeder/Tier0FeederPoller.py
@@ -43,6 +43,7 @@ class Tier0FeederPoller(BaseWorkerThread):
         self.tier0ConfigFile = config.Tier0Feeder.tier0ConfigFile
         self.specDirectory = config.Tier0Feeder.specDirectory
         self.lfnBase = getattr(config.Tier0Feeder, "lfnBase", "/store")
+        self.condUploadDir = config.Tier0Feeder.conditionUploadDir
         self.dqmUploadProxy = config.WMBSService.proxy
         self.localSummaryCouchDB = WMStatsWriter(config.AnalyticsDataCollector.localWMStatsURL)
 
@@ -133,6 +134,7 @@ class Tier0FeederPoller(BaseWorkerThread):
                                                         run, stream,
                                                         self.specDirectory,
                                                         self.lfnBase,
+                                                        self.condUploadDir,
                                                         self.dqmUploadProxy)
                     except:
                         logging.exception("Can't configure for run %d and stream %s" % (run, stream))

--- a/test/python/T0Component_t/Tier0Feeder_t/Tier0Feeder_t.py
+++ b/test/python/T0Component_t/Tier0Feeder_t/Tier0Feeder_t.py
@@ -44,6 +44,7 @@ class Tier0FeederTest(unittest.TestCase):
 
         self.hltkey = "/cdaq/physics/Run2011/3e33/v2.1/HLT/V2"
         self.hltConfig = None
+        self.condUploadDir = None
         self.dqmUploadProxy = None
         self.dbInterfaceStorageManager = None
         self.getExpressReadyRunsDAO = None
@@ -52,6 +53,7 @@ class Tier0FeederTest(unittest.TestCase):
 
             wmAgentConfig = loadConfigurationFile(os.environ["WMAGENT_CONFIG"])
 
+            self.condUploadDir = getattr(wmAgentConfig.Tier0Feeder, "conditionUploadDir", None)
             self.dqmUploadProxy = getattr(wmAgentConfig.WMBSService, "proxy", None)
             self.localSummaryCouchDB = WMStatsWriter(wmAgentConfig.AnalyticsDataCollector.localWMStatsURL)
 
@@ -1240,7 +1242,8 @@ class Tier0FeederTest(unittest.TestCase):
         self.assertEqual(set(runStreams[176161]), set(["A"]),
                          "ERROR: there should be new run/stream for run 176161 and stream A")
 
-        RunConfigAPI.configureRunStream(self.tier0Config, 176161, "A", self.testDir, "/store", self.dqmUploadProxy)
+        RunConfigAPI.configureRunStream(self.tier0Config, 176161, "A", self.testDir,
+                                        "/store", self.condUploadDir, self.dqmUploadProxy)
 
         runStreams = self.findNewRunStreamsDAO.execute(transaction = False)
         self.assertEqual(len(runStreams.keys()), 0,
@@ -1377,8 +1380,10 @@ class Tier0FeederTest(unittest.TestCase):
         self.assertEqual(self.getNumFeedStreamers(), 4,
                          "ERROR: there should be 4 streamers feed")
 
-        RunConfigAPI.configureRunStream(self.tier0Config, 176162, "A", self.testDir, "/store", self.dqmUploadProxy)
-        RunConfigAPI.configureRunStream(self.tier0Config, 176163, "Express", self.testDir, "/store", self.dqmUploadProxy)
+        RunConfigAPI.configureRunStream(self.tier0Config, 176162, "A", self.testDir,
+                                        "/store", self.condUploadDir, self.dqmUploadProxy)
+        RunConfigAPI.configureRunStream(self.tier0Config, 176163, "Express", self.testDir,
+                                        "/store", self.condUploadDir, self.dqmUploadProxy)
 
         runStreams = self.findNewRunStreamsDAO.execute(transaction = False)
         self.assertEqual(set(runStreams.keys()), set([176162, 176163]),
@@ -1417,8 +1422,10 @@ class Tier0FeederTest(unittest.TestCase):
         self.assertEqual(self.getNumFeedStreamers(), 6,
                          "ERROR: there should be 6 streamers feed")
 
-        RunConfigAPI.configureRunStream(self.tier0Config, 176162, "Express", self.testDir, "/store", self.dqmUploadProxy)
-        RunConfigAPI.configureRunStream(self.tier0Config, 176162, "HLTMON", self.testDir, "/store", self.dqmUploadProxy)
+        RunConfigAPI.configureRunStream(self.tier0Config, 176162, "Express", self.testDir,
+                                        "/store", self.condUploadDir, self.dqmUploadProxy)
+        RunConfigAPI.configureRunStream(self.tier0Config, 176162, "HLTMON", self.testDir,
+                                        "/store", self.condUploadDir, self.dqmUploadProxy)
 
         runStreams = self.findNewRunStreamsDAO.execute(transaction = False)
         self.assertEqual(set(runStreams.keys()), set([176163]),
@@ -1454,7 +1461,8 @@ class Tier0FeederTest(unittest.TestCase):
         self.assertEqual(self.getNumFeedStreamers(), 8,
                          "ERROR: there should be 8 streamers feed")
 
-        RunConfigAPI.configureRunStream(self.tier0Config, 176163, "A", self.testDir, "/store", self.dqmUploadProxy)
+        RunConfigAPI.configureRunStream(self.tier0Config, 176163, "A", self.testDir,
+                                        "/store", self.condUploadDir, self.dqmUploadProxy)
 
         runStreams = self.findNewRunStreamsDAO.execute(transaction = False)
         self.assertEqual(len(runStreams.keys()), 0,
@@ -1526,7 +1534,8 @@ class Tier0FeederTest(unittest.TestCase):
         self.assertEqual(len(self.getClosedLumis()), 0,
                          "ERROR: there should be no closed lumis")
 
-        RunConfigAPI.configureRunStream(self.tier0Config, 176161, "A", self.testDir, "/store", self.dqmUploadProxy)
+        RunConfigAPI.configureRunStream(self.tier0Config, 176161, "A", self.testDir,
+                                        "/store", self.condUploadDir, self.dqmUploadProxy)
 
         RunLumiCloseoutAPI.closeLumiSections(self.dbInterfaceStorageManager)
 
@@ -1544,7 +1553,8 @@ class Tier0FeederTest(unittest.TestCase):
 
         self.insertRunStreamLumi(176161, "HLTMON", 1)
 
-        RunConfigAPI.configureRunStream(self.tier0Config, 176161, "HLTMON", self.testDir, "/store", self.dqmUploadProxy)
+        RunConfigAPI.configureRunStream(self.tier0Config, 176161, "HLTMON", self.testDir,
+                                        "/store", self.condUploadDir, self.dqmUploadProxy)
 
         RunLumiCloseoutAPI.closeLumiSections(self.dbInterfaceStorageManager)
 
@@ -1582,7 +1592,6 @@ class Tier0FeederTest(unittest.TestCase):
         Test closeout code for run/stream filesets
 
         """
-        
         if self.dbInterfaceStorageManager == None:
             print "Your config is missing the StorageManagerDatabase section"
             print "Skipping run/lumi closing test"
@@ -1600,7 +1609,8 @@ class Tier0FeederTest(unittest.TestCase):
                                   { 'process' : "HLT",
                                     'mapping' : self.referenceMapping })
 
-        RunConfigAPI.configureRunStream(self.tier0Config, 176161, "A", self.testDir, "/store", self.dqmUploadProxy)
+        RunConfigAPI.configureRunStream(self.tier0Config, 176161, "A", self.testDir,
+                                        "/store", self.condUploadDir, self.dqmUploadProxy)
 
         RunLumiCloseoutAPI.endRuns(self.dbInterfaceStorageManager)
         RunLumiCloseoutAPI.closeLumiSections(self.dbInterfaceStorageManager)
@@ -1662,7 +1672,8 @@ class Tier0FeederTest(unittest.TestCase):
                                   { 'process' : "HLT",
                                     'mapping' : self.referenceMapping })
 
-        RunConfigAPI.configureRunStream(self.tier0Config, 176161, "A", self.testDir, "/store", self.dqmUploadProxy)
+        RunConfigAPI.configureRunStream(self.tier0Config, 176161, "A", self.testDir,
+                                        "/store", self.condUploadDir, self.dqmUploadProxy)
 
         self.insertClosedLumiDAO.execute(binds = { 'RUN' : 176161,
                                                    'STREAM' : 'A',

--- a/test/python/T0_t/WMBS_t/JobSplitting_t/ExpressMerge_t.py
+++ b/test/python/T0_t/WMBS_t/JobSplitting_t/ExpressMerge_t.py
@@ -23,11 +23,11 @@ from WMCore.Services.UUID import makeUUID
 from WMQuality.TestInit import TestInit
 
 
-class ExpressTest(unittest.TestCase):
+class ExpressMergeTest(unittest.TestCase):
     """
-    _ExpressTest_
+    _ExpressMergeTest_
 
-    Test for Express job splitter
+    Test for ExpressMerge job splitter
     """
 
     def setUp(self):
@@ -49,8 +49,8 @@ class ExpressTest(unittest.TestCase):
                                 dbinterface = myThread.dbi)
 
         myThread.dbi.processData("""INSERT INTO wmbs_location
-                                    (id, site_name)
-                                    VALUES (1, 'SomeSite')
+                                    (id, site_name, state)
+                                    VALUES (1, 'SomeSite', 1)
                                     """, transaction = False)
         myThread.dbi.processData("""INSERT INTO wmbs_location_senames
                                     (location, se_name)

--- a/test/python/T0_t/WMBS_t/JobSplitting_t/Express_t.py
+++ b/test/python/T0_t/WMBS_t/JobSplitting_t/Express_t.py
@@ -49,8 +49,8 @@ class ExpressTest(unittest.TestCase):
                                 dbinterface = myThread.dbi)
 
         myThread.dbi.processData("""INSERT INTO wmbs_location
-                                    (id, site_name)
-                                    VALUES (1, 'SomeSite')
+                                    (id, site_name, state)
+                                    VALUES (1, 'SomeSite', 1)
                                     """, transaction = False)
         myThread.dbi.processData("""INSERT INTO wmbs_location_senames
                                     (location, se_name)

--- a/test/python/T0_t/WMBS_t/JobSplitting_t/RepackMerge_t.py
+++ b/test/python/T0_t/WMBS_t/JobSplitting_t/RepackMerge_t.py
@@ -23,11 +23,11 @@ from WMCore.Services.UUID import makeUUID
 from WMQuality.TestInit import TestInit
 
 
-class RepackTest(unittest.TestCase):
+class RepackMergeTest(unittest.TestCase):
     """
-    _RepackTest_
+    _RepackMergeTest_
 
-    Test for Repack job splitter
+    Test for RepackMerge job splitter
     """
 
     def setUp(self):
@@ -49,8 +49,8 @@ class RepackTest(unittest.TestCase):
                                 dbinterface = myThread.dbi)
 
         myThread.dbi.processData("""INSERT INTO wmbs_location
-                                    (id, site_name)
-                                    VALUES (1, 'SomeSite')
+                                    (id, site_name, state)
+                                    VALUES (1, 'SomeSite', 1)
                                     """, transaction = False)
         myThread.dbi.processData("""INSERT INTO wmbs_location_senames
                                     (location, se_name)

--- a/test/python/T0_t/WMBS_t/JobSplitting_t/Repack_t.py
+++ b/test/python/T0_t/WMBS_t/JobSplitting_t/Repack_t.py
@@ -49,8 +49,8 @@ class RepackTest(unittest.TestCase):
                                 dbinterface = myThread.dbi)
 
         myThread.dbi.processData("""INSERT INTO wmbs_location
-                                    (id, site_name)
-                                    VALUES (1, 'SomeSite')
+                                    (id, site_name, state)
+                                    VALUES (1, 'SomeSite', 1)
                                     """, transaction = False)
         myThread.dbi.processData("""INSERT INTO wmbs_location_senames
                                     (location, se_name)


### PR DESCRIPTION
When a run is configured, any express streams with the PromptCalibProducer alca producer will
be flagged for PCL. This means the system expects PCL conditons for that run/stream pair.
Inside the Express Spec we configure for ALCAPROMPT output from the PromptCalibProducer and
then add an AlcaHarvest task for it. The AlcaHarvest will write out sqlite files, for which
we add a dummy Condition task. A Condition task has a Condition job splitter, which does
not create any jobs, but just forwards sqlite file information to special t0ast db tables.

Second step (and not part of this ticket) is using the information in these t0ast tables
to upload the conditions to the dropbox and enforce doing this in run order.

Also not part of this ticket yet is a timeout trigger for the PCL.
