### PR TITLE
fix merged status of express merge output

### DIFF
--- a/src/python/T0/WMSpec/StdSpecs/Express.py
+++ b/src/python/T0/WMSpec/StdSpecs/Express.py
@@ -199,6 +199,8 @@ class ExpressWorkloadFactory(StdBase):
         mergeTask.setTaskPriority(self.priority + 5)
 
         mergeTaskCmsswHelper = mergeTaskCmssw.getTypeHelper()
+        mergeTaskStageHelper = mergeTaskStageOut.getTypeHelper()
+
         mergeTaskCmsswHelper.cmsswSetup(self.frameworkVersion, softwareEnvironment = "",
                                         scramArch = self.scramArch)
 
@@ -206,7 +208,9 @@ class ExpressWorkloadFactory(StdBase):
         mergeTaskCmsswHelper.setGlobalTag(self.globalTag)
         mergeTaskCmsswHelper.setOverrideCatalog(self.overrideCatalog)
 
-        mergeTask.setTaskType("Express")
+        #mergeTaskStageHelper.setMinMergeSize(0, 0)
+
+        mergeTask.setTaskType("Merge")
 
         # DQM is handled differently
         #  merging does not increase size

--- a/src/python/T0/WMSpec/StdSpecs/Repack.py
+++ b/src/python/T0/WMSpec/StdSpecs/Repack.py
@@ -129,6 +129,8 @@ class RepackWorkloadFactory(StdBase):
         mergeTask.setInputReference(parentTaskCmssw, outputModule = parentOutputModuleName)
 
         mergeTaskCmsswHelper = mergeTaskCmssw.getTypeHelper()
+        mergeTaskStageHelper = mergeTaskStageOut.getTypeHelper()
+
         mergeTaskCmsswHelper.cmsswSetup(self.frameworkVersion, softwareEnvironment = "",
                                         scramArch = self.scramArch)
 
@@ -136,11 +138,13 @@ class RepackWorkloadFactory(StdBase):
         mergeTaskCmsswHelper.setGlobalTag(self.globalTag)
         mergeTaskCmsswHelper.setOverrideCatalog(self.overrideCatalog)
 
+        #mergeTaskStageHelper.setMinMergeSize(0, 0)
+
+        mergeTask.setTaskType("Merge")
+
         # finalize splitting parameters
         mySplitArgs = self.repackMergeSplitArgs.copy()
         mySplitArgs['algo_package'] = "T0.JobSplitting"
-
-        mergeTask.setTaskType("Merge")
 
         mergeTask.setSplittingAlgorithm("RepackMerge",
                                         **mySplitArgs)


### PR DESCRIPTION
Express files are marked as unmerged in WMBS because WMCore can't force direct
to merge for processing jobs with output module called 'Merged'. Work around it
by reverting the express merge task type to 'Merge'.
