### PR TITLE
more adjustments for the prompt calibration loop

### DIFF
--- a/src/python/T0/JobSplitting/AlcaHarvest.py
+++ b/src/python/T0/JobSplitting/AlcaHarvest.py
@@ -81,7 +81,6 @@ class AlcaHarvest(JobFactory):
         getAllFilesDAO = self.daoFactory(classname = "Subscriptions.GetAllFiles")
         return getAllFilesDAO.execute(self.subscription["id"])
 
-
     def createJob(self, fileList):
         """
         _createJob_

--- a/src/python/T0/JobSplitting/Condition.py
+++ b/src/python/T0/JobSplitting/Condition.py
@@ -50,6 +50,10 @@ class Condition(JobFactory):
         if len(availableFiles) == 0:
             return
 
+        # associate subscription with run/stream
+        updatePromptCalibrationDAO = daoFactory(classname = "JobSplitting.UpdatePromptCalibration")
+        updatePromptCalibrationDAO.execute(run, stream, self.subscription["id"])
+
         bindVarList = []
         for availableFile in availableFiles:
             bindVarList.append( { 'SUBSCRIPTION' : self.subscription["id"],

--- a/src/python/T0/WMBS/Oracle/ConditionUpload/IsPromptCalibrationFinished.py
+++ b/src/python/T0/WMBS/Oracle/ConditionUpload/IsPromptCalibrationFinished.py
@@ -1,0 +1,36 @@
+"""
+_IsPromptCalibrationFinished_
+
+Oracle implementation of IsPromptCalibrationFinished
+
+Figure out if PromptCalib is finished (input fileset
+closed and no available or acquired files)
+
+"""
+
+from WMCore.Database.DBFormatter import DBFormatter
+
+class IsPromptCalibrationFinished(DBFormatter):
+
+    def execute(self, subscription, conn = None, transaction = False):
+
+        sql = """SELECT 1
+                 FROM wmbs_subscription
+                   INNER JOIN wmbs_fileset ON
+                     wmbs_fileset.id = wmbs_subscription.fileset AND
+                     wmbs_fileset.open = 0
+                   LEFT OUTER JOIN wmbs_sub_files_available ON
+                     wmbs_sub_files_available.subscription = wmbs_subscription.id
+                   LEFT OUTER JOIN wmbs_sub_files_acquired ON
+                     wmbs_sub_files_acquired.subscription = wmbs_subscription.id
+                 WHERE wmbs_subscription.id = :SUBSCRIPTION
+                 HAVING COUNT(wmbs_sub_files_available.subscription) = 0
+                 AND COUNT(wmbs_sub_files_acquired.subscription) = 0
+                 """
+
+        binds = { 'SUBSCRIPTION' : subscription }
+
+        results = self.dbi.processData(sql, binds, conn = conn,
+                                       transaction = transaction)[0].fetchall()
+
+        return ( len(results) > 0 and results[0][0] == 1 )

--- a/src/python/T0/WMBS/Oracle/ConditionUpload/MarkPromptCalibrationFinished.py
+++ b/src/python/T0/WMBS/Oracle/ConditionUpload/MarkPromptCalibrationFinished.py
@@ -4,9 +4,6 @@ _MarkPromptCalibrationFinished_
 Oracle implementation of MarkPromptCalibrationFinished
 
 Mark the PCL finished for the given run and stream.
-There are two levels of finished here, 1 which means
-the harvesting is done and 2 which means the upload
-to the dropbox is complete too.
 
 """
 
@@ -14,18 +11,16 @@ from WMCore.Database.DBFormatter import DBFormatter
 
 class MarkPromptCalibrationFinished(DBFormatter):
 
-    def execute(self, run, stream, finished,
-                conn = None, transaction = False):
+    def execute(self, run, streamid, conn = None, transaction = False):
 
         sql = """UPDATE prompt_calib
-                 SET finished = :FINISHED
-                 WHERE run_id = :RUN_ID
-                 AND stream_id = (SELECT id FROM stream WHERE name = :STREAM)
+                 SET finished = 1
+                 WHERE run_id = :RUN
+                 AND stream_id = :STREAMID
                  """
 
