### PR TITLE
add missing GetRunEndTime DAO

### DIFF
--- a/src/python/T0/ConditionUpload/ConditionUploadAPI.py
+++ b/src/python/T0/ConditionUpload/ConditionUploadAPI.py
@@ -92,7 +92,7 @@ def uploadConditions(timeout, dropboxHost, validationMode):
 
             # if finished set to completely finished
             if conditions[run][stream]['finished'] == 1:
-                markPromptCalibrationFinishedDAO,execute(run, stream, 2, transaction = False)
+                markPromptCalibrationFinishedDAO.execute(run, stream, 2, transaction = False)
             else:
                 advanceToNextRun = False
 

--- a/src/python/T0/WMBS/Oracle/ConditionUpload/GetRunEndTime.py
+++ b/src/python/T0/WMBS/Oracle/ConditionUpload/GetRunEndTime.py
@@ -1,0 +1,29 @@
+"""
+_GetRunEndTime_
+
+Oracle implementation of GetRunEndTime
+
+Returns run end time or insert time of last
+streamer if run hasn't ended yet
+"""
+
+from WMCore.Database.DBFormatter import DBFormatter
+
+class GetRunEndTime(DBFormatter):
+
+    def execute(self, run, conn = None, transaction = False):
+
+        sql = """SELECT CASE
+                          WHEN run.end_time > 0 THEN run.end_time
+                          ELSE (SELECT MAX(streamer.insert_time)
+                                FROM streamer
+                                WHERE streamer.run_id = :RUN)
+                        END
+                 FROM run
+                 WHERE run.run_id = :RUN
+                 """
+
+        endTime = self.dbi.processData(sql, { 'RUN' : run },
+                                       conn = conn, transaction = transaction)[0].fetchall()[0][0]
+
+        return endTime


### PR DESCRIPTION
When comitting the latest AlcaHarvest changes forgot to include the GetRunEndTime DAO.
Also includes a fix for a typo in the ConditionUploadAPI.
