### PR TITLE
fix bug in lumi insertion

### DIFF
--- a/src/python/T0/RunLumiCloseout/RunLumiCloseoutAPI.py
+++ b/src/python/T0/RunLumiCloseout/RunLumiCloseoutAPI.py
@@ -106,10 +106,24 @@ def closeLumiSections(dbInterfaceStorageManager):
 
     if len(closedLumis) > 0:
 
-        bindVarList = []
+        #
+        # insert all lumis we find, but have to take care of duplicates
+        # (due to having the same lumi for different streams)
+        #
+        runLumis = {}
         for closedLumi in closedLumis:
-            bindVarList.append( { 'RUN' : closedLumi['RUN'],
-                                  'LUMI' : closedLumi['LUMI'] } )
+            run = closedLumi['RUN']
+            lumi = closedLumi['LUMI']
+            if not runLumis.has_key(run):
+                runLumis[run] = set()
+            runLumis[run].add(lumi)
+
+        bindVarList = []
+        for run, lumis in runLumis.items():
+            for lumi in lumis:
+                bindVarList.append( { 'RUN' : run,
+                                      'LUMI' : lumi } )
+
         insertLumiDAO.execute(binds = bindVarList,
                               transaction = False)
 


### PR DESCRIPTION
Had a crash where a lumi was passed twice in the same set of bind variables
to the lumi insert code, this caused a race condition and crash. Underlying
cause was that we find new closed lumis from the SM DB per stream but then
insert them stream independent. We missed filtering out duplicates.
