### PR TITLE
fix serious problem with repack merge scheduling

### DIFF
--- a/src/python/T0/WMBS/Oracle/JobSplitting/InsertSplitLumis.py
+++ b/src/python/T0/WMBS/Oracle/JobSplitting/InsertSplitLumis.py
@@ -9,19 +9,11 @@ from WMCore.Database.DBFormatter import DBFormatter
 
 class InsertSplitLumis(DBFormatter):
 
-    sql = """MERGE INTO lumi_section_split_active a
-             USING (
-               SELECT run_id AS run_id,
-                      :SUB AS subscription,
-                      :LUMI AS lumi_id
-               FROM run_stream_fileset_assoc
-               WHERE fileset =
-                 (SELECT fileset FROM wmbs_subscription WHERE id = :SUB)
-             ) b ON ( b.run_id = a.run_id AND
-                      b.subscription = a.subscription )
-             WHEN NOT MATCHED THEN
-               INSERT (run_id, subscription, lumi_id)
-               VALUES (b.run_id, b.subscription, b.lumi_id)
+    sql = """INSERT INTO lumi_section_split_active
+             (run_id, subscription, lumi_id)
+             SELECT run_id, :SUB, :LUMI
+             FROM run_stream_fileset_assoc
+             WHERE fileset = (SELECT fileset FROM wmbs_subscription WHERE id = :SUB)
              """
 
     def execute(self, binds, conn = None, transaction = False):


### PR DESCRIPTION
In cases where we split repack many consequetive lumis, there is a serous problem with the scheduling of repack merge jobs. The job splitter creates repack merge jobs for partial lumis. Fix this by making a change in the query that keeps track of split repacked lumis.
