### PR TITLE
make Repack job splitting parameters configurable

### DIFF
--- a/src/python/T0/JobSplitting/Repack.py
+++ b/src/python/T0/JobSplitting/Repack.py
@@ -31,7 +31,7 @@ class Repack(JobFactory):
         self.jobNamePrefix = kwargs.get('jobNamePrefix', "Repack")
         self.maxSizeSingleLumi = kwargs['maxSizeSingleLumi']
         self.maxSizeMultiLumi = kwargs['maxSizeMultiLumi']
-        self.maxEvents = kwargs['maxEvents']
+        self.maxInputEvents = kwargs['maxInputEvents']
         self.maxInputFiles = kwargs['maxInputFiles']
 
         self.createdGroup = False
@@ -141,7 +141,7 @@ class Repack(JobFactory):
             # => handle lumi individually and split
             #
             if lumiSizeTotal > self.maxSizeSingleLumi or \
-                   lumiEventsTotal > self.maxEvents:
+                   lumiEventsTotal > self.maxInputEvents:
 
                 splitLumis.append( { 'SUB' : self.subscription["id"],
                                      'LUMI' : lumi } )
@@ -171,7 +171,7 @@ class Repack(JobFactory):
                             newSizeTotal = sizeTotal + streamer['filesize']                        
 
                             if newSizeTotal <= self.maxSizeSingleLumi and \
-                                   newEventsTotal <= self.maxEvents:
+                                   newEventsTotal <= self.maxInputEvents:
                                 eventsTotal = newEventsTotal
                                 sizeTotal = newSizeTotal
                                 streamerList.append(streamer)
@@ -203,7 +203,7 @@ class Repack(JobFactory):
 
                 # still safe with new lumi, just add it
                 elif newSizeTotal <= self.maxSizeMultiLumi and \
-                       newEventsTotal <= self.maxEvents and \
+                       newEventsTotal <= self.maxInputEvents and \
                        newInputfiles <= self.maxInputFiles:
 
                     jobSizeTotal = newSizeTotal

