### PR TITLE
add or move various config options to OfflineConfiguration

### DIFF
--- a/etc/Tier0Config.py
+++ b/etc/Tier0Config.py
@@ -5,7 +5,6 @@ config.Tier0Feeder.componentDir = config.General.workDir + "/Tier0Feeder"
 config.Tier0Feeder.pollInterval = 30
 config.Tier0Feeder.tier0ConfigFile = "TIER0_CONFIG_FILE"
 config.Tier0Feeder.specDirectory = "TIER0_SPEC_DIR"
-config.Tier0Feeder.lfnBase = "TIER0_LFNBASE"
 
 config.JobSubmitter.LsfPluginQueue = "cmsrepack"
 config.JobSubmitter.LsfPluginResourceReq = "select[type==SLC5_64] rusage[pool=10000,mem=1800]"

--- a/src/python/T0/RunConfig/RunConfigAPI.py
+++ b/src/python/T0/RunConfig/RunConfigAPI.py
@@ -24,7 +24,7 @@ from T0.WMSpec.StdSpecs.Express import expressWorkload
 from WMCore.WMSpec.StdSpecs.PromptReco import getTestArguments as getPromptRecoArguments
 from WMCore.WMSpec.StdSpecs.PromptReco import promptrecoWorkload
 
-def configureRun(tier0Config, run, lfnBase, hltConfig, referenceHltConfig = None):
+def configureRun(tier0Config, run, hltConfig, referenceHltConfig = None):
     """
     _configureRun_
 
@@ -63,9 +63,13 @@ def configureRun(tier0Config, run, lfnBase, hltConfig, referenceHltConfig = None
         bindsUpdateRun = { 'RUN' : run,
                            'PROCESS' : hltConfig['process'],
                            'ACQERA' : tier0Config.Global.AcquisitionEra,
-                           'LFNBASE' : lfnBase,
+                           'LFNPREFIX' : tier0Config.Global.LFNPrefix,
+                           'BULKDATATYPE' : tier0Config.Global.BulkDataType,
                            'AHTIMEOUT' : tier0Config.Global.AlcaHarvestTimeout,
-                           'AHDIR' : tier0Config.Global.AlcaHarvestDir }
+                           'AHDIR' : tier0Config.Global.AlcaHarvestDir,
+                           'CONDTIMEOUT' : tier0Config.Global.ConditionUploadTimeout,
+                           'DBHOST' : tier0Config.Global.DropboxHost,
+                           'VALIDMODE' : tier0Config.Global.ValidationMode }
 
         bindsStream = []
         bindsDataset = []
@@ -112,9 +116,13 @@ def configureRun(tier0Config, run, lfnBase, hltConfig, referenceHltConfig = None
             bindsUpdateRun = { 'RUN' : run,
                                'PROCESS' : "FakeProcessName",
                                'ACQERA' : "FakeAcquisitionEra",
-                               'LFNBASE' : lfnBase,
+                               'LFNPREFIX' : "/fakelfnprefix",
+                               'BULKDATATYPE' : "FakeBulkDataType",
                                'AHTIMEOUT' : None,
-                               'AHDIR' : None }
+                               'AHDIR' : None,
+                               'CONDTIMEOUT' : None,
+                               'DBHOST' : None,
+                               'VALIDMODE' : None }
             updateRunDAO.execute(bindsUpdateRun,
                                  transaction = True)
         except:
@@ -331,8 +339,10 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
             workflowName = "Repack_Run%d_Stream%s" % (run, stream)
             specArguments = getRepackArguments()
             specArguments['ProcessingVersion'] = streamConfig.Repack.ProcessingVersion
-            specArguments['UnmergedLFNBase'] = "%s/t0temp/data" % runInfo['lfn_base']
-            specArguments['MergedLFNBase'] = "%s/data" % runInfo['lfn_base']
+            specArguments['UnmergedLFNBase'] = "%s/t0temp/%s" % (runInfo['lfn_prefix'],
+                                                                 runInfo['bulk_data_type'])
+            specArguments['MergedLFNBase'] = "%s/%s" % (runInfo['lfn_prefix'],
+                                                        runInfo['bulk_data_type'])
         elif streamConfig.ProcessingStyle == "Express":
             taskName = "Express"
             workflowName = "Express_Run%d_Stream%s" % (run, stream)
@@ -344,8 +354,8 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
             specArguments['GlobalTagTransaction'] = "Express_%d" % run
             specArguments['AlcaSkims'] = streamConfig.Express.AlcaSkims
             specArguments['DqmSequences'] = streamConfig.Express.DqmSequences
-            specArguments['UnmergedLFNBase'] = "%s/t0temp/express" % runInfo['lfn_base']
-            specArguments['MergedLFNBase'] = "%s/express" % runInfo['lfn_base']
+            specArguments['UnmergedLFNBase'] = "%s/t0temp/express" % runInfo['lfn_prefix']
+            specArguments['MergedLFNBase'] = "%s/express" % runInfo['lfn_prefix']
             specArguments['AlcaHarvestTimeout'] = runInfo['ah_timeout']
             specArguments['AlcaHarvestDir'] = runInfo['ah_dir']
             specArguments['DQMUploadProxy'] = dqmUploadProxy
@@ -604,8 +614,10 @@ def releasePromptReco(tier0Config, specDirectory, dqmUploadProxy = None):
                 specArguments['AlcaSkims'] = datasetConfig.Reco.AlcaSkims
                 specArguments['DqmSequences'] = datasetConfig.Reco.DqmSequences
 
-                specArguments['UnmergedLFNBase'] = "%s/t0temp/data" % runInfo['lfn_base']
-                specArguments['MergedLFNBase'] = "%s/data" % runInfo['lfn_base']
+                specArguments['UnmergedLFNBase'] = "%s/t0temp/%s" % (runInfo['lfn_prefix'],
+                                                                     runInfo['bulk_data_type'])
+                specArguments['MergedLFNBase'] = "%s/%s" % (runInfo['lfn_prefix'],
+                                                            runInfo['bulk_data_type'])
 
                 specArguments['OverrideCatalog'] = "trivialcatalog_file:/afs/cern.ch/cms/SITECONF/local/Tier0/override_catalog.xml?protocol=override"
                 specArguments['DQMUploadProxy'] = dqmUploadProxy

--- a/src/python/T0/RunConfig/Tier0Config.py
+++ b/src/python/T0/RunConfig/Tier0Config.py
@@ -14,6 +14,10 @@ Tier0Configuration - Global configuration object
 | |       |
 | |       |--> AcquisitionEra - The acquisition era for the run
 | |       |
+| |       |--> LFNPrefix - The LFN prefix for the run
+| |       |
+| |       |--> BulkDataType - The bulk data type for the run
+| |       |
 | |       |--> AlcaHarvestTimeout - AlcaHarvesting for a run/stream is normally trigered by
 | |       |                         fileset closing (ie. all data received and processed).
 | |       |                         This timeout will configure an additional time trigger
@@ -21,7 +25,19 @@ Tier0Configuration - Global configuration object
 | |       |                         file was received).
 | |       |
 | |       |--> AlcaHarvestDir - Directory to which the AlcaHarvest job copies the
-| |                             sqlite file and associated metadata.
+| |       |                     sqlite file and associated metadata.
+| |       |
+| |       |--> ConditionUploadTimeout - ConditionUpload normally only advances to the next run
+| |       |                             if the current run is completely finished (ie. all data
+| |       |                             received, processed, alca harvested and conditions
+| |       |                             uploaded). This timeout will configure an additional
+| |       |                             time trigger based on the run end_time ( or when the
+| |       |                             last streamer file was received).
+| |       |
+| |       |--> DropBoxHost - Machine where we upload the PCL conditions to
+| |       |
+| |       |--> ValidationMode - Whether or not we upload conditions for immediate use
+| |                             in PromptReco or just for validation checks.
 | |
 | |--> Streams - Configuration parameters that belong to a particular stream
 |       |
@@ -325,14 +341,37 @@ def setAcquisitionEra(config, acquisitionEra):
     config.Global.AcquisitionEra = acquisitionEra
     return
 
-def setAlcaHarvestConfig(config, alcaHarvestTimeout, alcaHarvestDir):
+def setLFNPrefix(config, prefix):
     """
