### PR TITLE
more workarounds for the Oracle ADG query bug

### DIFF
--- a/src/python/T0/WMBS/Oracle/Tier0Feeder/GetExpressReadyRuns.py
+++ b/src/python/T0/WMBS/Oracle/Tier0Feeder/GetExpressReadyRuns.py
@@ -25,8 +25,13 @@ class GetExpressReadyRuns(DBFormatter):
                  HAVING COUNT(*) > 0
                  """
 
-        results = self.dbi.processData(sql, binds, conn = conn,
-                                       transaction = transaction)[0].fetchall()
+        try:
+            results = self.dbi.processData(sql, binds, conn = conn,
+                                           transaction = transaction)[0].fetchall()
+        except DatabaseError, ex:
+            logging.error("ERROR: DatabaseError exception when checking for express ready runs")
+            logging.error("   %s" % ex)
+            results = []
 
         runs = []
         for result in results:


### PR DESCRIPTION
Same as we already did for a StorageManagerDB query, put in an exception catch for a PopConLogDB query to work around mysterious non-reproducible crashes that should not happen.
