### PR TITLE
select alternative fileset closing policy

### DIFF
--- a/src/python/T0/RunConfig/RunConfigAPI.py
+++ b/src/python/T0/RunConfig/RunConfigAPI.py
@@ -415,7 +415,7 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
             if streamConfig.ProcessingStyle in [ 'Bulk', 'Express' ]:
                 insertStreamFilesetDAO.execute(run, stream, filesetName, conn = myThread.transaction.conn, transaction = True)
                 fileset.load()
-                wmbsHelper.createSubscription(wmSpec.getTask(taskName), fileset)
+                wmbsHelper.createSubscription(wmSpec.getTask(taskName), fileset, alternativeFilesetClose = True)
                 insertWorkflowMonitoringDAO.execute([fileset.id],  conn = myThread.transaction.conn, transaction = True)
             if streamConfig.ProcessingStyle == "Bulk":
                 bindsRecoReleaseConfig = []
@@ -653,7 +653,7 @@ def releasePromptReco(tier0Config, specDirectory, dqmUploadProxy = None):
         if len(bindsReleasePromptReco) > 0:
             releasePromptRecoDAO.execute(bindsReleasePromptReco, conn = myThread.transaction.conn, transaction = True)
         for (wmbsHelper, wmSpec, fileset) in recoSpecs.values():
-            wmbsHelper.createSubscription(wmSpec.getTask(taskName), Fileset(id = fileset))
+            wmbsHelper.createSubscription(wmSpec.getTask(taskName), Fileset(id = fileset), alternativeFilesetClose = True)
             insertWorkflowMonitoringDAO.execute([fileset],  conn = myThread.transaction.conn, transaction = True)
         if len(recoSpecs) > 0:
             markWorkflowsInjectedDAO.execute(recoSpecs.keys(), injected = True, conn = myThread.transaction.conn, transaction = True)

--- a/src/python/T0/WMBS/Oracle/RunConfig/GetRunInfo.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/GetRunInfo.py
@@ -20,7 +20,10 @@ class GetRunInfo(DBFormatter):
                         lfn_prefix,
                         bulk_data_type,
                         ah_timeout,
-                        ah_dir
+                        ah_dir,
+                        cond_timeout,
+                        db_host,
+                        valid_mode
                  FROM run
                  WHERE run_id = :RUN
                  """

--- a/test/python/T0_t/WMBS_t/RunConfig_t/RunConfig_t.py
+++ b/test/python/T0_t/WMBS_t/RunConfig_t/RunConfig_t.py
@@ -150,10 +150,10 @@ class RunConfigTest(unittest.TestCase):
                                     'process': 'HLT',
                                     'hltkey': self.hltkey,
                                     'ah_timeout' : 12*3600,
-                                    'ah_dir' : "/blah/blah",
+                                    'ah_dir' : "/some/afs/dir",
                                     'cond_timeout' : 18*3600,
                                     'db_host' : "webcondvm.cern.ch",
-                                    'valid_mode' : True,
+                                    'valid_mode' : int(True),
                                     'acq_era': 'ExampleConfig_UnitTest' } ]
 
         self.referenceMapping = {}


### PR DESCRIPTION
WMBSHelper supports selecting an alternative fileset closing policy
which make RAW merges trigger when we have all data for a run/stream
repacked, not just when we release PromptReco as it's now.
