### PR TITLE
fix problem with PCL completion check, fixes #4013

### DIFF
--- a/src/python/T0/WMBS/Oracle/ConditionUpload/IsPromptCalibrationFinished.py
+++ b/src/python/T0/WMBS/Oracle/ConditionUpload/IsPromptCalibrationFinished.py
@@ -17,8 +17,7 @@ class IsPromptCalibrationFinished(DBFormatter):
         sql = """SELECT 1
                  FROM wmbs_subscription
                    INNER JOIN wmbs_fileset ON
-                     wmbs_fileset.id = wmbs_subscription.fileset AND
-                     wmbs_fileset.open = 0
+                     wmbs_fileset.id = wmbs_subscription.fileset
                    LEFT OUTER JOIN wmbs_sub_files_available ON
                      wmbs_sub_files_available.subscription = wmbs_subscription.id
                    LEFT OUTER JOIN wmbs_sub_files_acquired ON
@@ -26,6 +25,7 @@ class IsPromptCalibrationFinished(DBFormatter):
                  WHERE wmbs_subscription.id = :SUBSCRIPTION
                  HAVING COUNT(wmbs_sub_files_available.subscription) = 0
                  AND COUNT(wmbs_sub_files_acquired.subscription) = 0
+                 AND SUM(wmbs_fileset.open) = 0
                  """
 
         binds = { 'SUBSCRIPTION' : subscription }


### PR DESCRIPTION
If AlcaHarvest timeout triggered and caused conditions to be created
for upload before all the data was processed, we need to make sure
that the system would only upload these conditions and not set
the PCL to finished for this run. For this reason there is a completion
check in the ConditionUpload.IsPromptCalibrationFinished DAO.
The query in that DAO has a bug, it would always return true.
The patch fixes the query.
