### PR TITLE
copy back to AFS actually uploaded metadata file from alcaupload

### DIFF
--- a/src/python/T0/ConditionUpload/ConditionUploadAPI.py
+++ b/src/python/T0/ConditionUpload/ConditionUploadAPI.py
@@ -168,6 +168,8 @@ def uploadToDropbox(condFiles, dropboxHost, validationMode):
         os.chmod(filenameDB, stat.S_IREAD | stat.S_IWRITE | stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IWGRP | stat.S_IROTH | stat.S_IWOTH)
         os.chmod(filenameTXT, stat.S_IREAD | stat.S_IWRITE | stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IWGRP | stat.S_IROTH | stat.S_IWOTH)
 
+        shutil.copy2(filenameTXT, metaFile['pfn'] + ".uploaded")
+
         uploadStatus = True
         if validationMode:
 


### PR DESCRIPTION
To help with the PCL monitoring, copy back the metadata file created on the WN to AFS.
This provides the content (correct destDB parameter) and it means the file creation
timestamp will show the actual alcaupload time.
