### PR TITLE
Fix Express subscriptions

### DIFF
--- a/src/python/T0/RunConfig/RunConfigAPI.py
+++ b/src/python/T0/RunConfig/RunConfigAPI.py
@@ -274,8 +274,8 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
                                         'REQ_ONLY' : "n",
                                         'PRIO' : "high" } )
 
-            subscriptions['Express'].append( { 'custodialSites' : [expressPhEDExSubscribeNode],
-                                               'nonCustodialSites' : [],
+            subscriptions['Express'].append( { 'custodialSites' : [],
+                                               'nonCustodialSites' : [expressPhEDExSubscribeNode],
                                                'autoApproveSites' : [expressPhEDExSubscribeNode],
                                                'priority' : "high",
                                                'primaryDataset' : specialDataset } )
@@ -407,8 +407,8 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
                                             'REQ_ONLY' : "n",
                                             'PRIO' : "high" } )
 
-                subscriptions['Express'].append( { 'custodialSites' : [expressPhEDExSubscribeNode],
-                                                   'nonCustodialSites' : [],
+                subscriptions['Express'].append( { 'custodialSites' : [],
+                                                   'nonCustodialSites' : [expressPhEDExSubscribeNode],
                                                    'autoApproveSites' : [expressPhEDExSubscribeNode],
                                                    'priority' : "high",
                                                    'primaryDataset' : dataset } )


### PR DESCRIPTION
Express subscriptions to T2_CH_CERN can't be custodial. There is
no tape backend