-    _setAlcaHarvestConfig_
+    _setLFNPrefix_
 
-    Configure needed settings for AlcaHarvest
+    Set the LFN prefix in the configuration.
+    """
+    config.Global.LFNPrefix = prefix
+    return
+
+def setBulkDataType(config, type):
+    """
+    _setBulkDataType_
+
+    Set the bulk data type in the configuration.
+    """
+    config.Global.BulkDataType = type
+    return
+
+def setPromptCalibrationConfig(config, alcaHarvestTimeout, alcaHarvestDir,
+                               conditionUploadTimeout, dropboxHost,
+                               validationMode):
+    """
+    _setPromptCalibrationConfig_
+
+    Configure needed settings for PromptCalibration
     """
     config.Global.AlcaHarvestTimeout = alcaHarvestTimeout
     config.Global.AlcaHarvestDir = alcaHarvestDir
+    config.Global.ConditionUploadTimeout = conditionUploadTimeout
+    config.Global.DropboxHost = dropboxHost
+    config.Global.ValidationMode = validationMode
     return
 
 def setConfigVersion(config, version):

--- a/src/python/T0/WMBS/Oracle/Create.py
+++ b/src/python/T0/WMBS/Oracle/Create.py
@@ -121,11 +121,15 @@ class Create(DBCreator):
                  lumicount          int           default 0 not null,
                  process            varchar2(255),
                  acq_era            varchar2(255),
-                 lfn_base           varchar2(255),
+                 lfn_prefix         varchar2(255),
+                 bulk_data_type     varchar2(255),
                  ah_timeout         int,
                  ah_dir             varchar2(255),
+                 cond_timeout       int,
+                 db_host            varchar2(255),
+                 valid_mode         int,
                  primary key(run_id)
-               )"""
+               ) ORGANIZATION INDEX"""
 
         self.create[len(self.create)] = \
             """CREATE TABLE run_trig_primds_assoc (

--- a/src/python/T0/WMBS/Oracle/RunConfig/GetPhEDExConfig.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/GetPhEDExConfig.py
@@ -26,7 +26,7 @@ class GetPhEDExConfig(DBFormatter):
                    primary_dataset.id = phedex_config.primds_id
                  INNER JOIN storage_node ON
                    storage_node.id = phedex_config.node_id
-                 WHERE run_primds_stream_assoc.run_id.run_id = :RUN
+                 WHERE run_primds_stream_assoc.run_id = :RUN
                  AND run_primds_stream_assoc.stream_id =
                    (SELECT id FROM stream WHERE name = :STREAM)
                  """

--- a/src/python/T0/WMBS/Oracle/RunConfig/GetRunInfo.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/GetRunInfo.py
@@ -17,7 +17,8 @@ class GetRunInfo(DBFormatter):
                         hltkey,
                         process,
                         acq_era,
-                        lfn_base,
+                        lfn_prefix,
+                        bulk_data_type,
                         ah_timeout,
                         ah_dir
                  FROM run

--- a/src/python/T0/WMBS/Oracle/RunConfig/UpdateRun.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/UpdateRun.py
@@ -14,9 +14,13 @@ class UpdateRun(DBFormatter):
         sql = """UPDATE run
                  SET process = :PROCESS,
                      acq_era = :ACQERA,
-                     lfn_base = :LFNBASE,
+                     lfn_prefix = :LFNPREFIX,
+                     bulk_data_type = :BULKDATATYPE,
                      ah_timeout = :AHTIMEOUT,
-                     ah_dir = :AHDIR
+                     ah_dir = :AHDIR,
+                     cond_timeout = :CONDTIMEOUT,
+                     db_host = :DBHOST,
+                     valid_mode = :VALIDMODE
                  WHERE run_id = :RUN
                  """
 

--- a/src/python/T0Component/Tier0Feeder/Tier0FeederPoller.py
+++ b/src/python/T0Component/Tier0Feeder/Tier0FeederPoller.py
@@ -43,15 +43,10 @@ class Tier0FeederPoller(BaseWorkerThread):
 
         self.tier0ConfigFile = config.Tier0Feeder.tier0ConfigFile
         self.specDirectory = config.Tier0Feeder.specDirectory
-        self.lfnBase = getattr(config.Tier0Feeder, "lfnBase", "/store")
 
         self.dqmUploadProxy = config.WMBSService.proxy
 
         self.localSummaryCouchDB = WMStatsWriter(config.AnalyticsDataCollector.localWMStatsURL)
-
-        self.condUploadTimeout = 18 * 3600
-        self.dropboxHost = "webcondvm.cern.ch"
-        self.validationMode = True
 
         hltConfConnectUrl = config.HLTConfDatabase.connectUrl
         dbFactoryHltConf = DBFactory(logging, dburl = hltConfConnectUrl, options = {})
@@ -124,7 +119,7 @@ class Tier0FeederPoller(BaseWorkerThread):
                         continue
 
                 try:
-                    RunConfigAPI.configureRun(tier0Config, run, self.lfnBase, hltConfig)
+                    RunConfigAPI.configureRun(tier0Config, run, hltConfig)
                 except:
                     logging.exception("Can't configure for run %d" % (run))
 
@@ -221,9 +216,7 @@ class Tier0FeederPoller(BaseWorkerThread):
         #
         # upload PCL conditions to DropBox
         #
-        ConditionUploadAPI.uploadConditions(self.condUploadTimeout,
-                                            self.dropboxHost,
-                                            self.validationMode)
+        ConditionUploadAPI.uploadConditions()
 
         return
 

--- a/test/python/T0Component_t/Tier0Feeder_t/ExampleConfig.py
+++ b/test/python/T0Component_t/Tier0Feeder_t/ExampleConfig.py
@@ -7,7 +7,9 @@ Example configuration for RunConfig unittest
 from T0.RunConfig.Tier0Config import addDataset
 from T0.RunConfig.Tier0Config import createTier0Config
 from T0.RunConfig.Tier0Config import setAcquisitionEra
-from T0.RunConfig.Tier0Config import setAlcaHarvestConfig
+from T0.RunConfig.Tier0Config import setLFNPrefix
+from T0.RunConfig.Tier0Config import setBulkDataType
+from T0.RunConfig.Tier0Config import setPromptCalibrationConfig
 from T0.RunConfig.Tier0Config import setConfigVersion
 from T0.RunConfig.Tier0Config import ignoreStream
 from T0.RunConfig.Tier0Config import addRepackConfig
@@ -27,11 +29,14 @@ setConfigVersion(tier0Config, "replace with real version")
 #  LFN prefix
 #  data type
 setAcquisitionEra(tier0Config, "ExampleConfig_UnitTest")
-#setLFNPrefix(tier0Config, "/store")
-#setDataType(tier0Config, "data")
-setAlcaHarvestConfig(tier0Config,
-                     alcaHarvestTimeout = 12*3600,
-                     alcaHarvestDir = "/blah/blah")
+setLFNPrefix(tier0Config, "/store")
+setBulkDataType(tier0Config, "data")
+setPromptCalibrationConfig(tier0Config,
+                           alcaHarvestTimeout = 12*3600,
+                           alcaHarvestDir = "/some/afs/dir",
+                           conditionUploadTimeout = 18*3600,
+                           dropboxHost = "webcondvm.cern.ch",
+                           validationMode = True)
 
 # setup repack and express version mappings
 repackVersionOverride = {

--- a/test/python/T0Component_t/Tier0Feeder_t/Tier0Feeder_t.py
+++ b/test/python/T0Component_t/Tier0Feeder_t/Tier0Feeder_t.py
@@ -1223,7 +1223,7 @@ class Tier0FeederTest(unittest.TestCase):
         self.assertEqual(len(runStreams.keys()), 0,
                          "ERROR: there should be no new run/stream")
 
-        RunConfigAPI.configureRun(self.tier0Config, 176161, "/store",
+        RunConfigAPI.configureRun(self.tier0Config, 176161,
                                   self.hltConfig,
                                   { 'process' : "HLT",
                                     'mapping' : self.referenceMapping })
@@ -1341,7 +1341,7 @@ class Tier0FeederTest(unittest.TestCase):
         self.assertEqual(self.getNumFeedStreamers(), 4,
                          "ERROR: there should be 4 streamers feed")
 
-        RunConfigAPI.configureRun(self.tier0Config, 176162, "/store",
+        RunConfigAPI.configureRun(self.tier0Config, 176162,
                                   self.hltConfig,
                                   { 'process' : "HLT",
                                     'mapping' : self.referenceMapping })
@@ -1360,7 +1360,7 @@ class Tier0FeederTest(unittest.TestCase):
         self.assertEqual(self.getNumFeedStreamers(), 4,
                          "ERROR: there should be 4 streamers feed")
 
-        RunConfigAPI.configureRun(self.tier0Config, 176163, "/store",
+        RunConfigAPI.configureRun(self.tier0Config, 176163,
                                   self.hltConfig,
                                   { 'process' : "HLT",
                                     'mapping' : self.referenceMapping })
@@ -1522,7 +1522,7 @@ class Tier0FeederTest(unittest.TestCase):
         self.assertEqual(len(self.getClosedLumis()), 0,
                          "ERROR: there should be no closed lumis")
 
-        RunConfigAPI.configureRun(self.tier0Config, 176161, "/store",
+        RunConfigAPI.configureRun(self.tier0Config, 176161,
                                   self.hltConfig,
                                   { 'process' : "HLT",
                                     'mapping' : self.referenceMapping })
@@ -1600,7 +1600,7 @@ class Tier0FeederTest(unittest.TestCase):
         for count in range(14):
             self.insertRunStreamLumi(176161, "A", 1)
 
-        RunConfigAPI.configureRun(self.tier0Config, 176161, "/store",
+        RunConfigAPI.configureRun(self.tier0Config, 176161,
                                   self.hltConfig,
                                   { 'process' : "HLT",
                                     'mapping' : self.referenceMapping })
@@ -1663,7 +1663,7 @@ class Tier0FeederTest(unittest.TestCase):
         self.insertRunStreamLumi(176161, "A", 1)
         self.insertRunStreamLumi(176161, "A", 1)
 
-        RunConfigAPI.configureRun(self.tier0Config, 176161, "/store",
+        RunConfigAPI.configureRun(self.tier0Config, 176161,
                                   self.hltConfig,
                                   { 'process' : "HLT",
                                     'mapping' : self.referenceMapping })

--- a/test/python/T0_t/WMBS_t/RunConfig_t/ExampleConfig.py
+++ b/test/python/T0_t/WMBS_t/RunConfig_t/ExampleConfig.py
@@ -7,7 +7,9 @@ Example configuration for RunConfig unittest
 from T0.RunConfig.Tier0Config import addDataset
 from T0.RunConfig.Tier0Config import createTier0Config
 from T0.RunConfig.Tier0Config import setAcquisitionEra
-from T0.RunConfig.Tier0Config import setAlcaHarvestConfig
+from T0.RunConfig.Tier0Config import setLFNPrefix
+from T0.RunConfig.Tier0Config import setBulkDataType
+from T0.RunConfig.Tier0Config import setPromptCalibrationConfig
 from T0.RunConfig.Tier0Config import setConfigVersion
 from T0.RunConfig.Tier0Config import ignoreStream
 from T0.RunConfig.Tier0Config import addRepackConfig
@@ -27,11 +29,14 @@ setConfigVersion(tier0Config, "replace with real version")
 #  LFN prefix
 #  data type
 setAcquisitionEra(tier0Config, "ExampleConfig_UnitTest")
-#setLFNPrefix(tier0Config, "/store")
-#setDataType(tier0Config, "data")
-setAlcaHarvestConfig(tier0Config,
-                     alcaHarvestTimeout = 12*3600,
-                     alcaHarvestDir = "/blah/blah")
+setLFNPrefix(tier0Config, "/store")
+setBulkDataType(tier0Config, "data")
+setPromptCalibrationConfig(tier0Config,
+                           alcaHarvestTimeout = 12*3600,
+                           alcaHarvestDir = "/some/afs/dir",
+                           conditionUploadTimeout = 18*3600,
+                           dropboxHost = "webcondvm.cern.ch",
+                           validationMode = True)
 
 # setup repack and express version mappings
 repackVersionOverride = {

--- a/test/python/T0_t/WMBS_t/RunConfig_t/RunConfig_t.py
+++ b/test/python/T0_t/WMBS_t/RunConfig_t/RunConfig_t.py
@@ -145,11 +145,15 @@ class RunConfigTest(unittest.TestCase):
         self.tier0Config = loadConfigurationFile("ExampleConfig.py")
 
         self.referenceRunInfo = [ { 'status': 1,
-                                    'lfn_base' : "/store",
+                                    'lfn_prefix' : "/store",
+                                    'bulk_data_type' : "data",
                                     'process': 'HLT',
                                     'hltkey': self.hltkey,
                                     'ah_timeout' : 12*3600,
                                     'ah_dir' : "/blah/blah",
+                                    'cond_timeout' : 18*3600,
+                                    'db_host' : "webcondvm.cern.ch",
+                                    'valid_mode' : True,
                                     'acq_era': 'ExampleConfig_UnitTest' } ]
 
         self.referenceMapping = {}
@@ -1087,7 +1091,7 @@ class RunConfigTest(unittest.TestCase):
         """
         myThread = threading.currentThread()
 
-        RunConfigAPI.configureRun(self.tier0Config, 176161, "/store",
+        RunConfigAPI.configureRun(self.tier0Config, 176161,
                                   self.hltConfig,
                                   { 'process' : "HLT",
                                     'mapping' : self.referenceMapping })


### PR DESCRIPTION
LFN prefix (/store or /store/backfill/n) and bulk data type (data or hidate)
are now configurable in OfflineConfiguration. Also rework the config options
for the PCL, configuring all the options in OfflineConfiguration as well.