--- a/src/python/T0/JobSplitting/RepackMerge.py
+++ b/src/python/T0/JobSplitting/RepackMerge.py
@@ -30,9 +30,9 @@ class RepackMerge(JobFactory):
         """
         # extract some global scheduling parameters
         self.jobNamePrefix = kwargs.get('jobNamePrefix', "RepackMerge")
-        self.minSize = kwargs['minSize']
-        self.maxSize = kwargs['maxSize']
-        self.maxEvents = kwargs['maxEvents']
+        self.minInputSize = kwargs['minInputSize']
+        self.maxInputSize = kwargs['maxInputSize']
+        self.maxInputEvents = kwargs['maxInputEvents']
         self.maxInputFiles = kwargs['maxInputFiles']
         self.maxEdmSize = kwargs['maxEdmSize']
         self.maxOverSize = kwargs['maxOverSize']
@@ -174,7 +174,7 @@ class RepackMerge(JobFactory):
                             newSizeTotal = sizeTotal + fileInfo['filesize']
 
                             if newSizeTotal <= self.maxEdmSize and \
-                                   newEventsTotal <= self.maxEvents:
+                                   newEventsTotal <= self.maxInputEvents:
                                 eventsTotal = newEventsTotal
                                 sizeTotal = newSizeTotal
                                 fileList.append(fileInfo)
@@ -184,8 +184,8 @@ class RepackMerge(JobFactory):
                     for fileInfo in fileList:
                         lumiFileList.remove(fileInfo)
 
-            elif lumiSizeTotal >= self.maxSize or \
-                     lumiEventsTotal >= self.maxEvents or \
+            elif lumiSizeTotal >= self.maxInputSize or \
+                     lumiEventsTotal >= self.maxInputEvents or \
                      lumiInputFiles >= self.maxInputFiles:
 
                 # merge what we have to preserve order
@@ -206,8 +206,8 @@ class RepackMerge(JobFactory):
                 newInputFiles = jobInputFiles + lumiInputFiles
 
                 # still safe with new file, just add it
-                if newSizeTotal <= self.maxSize and \
-                       newEventsTotal <= self.maxEvents and \
+                if newSizeTotal <= self.maxInputSize and \
+                       newEventsTotal <= self.maxInputEvents and \
                        newInputFiles <= self.maxInputFiles:
 
                     jobSizeTotal = newSizeTotal
@@ -217,7 +217,7 @@ class RepackMerge(JobFactory):
 
                 # over limits with new file, over minimum without it
                 # issue merge job (regular)
-                elif jobSizeTotal > self.minSize:
+                elif jobSizeTotal > self.minInputSize:
 
                     self.createJob(jobFileList)
                     jobSizeTotal = lumiSizeTotal
@@ -230,7 +230,7 @@ class RepackMerge(JobFactory):
                 # still below override limits (and below event limit)
                 # add file, issue merge job (too large)
                 elif newSizeTotal <= self.maxOverSize and \
-                         newEventsTotal <= self.maxEvents:
+                         newEventsTotal <= self.maxInputEvents:
 
                     jobFileList.extend(lumiFileList)
                     self.createJob(jobFileList)

--- a/src/python/T0/RunConfig/RunConfigAPI.py
+++ b/src/python/T0/RunConfig/RunConfigAPI.py
@@ -228,7 +228,15 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
 
             bindsRepackConfig = { 'RUN' : run,
                                   'STREAM' : stream,
-                                  'PROC_VER': streamConfig.Repack.ProcessingVersion }
+                                  'PROC_VER': streamConfig.Repack.ProcessingVersion,
+                                  'MAX_SIZE_SINGLE_LUMI' : streamConfig.Repack.MaxSizeSingleLumi,
+                                  'MAX_SIZE_MULTI_LUMI' : streamConfig.Repack.MaxSizeMultiLumi,
+                                  'MIN_SIZE' : streamConfig.Repack.MinInputSize,
+                                  'MAX_SIZE' : streamConfig.Repack.MaxInputSize,
+                                  'MAX_EDM_SIZE' : streamConfig.Repack.MaxEdmSize,
+                                  'MAX_OVER_SIZE' : streamConfig.Repack.MaxOverSize,
+                                  'MAX_EVENTS' : streamConfig.Repack.MaxInputEvents,
+                                  'MAX_FILES' : streamConfig.Repack.MaxInputFiles }
 
         elif streamConfig.ProcessingStyle == "Express":
 
@@ -342,6 +350,14 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
             workflowName = "Repack_Run%d_Stream%s" % (run, stream)
             specArguments = getRepackArguments()
             specArguments['ProcessingVersion'] = streamConfig.Repack.ProcessingVersion
+            specArguments['MaxSizeSingleLumi'] = streamConfig.Repack.MaxSizeSingleLumi
+            specArguments['MaxSizeMultiLumi'] = streamConfig.Repack.MaxSizeMultiLumi
+            specArguments['MinInputSize'] = streamConfig.Repack.MinInputSize
+            specArguments['MaxInputSize'] = streamConfig.Repack.MaxInputSize
+            specArguments['MaxEdmSize'] = streamConfig.Repack.MaxEdmSize
+            specArguments['MaxOverSize'] = streamConfig.Repack.MaxOverSize
+            specArguments['MaxInputEvents'] = streamConfig.Repack.MaxInputEvents
+            specArguments['MaxInputFiles'] = streamConfig.Repack.MaxInputFiles
             specArguments['UnmergedLFNBase'] = "%s/t0temp/%s" % (runInfo['lfn_prefix'],
                                                                  runInfo['bulk_data_type'])
             specArguments['MergedLFNBase'] = "%s/%s" % (runInfo['lfn_prefix'],

--- a/src/python/T0/RunConfig/Tier0Config.py
+++ b/src/python/T0/RunConfig/Tier0Config.py
@@ -52,7 +52,31 @@ Tier0Configuration - Global configuration object
 |             |
 |             |--> Repack - Configuration section for bulk streams
 |             |     |
-|             |     |--> Nothing here for now, placeholder
+|             |     |--> ProcessingVersion - processing version
+|             |     |
+|             |     |--> MaxSizeSingleLumi - max size of single lumi before we break
+|             |     |                        it up into multiple repack jobs
+|             |     |
+|             |     |--> MaxSizeMultiLumi - max size for a multi lumi repack job
+|             |     |
+|             |     |--> MinInputSize - min input size for repack merge job
+|             |     |
+|             |     |--> MaxInputSize - max input size for repack merge job
+|             |     |
+|             |     |--> MaxEdmSize - max size for repack merge output, break
+|             |     |                 up lumi into multiple files and send to
+|             |     |                 error dataset if larger
+|             |     |
+|             |     |--> MaxOverSize - max size for overmerge (where merging in
+|             |     |                  order forces us to use a lumi to get over
+|             |     |                  the min size but that also gets us over
+|             |     |                  the max size allowed. In these case we
+|             |     |                  have a preference for creating too large
+|             |     |                  files compared to too small files.
+|             |     |
+|             |     |--> MaxInputEvents - max input events for repack and repack merge job
+|             |     |
+|             |     |--> MaxInputFiles - max input files for repack and repack merge job
 |             |
 |             |--> Express - Configuration section for express streams
 |             |     |
@@ -68,7 +92,7 @@ Tier0Configuration - Global configuration object
 |             |     |
 |             |     |--> ProcessingVersion - processing version
 |             |     |
-|             |     |--> MaxInputEvents - max events for express processing job
+|             |     |--> MaxInputEvents - max input events for express processing job
 |             |     |
 |             |     |--> MaxInputSize - max input size for express merge job
 |             |     |
@@ -429,6 +453,49 @@ def addRepackConfig(config, streamName, **options):
         streamConfig.Repack.ProcessingVersion = options.get("proc_ver", streamConfig.Repack.ProcessingVersion)
     else:
         streamConfig.Repack.ProcessingVersion = options.get("proc_ver", 1)
+
+    if hasattr(streamConfig.Repack, "MaxSizeSingleLumi"):
+        streamConfig.Repack.MaxSizeSingleLumi = options.get("maxSizeSingleLumi", streamConfig.Repack.MaxSizeSingleLumi)
+    else:
+        streamConfig.Repack.MaxSizeSingleLumi = options.get("maxSizeSingleLumi", 10*1024*1024*1024)
+
+    if hasattr(streamConfig.Repack, "MaxSizeMultiLumi"):
+        streamConfig.Repack.MaxSizeMultiLumi = options.get("maxSizeMultiLumi", streamConfig.Repack.MaxSizeMultiLumi)
+    else:
+        streamConfig.Repack.MaxSizeMultiLumi = options.get("maxSizeMultiLumi", 8*1024*1024*1024)
+
+    if hasattr(streamConfig.Repack, "MinInputSize"):
+        streamConfig.Repack.MinInputSize = options.get("minInputSize", streamConfig.Repack.MinInputSize)
+    else:
+        streamConfig.Repack.MinInputSize = options.get("minInputSize", 2.1 * 1024 * 1024 * 1024)
+
+    if hasattr(streamConfig.Repack, "MaxInputSize"):
+        streamConfig.Repack.MaxInputSize = options.get("maxInputSize", streamConfig.Repack.MaxInputSize)
+    else:
+        streamConfig.Repack.MaxInputSize = options.get("maxInputSize", 4 * 1024 * 1024 * 1024)
+
+    if hasattr(streamConfig.Repack, "MaxEdmSize"):
+        streamConfig.Repack.MaxEdmSize = options.get("maxEdmSize", streamConfig.Repack.MaxEdmSize)
+    else:
+        streamConfig.Repack.MaxEdmSize = options.get("maxEdmSize", 10 * 1024 * 1024 * 1024)
+
+    if hasattr(streamConfig.Repack, "MaxOverSize"):
+        streamConfig.Repack.MaxOverSize = options.get("maxOverSize", streamConfig.Repack.MaxOverSize)
+    else:
+        streamConfig.Repack.MaxOverSize = options.get("maxOverSize", 8 * 1024 * 1024 * 1024)
+
+    if hasattr(streamConfig.Repack, "MaxInputEvents"):
+        streamConfig.Repack.MaxInputEvents = options.get("maxInputEvents", streamConfig.Repack.MaxInputEvents)
+    else:
+        streamConfig.Repack.MaxInputEvents = options.get("maxInputEvents", 10 * 1000 * 1000)
+
+    if hasattr(streamConfig.Repack, "MaxInputFiles"):
+        streamConfig.Repack.MaxInputFiles = options.get("maxInputFiles", streamConfig.Repack.MaxInputFiles)
+    else:
+        streamConfig.Repack.MaxInputFiles = options.get("maxInputFiles", 1000)
+
+    if streamConfig.Repack.MaxOverSize > streamConfig.Repack.MaxEdmSize:
+        streamConfig.Repack.MaxOverSize = streamConfig.Repack.MaxEdmSize
 
     return
 

--- a/src/python/T0/WMBS/Oracle/Create.py
+++ b/src/python/T0/WMBS/Oracle/Create.py
@@ -251,9 +251,17 @@ class Create(DBCreator):
 
         self.create[len(self.create)] = \
             """CREATE TABLE repack_config (
-                 run_id         int not null,
-                 stream_id      int not null,
-                 proc_version   int not null,
+                 run_id               int not null,
+                 stream_id            int not null,
+                 proc_version         int not null,
+                 max_size_single_lumi int not null,
+                 max_size_multi_lumi  int not null,
+                 min_size             int not null,
+                 max_size             int not null,
+                 max_edm_size         int not null,
+                 max_over_size        int not null,
+                 max_events           int not null,
+                 max_files            int not null,
                  primary key (run_id, stream_id)
                ) ORGANIZATION INDEX"""
 

--- a/src/python/T0/WMBS/Oracle/RunConfig/GetRepackConfig.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/GetRepackConfig.py
@@ -14,6 +14,14 @@ class GetRepackConfig(DBFormatter):
     def execute(self, run, stream, conn = None, transaction = False):
 
         sql = """SELECT repack_config.proc_version AS proc_ver,
