### PR TITLE
fix bug in the prompt calibration loop

### DIFF
--- a/src/python/T0/ConditionUpload/ConditionUploadAPI.py
+++ b/src/python/T0/ConditionUpload/ConditionUploadAPI.py
@@ -50,6 +50,7 @@ def uploadConditions(timeout, dropboxHost, validationMode):
 
     findConditionsDAO = daoFactory(classname = "ConditionUpload.GetConditions")
     completeFilesDAO = daoFactory(classname = "ConditionUpload.CompleteFiles")
+    
     markPromptCalibrationFinishedDAO = daoFactory(classname = "ConditionUpload.MarkPromptCalibrationFinished")
 
     # look at all runs not completely finished with condition uploads
@@ -90,11 +91,17 @@ def uploadConditions(timeout, dropboxHost, validationMode):
                 else:
                     myThread.transaction.commit()
 
-            # if finished set to completely finished
-            if conditions[run][stream]['finished'] == 1:
-                markPromptCalibrationFinishedDAO.execute(run, stream, 2, transaction = False)
-            else:
-                advanceToNextRun = False
+                # FIXME, only finish and advance to next run if fileset for
+                # subscription closed and no more acquired files
+                #
+                # PROBLEM, how to check that without file/subscription
+                #
+                # might need to cache the subscription in prompt_calib
+                # update call from job splitter maybe
+                if True:
+                    markPromptCalibrationFinishedDAO.execute(run, stream, 2, transaction = False)
+                else:
+                    advanceToNextRun = False
 
         # check for timeout, but only if there is a next run
         if not advanceToNextRun and index < len(conditions.keys()):

--- a/src/python/T0/JobSplitting/Condition.py
+++ b/src/python/T0/JobSplitting/Condition.py
@@ -34,23 +34,13 @@ class Condition(JobFactory):
         Some other component will pick up from the info we wrote.
 
         """
-        runNumber = kwargs['runNumber']
-        streamName = kwargs['streamName']
+        run = kwargs['runNumber']
+        stream = kwargs['streamName']
 
         myThread = threading.currentThread()
         daoFactory = DAOFactory(package = "T0.WMBS",
                                 logger = logging,
                                 dbinterface = myThread.dbi)
-
-        # check if fileset is open
-        # if fileset is open, AlcaHarvest was triggered by timeout
-        # in that case do not set to finished, there is another payload coming
-        fileset = self.subscription.getFileset()
-        fileset.load()
-
-        if not fileset.open:
-            markPromptCalibrationFinishedDAO = daoFactory(classname = "ConditionUpload.MarkPromptCalibrationFinished")
-            markPromptCalibrationFinishedDAO.execute(runNumber, streamName, 1)
 
         # data discovery
         getFilesDAO = daoFactory(classname = "Subscriptions.GetAvailableConditionFiles")
@@ -64,8 +54,8 @@ class Condition(JobFactory):
         for availableFile in availableFiles:
             bindVarList.append( { 'SUBSCRIPTION' : self.subscription["id"],
                                   'FILEID' : availableFile['id'],
-                                  'RUN_ID' : runNumber,
-                                  'STREAM' : streamName } )
+                                  'RUN_ID' : run,
+                                  'STREAM' : stream } )
 
         if len(bindVarList) > 0:
             insertPromptCalibrationFileDAO = daoFactory(classname = "JobSplitting.InsertPromptCalibrationFile")

--- a/src/python/T0/WMBS/Oracle/ConditionUpload/GetConditions.py
+++ b/src/python/T0/WMBS/Oracle/ConditionUpload/GetConditions.py
@@ -11,7 +11,7 @@ from WMCore.Database.DBFormatter import DBFormatter
 class GetConditions(DBFormatter):
 
     sql = """SELECT prompt_calib.run_id,
-                    prompt_calib.stream_id,
+                    stream.name,
                     prompt_calib.finished,
                     prompt_calib_file.fileid,
                     wmbs_sub_files_acquired.subscription,
@@ -19,6 +19,8 @@ class GetConditions(DBFormatter):
              FROM prompt_calib
                INNER JOIN run ON
                  run.run_id = prompt_calib.run_id
+               INNER JOIN stream ON
+                 stream.id = prompt_calib.stream_id
                LEFT OUTER JOIN prompt_calib_file ON
                  prompt_calib_file.run_id = prompt_calib.run_id AND
                  prompt_calib_file.stream_id = prompt_calib.stream_id


### PR DESCRIPTION
Two types of bugs in the PCL. We passed a stream id instead of a stream name to a call. Plus there was a logic bug that prevented this call from being made in almost all cases (this is how it slipped through testing). Put in a temporary fix that will restore upload functionality, but isn't final yes.
