### PR TITLE
Tier0 PromptReco does not support LogCollect

### DIFF
--- a/src/python/T0/RunConfig/RunConfigAPI.py
+++ b/src/python/T0/RunConfig/RunConfigAPI.py
@@ -582,6 +582,8 @@ def releasePromptReco(tier0Config, specDirectory, lfnBase, dqmUploadProxy = None
             specArguments['OverrideCatalog'] = "trivialcatalog_file:/afs/cern.ch/cms/SITECONF/local/Tier0/override_catalog.xml?protocol=override"
             specArguments['DQMUploadProxy'] = dqmUploadProxy
 
+            specArguments['DoLogCollect'] = False
+
             wmSpec = promptrecoWorkload(workflowName, specArguments)
 
             wmSpec.setOwnerDetails("Dirk.Hufnagel@cern.ch", "T0",


### PR DESCRIPTION
Add a parameter to the PromptReco spec instance created by RunConfig that tells it do not run any LogCollect jobs. For the parameter to be actually used a newer version of the PromptReco Spec in WMCore is needed.