-        binds = { 'RUN_ID' : run,
-                  'STREAM' : stream,
-                  'FINISHED' : finished }
+        binds = { 'RUN' : run,
+                  'STREAMID' : streamid }
 
         self.dbi.processData(sql, binds, conn = conn,
                              transaction = transaction)

--- a/src/python/T0/WMBS/Oracle/Create.py
+++ b/src/python/T0/WMBS/Oracle/Create.py
@@ -251,9 +251,10 @@ class Create(DBCreator):
 
         self.create[len(self.create)] = \
             """CREATE TABLE prompt_calib (
-                 run_id      int not null,
-                 stream_id   int not null,
-                 finished    int default 0 not null,
+                 run_id        int not null,
+                 stream_id     int not null,
+                 finished      int default 0 not null,
+                 subscription  int,
                  primary key (run_id, stream_id)
                )"""
 
@@ -421,7 +422,7 @@ class Create(DBCreator):
             """CREATE INDEX idx_streamer_3 ON streamer (checkForZeroOneState(deleted))"""
 
         self.indexes[len(self.indexes)] = \
-            """CREATE INDEX idx_prompt_calib_1 ON prompt_calib (checkForZeroOneState(finished))"""
+            """CREATE INDEX idx_prompt_calib_1 ON prompt_calib (checkForZeroState(finished))"""
 
         self.indexes[len(self.indexes)] = \
             """CREATE INDEX idx_reco_release_config_1 ON reco_release_config (checkForZeroState(released))"""
@@ -675,6 +676,13 @@ class Create(DBCreator):
                  REFERENCES stream(id)"""
 
         self.constraints[len(self.constraints)] = \
+            """ALTER TABLE prompt_calib
+                 ADD CONSTRAINT pro_cal_sub_fk
+                 FOREIGN KEY (subscription)
+                 REFERENCES wmbs_subscription(id)
+                 ON DELETE CASCADE"""
+
+        self.constraints[len(self.constraints)] = \
             """ALTER TABLE prompt_calib_file
                  ADD CONSTRAINT pro_cal_fil_run_id_fk
                  FOREIGN KEY (run_id)
@@ -775,7 +783,8 @@ class Create(DBCreator):
             """ALTER TABLE workflow_monitoring
                  ADD CONSTRAINT wor_mon_wor_fk
                  FOREIGN KEY (workflow)
-                 REFERENCES wmbs_workflow(id)"""
+                 REFERENCES wmbs_workflow(id)
+                 ON DELETE CASCADE"""
 
         subTypes = ["Express"]
         for name in subTypes:

--- a/src/python/T0/WMBS/Oracle/JobSplitting/UpdatePromptCalibration.py
+++ b/src/python/T0/WMBS/Oracle/JobSplitting/UpdatePromptCalibration.py
@@ -1,0 +1,31 @@
+"""
+_UpdatePromptCalibration_
+
+Oracle implementation of UpdatePromptCalibration
+
+Associate the PCL ConditionUpload subscription with
+run and stream information, which is needed for
+checking if the PCL is finished.
+
+"""
+
+from WMCore.Database.DBFormatter import DBFormatter
+
+class UpdatePromptCalibration(DBFormatter):
+
+    def execute(self, run, stream, subscription, conn = None, transaction = False):
+
+        sql = """UPDATE prompt_calib
+                 SET subscription = :SUBSCRIPTION
+                 WHERE run_id = :RUN_ID
+                 AND stream_id = (SELECT id FROM stream WHERE name = :STREAM)
+                 """
+
+        binds = { 'RUN_ID' : run,
+                  'STREAM' : stream,
+                  'SUBSCRIPTION' : subscription }
+
+        self.dbi.processData(sql, binds, conn = conn,
+                             transaction = transaction)
+
+        return


### PR DESCRIPTION
Change PCL logic. Instead of having three states only have two now,
finished and not finished. The AlcaHarvest triggers on a closed fileset
and (once) on timeout. The ConditionUpload will upload everything,
but only set the PCL to finished if it's done. The later is detected
by checking the status of the subscription. The input fileset needs
to be closed and there can be no available or acquired files.