+                        repack_config.max_size_single_lumi AS max_size_single_lumi,
+                        repack_config.max_size_multi_lumi AS max_size_multi_lumi,
+                        repack_config.min_size AS min_size,
+                        repack_config.max_size AS max_size,
+                        repack_config.max_edm_size AS max_edm_size,
+                        repack_config.max_over_size AS max_over_size,
+                        repack_config.max_events AS max_events,
+                        repack_config.max_files AS max_files,
                         cmssw_version.name AS cmssw
                  FROM repack_config
                  INNER JOIN run_stream_cmssw_assoc ON

--- a/src/python/T0/WMBS/Oracle/RunConfig/InsertRepackConfig.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/InsertRepackConfig.py
@@ -12,10 +12,19 @@ class InsertRepackConfig(DBFormatter):
     def execute(self, binds, conn = None, transaction = False):
 
         sql = """INSERT INTO repack_config
-                 (RUN_ID, STREAM_ID, PROC_VERSION)
+                 (RUN_ID, STREAM_ID, PROC_VERSION, MAX_SIZE_SINGLE_LUMI, MAX_SIZE_MULTI_LUMI,
+                  MIN_SIZE, MAX_SIZE, MAX_EDM_SIZE, MAX_OVER_SIZE, MAX_EVENTS, MAX_FILES)
                  VALUES (:RUN,
                          (SELECT id FROM stream WHERE name = :STREAM),
-                         :PROC_VER)
+                         :PROC_VER,
+                         :MAX_SIZE_SINGLE_LUMI,
+                         :MAX_SIZE_MULTI_LUMI,
+                         :MIN_SIZE,
+                         :MAX_SIZE,
+                         :MAX_EDM_SIZE,
+                         :MAX_OVER_SIZE,
+                         :MAX_EVENTS,
+                         :MAX_FILES)
                  """
 
         self.dbi.processData(sql, binds, conn = conn,

--- a/src/python/T0/WMSpec/StdSpecs/Repack.py
+++ b/src/python/T0/WMSpec/StdSpecs/Repack.py
@@ -180,20 +180,17 @@ class RepackWorkloadFactory(StdBase):
 
         # job splitting parameters
         self.repackSplitArgs = {}
-        self.repackSplitArgs['maxSizeSingleLumi'] = 20*1024*1024*1024
-        self.repackSplitArgs['maxSizeMultiLumi'] = 10*1024*1024*1024
-        self.repackSplitArgs['maxEvents'] = 500000
-        self.repackSplitArgs['maxInputFiles'] = 1000
+        self.repackSplitArgs['maxSizeSingleLumi'] = arguments['MaxSizeSingleLumi']
+        self.repackSplitArgs['maxSizeMultiLumi'] = arguments['MaxSizeMultiLumi']
+        self.repackSplitArgs['maxInputEvents'] = arguments['MaxInputEvents']
+        self.repackSplitArgs['maxInputFiles'] = arguments['MaxInputFiles']
         self.repackMergeSplitArgs = {}
-        self.repackMergeSplitArgs['minSize'] = 2.1 * 1024 * 1024 * 1024
-        self.repackMergeSplitArgs['maxSize'] = 4.0 * 1024 * 1024 * 1024
-        self.repackMergeSplitArgs['maxEvents'] = 100000000
-        self.repackMergeSplitArgs['maxInputFiles'] = 1000
-        self.repackMergeSplitArgs['maxEdmSize'] = 20 * 1024 * 1024 * 1024
-        self.repackMergeSplitArgs['maxOverSize'] = 10 * 1024 * 1024 * 1024
-
-        if self.repackMergeSplitArgs['maxOverSize'] > self.repackMergeSplitArgs['maxEdmSize']:
-            self.repackMergeSplitArgs['maxOverSize'] = self.repackMergeSplitArgs['maxEdmSize']
+        self.repackMergeSplitArgs['minInputSize'] = arguments['MinInputSize']
+        self.repackMergeSplitArgs['maxInputSize'] = arguments['MaxInputSize']
+        self.repackMergeSplitArgs['maxEdmSize'] = arguments['MaxEdmSize']
+        self.repackMergeSplitArgs['maxOverSize'] = arguments['MaxOverSize']
+        self.repackMergeSplitArgs['maxInputEvents'] = arguments['MaxInputEvents']
+        self.repackMergeSplitArgs['maxInputFiles'] = arguments['MaxInputFiles']
 
         if arguments.has_key("Multicore"):
             numCores = arguments.get("Multicore")

--- a/test/python/T0_t/WMBS_t/RunConfig_t/ExampleConfig.py
+++ b/test/python/T0_t/WMBS_t/RunConfig_t/ExampleConfig.py
@@ -50,6 +50,14 @@ hltmonVersionOverride = {
 
 addRepackConfig(tier0Config, "Default",
                 proc_ver = 1,
+                maxSizeSingleLumi = 1234,
+                maxSizeMultiLumi = 1122,
+                minInputSize = 210,
+                maxInputSize = 400,
+                maxEdmSize = 1233,
+                maxOverSize = 1133,
+                maxInputEvents = 500,
+                maxInputFiles = 1111,
                 versionOverride = repackVersionOverride)
 
 addExpressConfig(tier0Config, "Express",

--- a/test/python/T0_t/WMBS_t/RunConfig_t/RunConfig_t.py
+++ b/test/python/T0_t/WMBS_t/RunConfig_t/RunConfig_t.py
@@ -1171,6 +1171,30 @@ class RunConfigTest(unittest.TestCase):
         self.assertEqual(repackConfig['proc_ver'], 1,
                          "ERROR: wrong processing version for stream A")
 
+        self.assertEqual(repackConfig['max_size_single_lumi'], 1234,
+                         "ERROR: wrong max single lumi size for stream A")
+
+        self.assertEqual(repackConfig['max_size_multi_lumi'], 1122,
+                         "ERROR: wrong max multi lumi size for stream A")
+
+        self.assertEqual(repackConfig['min_size'], 210,
+                         "ERROR: wrong min input size for stream A")
+
+        self.assertEqual(repackConfig['max_size'], 400,
+                         "ERROR: wrong max input size for stream A")
+
+        self.assertEqual(repackConfig['max_edm_size'], 1233,
+                         "ERROR: wrong max edm size for stream A")
+
+        self.assertEqual(repackConfig['max_over_size'], 1133,
+                         "ERROR: wrong max over size for stream A")
+
+        self.assertEqual(repackConfig['max_events'], 500,
+                         "ERROR: wrong max input events for stream A")
+
+        self.assertEqual(repackConfig['max_files'], 1111,
+                         "ERROR: wrong max input files for stream A")
+
         self.assertEqual(repackConfig['cmssw'], "CMSSW_4_2_7",
                          "ERROR: wrong CMSSW version for stream A")
 


### PR DESCRIPTION
All the Repack job splitting parameters are currently hardcoded in the
Repack Spec. Make them configurable in OfflineConfiguration.
