### PR TITLE
add missing cleanup task for Express ALCARECO output

### DIFF
--- a/src/python/T0/WMSpec/StdSpecs/Express.py
+++ b/src/python/T0/WMSpec/StdSpecs/Express.py
@@ -136,6 +136,8 @@ class ExpressWorkloadFactory(StdBase):
                                                            stepType = cmsswStepType,
                                                            forceMerged = True)
 
+                self.addCleanupTask(expressTask, expressOutLabel)
+
                 for alcaSkimOutLabel, alcaSkimOutInfo in alcaSkimOutMods.items():
 
                     if alcaSkimOutInfo['dataTier'] == "ALCAPROMPT" and self.alcaHarvestDir != None:


### PR DESCRIPTION
In the Express Spec, all expressmerged output has a cleanup task attached to it.
ALCARECO does not go through an expressmerge though, but instead is alca skimmed.
Add the missing cleanup task.
