### PR TITLE
Increase performance limits for T0 workflows

### DIFF
--- a/src/python/T0/RunConfig/RunConfigAPI.py
+++ b/src/python/T0/RunConfig/RunConfigAPI.py
@@ -372,6 +372,10 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
             wmSpec.setOwnerDetails("Dirk.Hufnagel@cern.ch", "T0",
                                    { 'vogroup': 'DEFAULT', 'vorole': 'DEFAULT',
                                      'dn' : "Dirk.Hufnagel@cern.ch" } )
+
+            wmSpec.setupPerformanceMonitoring(maxRSS = 10485760, maxVSize = 10485760,
+                                              softTimeout = 604800, gracePeriod = 3600)
+
             wmbsHelper = WMBSHelper(wmSpec, taskName, cachepath = specDirectory)
 
         filesetName = "Run%d_Stream%s" % (run, stream)
@@ -618,6 +622,9 @@ def releasePromptReco(tier0Config, specDirectory, dqmUploadProxy = None):
                 wmSpec.setOwnerDetails("Dirk.Hufnagel@cern.ch", "T0",
                                        { 'vogroup': 'DEFAULT', 'vorole': 'DEFAULT',
                                          'dn' : "Dirk.Hufnagel@cern.ch" } )
+
+                wmSpec.setupPerformanceMonitoring(maxRSS = 10485760, maxVSize = 10485760,
+                                                  softTimeout = 604800, gracePeriod = 3600)
                 wmbsHelper = WMBSHelper(wmSpec, taskName, cachepath = specDirectory)
 
                 recoSpecs[workflowName] = (wmbsHelper, wmSpec, fileset)


### PR DESCRIPTION
T0 run sin a special setup where memory limits can be higher and runtime is 1 week.

@hufnagel, can you commit this before making the release please. This avoids having job failing because memory limits (specifically VSize limit which has a low default). I ran the RunConfig_t and Tier0Feeder_t test and it checks out

I don't know if we ever wanna have those configurable though. 
