### PR TITLE
Implement check for active runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ install/
 dist/
 *.egg-info
 merge.cmd
+.settings

--- a/bin/diagnoseActiveRuns.py
+++ b/bin/diagnoseActiveRuns.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python
+"""
+__DiagnoseActiveRuns__
+
+Check a given run and look
+for problems in the input streamer data,
+e.g. incomplete data for lumis, EoLS/EoR missing records
+"""
+
+import logging
+import os
+import re
+import sys
+import traceback
+
+from optparse import OptionParser
+
+from T0 import version as T0Version
+from WMCore.Configuration import loadConfigurationFile
+from WMCore.DAOFactory import DAOFactory
+from WMCore.Database.DBFactory import DBFactory
+from WMCore.Database.Transaction import Transaction
+from WMCore.Services.WMStats.WMStatsReader import WMStatsReader
+
+def buildLumiRanges(lumiList):
+    """
+    _buildLumiRanges_
+
+    Get a list of integer
+    lumi ids and build a list
+    of tuples with the lumis in closed ranges
+    """
+    lumiRanges = []
+    firstLumi = lumiList[0]
+    lastLumi = lumiList[0]
+    for singleLumi in lumiList[1:]:
+        if singleLumi != lastLumi + 1:
+            lumiRanges.append((firstLumi, lastLumi))
+            firstLumi = singleLumi
+        lastLumi = singleLumi
+    lumiRanges.append((firstLumi, lastLumi))
+    return lumiRanges
+
+def diagnoseRun(runNumber, doChange):
+    """
+    _diagnoseRun_
+
+    Gets a run number and checks if it is active
+    and why. Particularly looks for problems in the input
+    lumi sections from SM.
+    """
+    # Setup everything, first the configuration
+    if "WMAGENT_CONFIG" not in os.environ:
+        logging.error("WMAGENT_CONFIG is not in the environment. Exiting.")
+        return 1
+
+    wmat0Config = loadConfigurationFile(os.environ["WMAGENT_CONFIG"])
+    t0astConnectUrl = wmat0Config.CoreDatabase.connectUrl
+    storageManagerConnectUrl = wmat0Config.StorageManagerDatabase.connectUrl
+
+    # Get all the DAO factories and DB interfaces
+    dbFactoryT0AST = DBFactory(logging, dburl = t0astConnectUrl, options = {})
+    dbInterfaceT0AST = dbFactoryT0AST.connect()
+    daoFactoryT0AST = DAOFactory(package = "T0.WMBS",
+                                 logger = logging,
+                                 dbinterface = dbInterfaceT0AST)
+    daoFactoryWMBS = DAOFactory(package = "WMCore.WMBS",
+                                logger = logging,
+                                dbinterface = dbInterfaceT0AST)
+
+    dbFactorySM = DBFactory(logging, dburl = storageManagerConnectUrl, options = {})
+    dbInterfaceSM = dbFactorySM.connect()
+    daoFactorySM = DAOFactory(package = "T0.WMBS",
+                                 logger = logging,
+                                 dbinterface = dbInterfaceSM)
+
+    # It needs WMStats as well
+    localWmstatsUrl = wmat0Config.AnalyticsDataCollector.localWMStatsURL
+    localDBreader = WMStatsReader(localWmstatsUrl)
+
+    # Start the checks
+    findActiveRunsDAO = daoFactoryT0AST(classname = "RunLumiCloseout.FindActiveRuns")
+    activeRuns = findActiveRunsDAO.execute()
+
+    if int(runNumber) in activeRuns:
+        logging.debug("Run has not ended yet, checking EoR records...")
+        # Run has not ended yet, check if it's an issue with EoR records
+        checkEoRRecordsDAO = daoFactorySM(classname = "RunLumiCloseout.CheckEndOfRunRecords")
+        result = checkEoRRecordsDAO.execute(run = runNumber)
+        if result["totalInstances"] != (len(result["instancesWithEoR"]) + len(result["instancesWithoutEoR"])):
+            logging.error("Number of instances in SM don't match.")
+        if result["instancesWithEoR"] and result["instancesWithoutEoR"]:
+            for instance in result["instancesWithoutEoR"]:
+                print "Instance %s didn't write an EoR record." % instance
+        elif result["instancesWithEoR"]:
+            print "Run %s has already ended according to SM, but not in T0AST. Check the Tier0Feeder" % runNumber
+        else:
+            print "Run %s has not ended yet according to SM." % runNumber
+        return 0
+
+    findEndedRunsDAO = daoFactorySM(classname = "RunLumiCloseout.FindEndedRuns")
+    endedRuns = findEndedRunsDAO.execute([runNumber])
+
+    if not endedRuns:
+        logging.error("Run does not exist. Exiting.")
+        return 1
+
+    logging.debug("Run has already ended, checking WMStats to see if it is closed.")
+
+    activeWorkflows = localDBreader.workflowsByStatus(["new"], stale = False)
+    closedWorkflows = localDBreader.workflowsByStatus([], stale = False)
+    regex = re.compile(r"^[\w]+_Run%s_[\w]+$" % runNumber)
+    matchingWorkflows = filter(regex.match, activeWorkflows)
+    matchingAllWorkflows = filter(regex.match, closedWorkflows)
+
+    if not matchingWorkflows and not matchingAllWorkflows:
+        print "Run is not yet available in WMStats."
+        return 0
+    elif not matchingWorkflows:
+        print "All workflows associated to the run are closed already."
+        return 0
+
+    for workflow in matchingWorkflows:
+        logging.debug("%s is still not closed" % workflow)
+
+    logging.debug("Checking for missing EoLS records")
+
+    lumiCloseDAO = daoFactoryT0AST(classname = "RunLumiCloseout.CheckClosedLumis")
+    closedRecords = lumiCloseDAO.execute(run = runNumber)
+
+    affectedStreams = {}
+
+    for entry in closedRecords:
+        if entry["closed_lumi_count"] != entry["expected_lumi_count"] or \
+           entry["closed_lumi_count"] != entry["max_lumi"]:
+            affectedStreams[entry["stream_id"]] = range(1, entry["expected_lumi_count"] + 1)
+
+    # If there are lumis with mismatching EoLS, report on the specific lumis
+    if affectedStreams:
+        print "There are missing EoLS records"
+        logging.debug("Checking individual streams")
+        closedLumisDAO = daoFactoryT0AST(classname = "RunLumiCloseout.GetClosedLumisForStream")
+        closedLumis = closedLumisDAO.execute(run = runNumber, streams = affectedStreams.keys())
+
+        for stream in affectedStreams:
+            logging.debug("Stream %s has lumis missing EoLS" % stream)
+            lumiList = affectedStreams[stream]
+            closedLumiList = closedLumis[stream]["closedLumis"]
+            openLumis = set(lumiList) - set(closedLumiList)
+            spuriousLumis = set(closedLumiList) - set(lumiList)
+
+            # Missing EoLS found
+            if openLumis:
+                lumis = sorted(list(openLumis))
+                lumiRanges = buildLumiRanges(lumis)
+                msg = "Stream %s has missing EoLS records in lumis: %s" % (closedLumis[stream]["name"],
+                                                                                    str(sorted(lumiRanges)))
+                print msg
+
+            # Extra closed lumi section records found
+            if spuriousLumis:
+                lumis = sorted(list(spuriousLumis))
+                lumiRanges = buildLumiRanges(lumis)
+                msg = "Stream %s has spurious EoLS records in lumis: %s" % (closedLumis[stream]["name"],
+                                                                                     str(sorted(lumiRanges)))
+                print msg
+        return 0
+
+    logging.debug("There are no EoLS missing records")
+    logging.debug("Checking for incomplete data in lumis")
+
+    openLumisDAO = daoFactoryT0AST(classname = "RunLumiCloseout.GetFileCountOnOpenLumis")
+    openLumis = openLumisDAO.execute(run = runNumber)
+
+    # Not problem so far, point the user to other systems.
+    if not openLumis:
+        print "No problem was found, check WMStats monitoring if run is still marked as Active."
+        return 0
+
+    # Inform about the lumis with missing/extra streamers
+    for streamKey in openLumis:
+        print "Stream %s has lumis with inconsistent data" % streamKey[1]
+        for lumi in openLumis[streamKey]:
+            msg = "Lumi %s has a mismatching number of streamers:\n Expected: %s, Found: %s" % (lumi, openLumis[streamKey][lumi][0], openLumis[streamKey][lumi][1])
+            print msg
+
+    if doChange:
+        # We are changing T0AST to closeout the run
+        logging.info("Making changes to T0AST, wiping incomplete lumis.")
+
+        # Get the files to delete
+        filesForStreamDAO = daoFactoryT0AST(classname = "RunLumiCloseout.GetFilesForStreamLumi")
+        streams = dict((streamKey[0], openLumis[streamKey]) for streamKey in openLumis)
+        fileList = filesForStreamDAO.execute(runNumber, streams)
+
+        # Log the full extent of the action
+        logging.info("Inserting into lumi_section_closed:")
+        for stream in streams:
+            for lumi in streams[stream]:
+                logging.info("    Run: %s, Stream: %s, Lumi: %s" % (runNumber, stream, lumi))
+        if fileList:
+            logging.info("Removing from STREAMER and WMBS_FILE_DETAILS")
+        for fileId in fileList:
+            logging.info(" ID: %s, LFN: %s" % (fileId, fileList[fileId]))
+
+        trans = None
+        try:
+            # Wrap it in a transaction since it is a delicate operation
+            trans = Transaction(dbinterface = dbInterfaceT0AST)
+            trans.begin()
+
+            # Close the lumis with 0 streamers
+            forceCloseLumiDAO = daoFactoryT0AST(classname = "RunLumiCloseout.ForceCloseLumi")
+            forceCloseLumiDAO.execute(runNumber, streams, conn = trans.conn, transaction = True)
+
+            deleteStreamerDAO = daoFactoryT0AST(classname = "RunLumiCloseout.DeleteStreamers")
+            deleteWMBSFileDAO = daoFactoryWMBS(classname = "Files.Delete")
+            if fileList:
+                # Get rid of the remaining streamer files
+                deleteStreamerDAO.execute(fileList.keys(), conn = trans.conn, transaction = True)
+                deleteWMBSFileDAO.execute(fileList.values(), conn = trans.conn, transaction = True)
+
+            # Everything went well, commit it
+            trans.commit()
+            print "Done with the changes, run should close soon."
+            return 0
+        except Exception, ex:
+            if trans:
+                # In case of error, rollback and close connection
+                trans.rollbackForError()
+            logging.error("Failed to make changes:\n %s" % str(ex))
+            logging.error(traceback.format_exc())
+
+            return 1
+
+    return 0
+
+def main():
+    """
+    _main_
+
+    Parse the options and check the requested run
+    """
+    usage = "Usage: %prog [options] RunNumber"
+    version = "Compatible with: %s" % T0Version
+    parser = OptionParser(usage = usage, version = version)
+    parser.add_option("--wipe-incomplete-lumi", action = "store_true", default = False,
+                      dest = "fixIncompleteLumi", help = "Wipes lumis with incomplete data from T0AST")
+    parser.add_option("-v", "--verbose", action = "store_true", default = False,
+                      dest = "verbose", help = "Prints DEBUG logging statements")
+    parser.add_option("-s", "--silent", action = "store_true", default = False,
+                      dest = "silent", help = "Suppress any logging statements below ERROR level")
+    (options, args) = parser.parse_args()
+
+    if options.verbose and options.silent:
+        print "Conflicting options: silent and verbose. Exiting."
+        return 1
+    loggingLevel = logging.INFO
+    if options.silent:
+        loggingLevel = logging.ERROR
+    if options.verbose:
+        loggingLevel = logging.DEBUG
+    logging.basicConfig(level = loggingLevel)
+    logging.debug("Set verbose console output.")
+
+    # Check the run number
+    if not len(args):
+        logging.error("No run number was provided. Exiting.")
+        return 1
+    runNumber = args[0]
+    try:
+        runNumber = int(runNumber)
+    except:
+        logging.error("Invalid wrong number. Exiting.")
+        return 1
+
+    return diagnoseRun(str(runNumber), options.fixIncompleteLumi)
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/src/python/T0/WMBS/Oracle/RunLumiCloseout/CheckClosedLumis.py
+++ b/src/python/T0/WMBS/Oracle/RunLumiCloseout/CheckClosedLumis.py
@@ -1,0 +1,42 @@
+"""
+_CheckClosedLumis_
+
+Oracle implementation of RunLumiCloseout.CheckClosedLumis
+
+Created on Nov 29, 2012
+
+@author: dballest
+"""
+
+from WMCore.Database.DBFormatter import DBFormatter
+
+class CheckClosedLumis(DBFormatter):
+    """
+    _CheckClosedLumis_
+
+    Cross-checks the number of closed lumis for
+    every stream in a run with the lumicount
+    in the run table
+    """
+
+    sql = """SELECT stream_id,
+                    COUNT(*) AS closed_lumi_count,
+                    MAX(lumi_id) AS max_lumi,
+                    (SELECT lumicount
+                     FROM run
+                     WHERE run_id = :RUN_ID) AS expected_lumi_count
+             FROM lumi_section_closed
+             WHERE run_id = :RUN_ID
+             GROUP BY stream_id
+          """
+
+    def execute(self, run, conn = None, transaction = False):
+        """
+        _execute_
+
+        Basic execute query plus formatDict
+        """
+        result = self.dbi.processData(self.sql, {'RUN_ID': run}, conn = conn,
+                                      transaction = transaction)
+
+        return self.formatDict(result)

--- a/src/python/T0/WMBS/Oracle/RunLumiCloseout/CheckEndOfRunRecords.py
+++ b/src/python/T0/WMBS/Oracle/RunLumiCloseout/CheckEndOfRunRecords.py
@@ -1,0 +1,55 @@
+"""
+_CheckEndOfRunRecords_
+
+Oracle implementation of WMBS.RunLumiCloseout.CheckEndOfRunRecords
+
+Created on Nov 28, 2012
+
+@author: dballest
+"""
+
+from WMCore.Database.DBFormatter import DBFormatter
+
+class CheckEndOfRunRecords(DBFormatter):
+    """
+    _CheckEndOfRunRecords_
+
+    Checks the CMS StorageManager database for
+    End of Run records from the different instances
+    """
+
+    sql = """
+          SELECT smdb.instance, smdb.status, smdb.n_instances
+                 FROM CMS_STOMGR.runs smdb
+                 WHERE smdb.runnumber = :RUN_ID
+          """
+
+    def execute(self, run, conn = None, transaction = False):
+        """
+        _execute_
+
+        Execute the query, a dictionary with the following format
+        {totalInstances : <int>,
+         instancesWithEoR : [<str>, <str>],
+         instancesWithoutEoR : [<str>, <str>]
+        }
+        """
+
+        result = self.dbi.processData(self.sql, {'RUN_ID' : run}, conn = conn,
+                                       transaction = transaction)
+
+        resultDict = self.formatDict(result)
+
+        formattedResult = {"totalInstances" : 0,
+                           "instancesWithEoR" : [],
+                           "instancesWithoutEoR" : []
+                           }
+
+        for entry in resultDict:
+            formattedResult["totalInstances"] = max(entry["n_instances"], formattedResult["totalInstances"])
+            if entry["status"] != 0:
+                formattedResult["instancesWithoutEoR"].append(entry["instance"])
+            else:
+                formattedResult["instancesWithEoR"].append(entry["instance"])
+
+        return formattedResult

--- a/src/python/T0/WMBS/Oracle/RunLumiCloseout/DeleteStreamers.py
+++ b/src/python/T0/WMBS/Oracle/RunLumiCloseout/DeleteStreamers.py
@@ -1,0 +1,40 @@
+'''
+_DeleteStreamers_
+
+Oracle implementation of RunLumiCloseOut.DeleteStreamers
+
+Created on Nov 30, 2012
+
+@author: dballest
+'''
+
+from WMCore.Database.DBFormatter import DBFormatter
+
+class DeleteStreamers(DBFormatter):
+    """
+    _DeleteStreamers_
+
+    Delete the streamers with the given IDs from
+    the streamer table
+    """
+
+    sql = """DELETE FROM streamer
+             WHERE id = :FILEID
+          """
+
+    def execute(self, fileList, conn = None, transaction = False):
+        """
+        _execute_
+
+        Executes the deletion
+        """
+        if not fileList:
+            return
+        binds = []
+        for fileId in fileList:
+            binds.append({"FILEID" : fileId})
+
+        self.dbi.processData(self.sql, binds = binds, conn = conn,
+                             transaction = transaction)
+
+        return

--- a/src/python/T0/WMBS/Oracle/RunLumiCloseout/ForceCloseLumi.py
+++ b/src/python/T0/WMBS/Oracle/RunLumiCloseout/ForceCloseLumi.py
@@ -1,0 +1,62 @@
+"""
+_ForceCloseLumi_
+
+Oracle implementation of LumiRunCloseout.ForceCloseLumi
+
+Created on Nov 30, 2012
+
+@author: dballest
+"""
+
+import time
+
+from WMCore.Database.DBFormatter import DBFormatter
+
+class ForceCloseLumi(DBFormatter):
+    """
+    _ForceCloseLumi_
+
+    Inserts a closing time for the given run,stream and lumi. If lumi
+    doesn't exist then it's inserted into lumi_section_closed.
+    Sets the filecount to 0 on those lumis.
+    """
+
+    sql = """MERGE INTO lumi_section_closed
+             USING DUAL ON (
+                            run_id = :RUN_ID AND
+                            lumi_id = :LUMI_ID AND
+                            stream_id = :STREAM_ID
+                           )
+             WHEN MATCHED THEN
+                 UPDATE SET filecount = 0,
+                            close_time = :CURRENT_TIME
+             WHEN NOT MATCHED THEN
+                 INSERT (run_id, lumi_id, stream_id, filecount, insert_time, close_time)
+                 VALUES (:RUN_ID, :LUMI_ID, :STREAM_ID, 0, :CURRENT_TIME, :CURRENT_TIME)
+          """
+
+    def execute(self, run, streams, conn = None, transaction = False):
+        """
+        _execute_
+
+        Executes the query, passes the current time
+        """
+        if not streams:
+            return
+
+        currentTime = int(time.time())
+
+        binds = []
+        for stream in streams:
+            for lumi in streams[stream]:
+                binds.append({"RUN_ID" : run,
+                              "STREAM_ID" : stream,
+                              "LUMI_ID" : lumi,
+                              "CURRENT_TIME" : currentTime})
+
+        self.dbi.processData(self.sql, binds = binds,
+                             conn = conn,
+                             transaction = transaction)
+
+        return
+

--- a/src/python/T0/WMBS/Oracle/RunLumiCloseout/GetClosedLumisForStream.py
+++ b/src/python/T0/WMBS/Oracle/RunLumiCloseout/GetClosedLumisForStream.py
@@ -1,0 +1,61 @@
+"""
+_GetClosedLumisForStream_
+
+Oracle implementation of RunLumiCloseout.GetClosedLumisForStream
+
+Created on Nov 29, 2012
+
+@author: dballest
+"""
+
+from WMCore.Database.DBFormatter import DBFormatter
+
+class GetClosedLumisForStream(DBFormatter):
+    """
+    _GetClosedLumisForStream_
+
+    Gets the list of closed lumis for
+    a given stream and run
+    """
+
+    sql = """SELECT stream_id,
+                    lumi_section_closed.lumi_id,
+                    (SELECT name
+                     FROM stream
+                     WHERE id = :STREAM_ID) AS name
+             FROM lumi_section_closed
+             WHERE lumi_section_closed.run_id = :RUN_ID AND
+                   lumi_section_closed.stream_id = :STREAM_ID
+          """
+
+
+    def execute(self, run, streams, conn = None, transaction = False):
+        """
+        _execute_
+
+        Returns a dictionary with the following format:
+
+        {<streamId> : {name: <str>,
+                       closedLumis: [<int>, <int>]
+                      }
+        }
+        """
+
+        if not streams:
+            return {}
+        binds = []
+        for stream in streams:
+            binds.append({'RUN_ID' : run,
+                          'STREAM_ID' : stream})
+        result = self.dbi.processData(self.sql, binds = binds,
+                                      conn = conn, transaction = transaction)
+
+        formattedResult = self.formatDict(result)
+        streamInfo = {}
+        for entry in formattedResult:
+            if entry["stream_id"] not in streamInfo:
+                streamInfo[entry["stream_id"]] = {"name" : entry["name"],
+                                                  "closedLumis" : []}
+            streamInfo[entry["stream_id"]]["closedLumis"].append(int(entry["lumi_id"]))
+
+        return streamInfo

--- a/src/python/T0/WMBS/Oracle/RunLumiCloseout/GetFileCountOnOpenLumis.py
+++ b/src/python/T0/WMBS/Oracle/RunLumiCloseout/GetFileCountOnOpenLumis.py
@@ -1,0 +1,61 @@
+"""
+_GetFileCountOnOpenLumis_
+
+Oracle implementation of RunLumiCloseout.GetFileCountOnOpenLumis
+
+Created on Nov 29, 2012
+
+@author: dballest
+"""
+
+from WMCore.Database.DBFormatter import DBFormatter
+
+class GetFileCountOnOpenLumis(DBFormatter):
+    """
+    GetFileCountOnOpenLumis_
+
+    Get filecounts from lumis in the run which
+    are not closed yet in lumi_section_closed
+    """
+
+    sql = """SELECT lumi_section_closed.lumi_id,
+                    lumi_section_closed.stream_id,
+                    stream.name,
+                    lumi_section_closed.filecount AS expected_filecount,
+                    COUNT(streamer.id) AS filecount
+             FROM lumi_section_closed
+             INNER JOIN stream ON
+                 stream.id = lumi_section_closed.stream_id
+             LEFT OUTER JOIN streamer ON
+                 streamer.lumi_id = lumi_section_closed.lumi_id AND
+                 streamer.stream_id = lumi_section_closed.stream_id AND
+                 streamer.run_id = :RUN_ID
+             WHERE checkForZeroState(lumi_section_closed.close_time) = 0 AND
+                   lumi_section_closed.run_id = :RUN_ID
+             GROUP BY lumi_section_closed.lumi_id,
+                      lumi_section_closed.stream_id,
+                      stream.name,
+                      lumi_section_closed.filecount
+             ORDER BY lumi_section_closed.lumi_id,
+                      lumi_section_closed.stream_id,
+                      stream.name,
+                      lumi_section_closed.filecount
+          """
+
+    def execute(self, run, conn = None, transaction = False):
+        """
+        _execute_
+
+        Get open lumis for a run and sort it by stream.
+        """
+        result = self.dbi.processData(self.sql, {"RUN_ID" : run}, conn = conn,
+                                      transaction = transaction)
+
+        formattedResult = self.formatDict(result)
+        streamInfo = {}
+        for entry in formattedResult:
+            if (entry["stream_id"], entry["name"]) not in streamInfo:
+                streamInfo[(entry["stream_id"], entry["name"])] = {}
+            streamInfo[(entry["stream_id"], entry["name"])][int(entry["lumi_id"])] = (entry["expected_filecount"], entry["filecount"])
+
+        return streamInfo

--- a/src/python/T0/WMBS/Oracle/RunLumiCloseout/GetFilesForStreamLumi.py
+++ b/src/python/T0/WMBS/Oracle/RunLumiCloseout/GetFilesForStreamLumi.py
@@ -1,0 +1,61 @@
+"""
+_GetFilesForStreamLumi_
+
+Oracle implementation of RunLumiCloseout.GetFilesForStreamLumi
+
+Created on Nov 30, 2012
+
+@author: dballest
+"""
+
+from WMCore.Database.DBFormatter import DBFormatter
+
+class GetFilesForStreamLumi(DBFormatter):
+    """
+    _GetFilesForStreamLumi_
+
+    Get the dictionary with the information
+    for the files associated to the
+    given run, stream and lumi.
+    The dictionary keys are the files IDs (WMBS and STREAMER tables)
+    and the values  are the LFNs.
+    """
+
+
+    sql = """SELECT wmbs_file_details.lfn,
+                    streamer.id
+             FROM streamer
+             INNER JOIN wmbs_file_details ON
+                 wmbs_file_details.id = streamer.id
+             WHERE streamer.run_id = :RUN_ID AND
+                   streamer.lumi_id = :LUMI_ID AND
+                   streamer.stream_id = :STREAM_ID
+          """
+
+    def execute(self, run, streams, conn = None,
+                transaction = False):
+        """
+        _execute_
+
+        Executes the query and formats the output
+        """
+
+        binds = []
+        for stream in streams:
+            for lumi in streams[stream]:
+                binds.append({"RUN_ID" : run,
+                              "STREAM_ID" : stream,
+                              "LUMI_ID" : lumi})
+
+        result = self.dbi.processData(self.sql, binds = binds,
+                                      conn = conn,
+                                      transaction = transaction)
+
+        formattedResult = self.formatDict(result)
+
+        fileInfo = {}
+
+        for entry in formattedResult:
+            fileInfo[entry["id"]] = entry["lfn"]
+
+        return fileInfo


### PR DESCRIPTION
Implement tool a la fixRunStuckInCloseout to check
runs which have the top fileset open for
express and repack, it looks into inconsistencies
in the streamer and lumi sections. It can also
wipe information for incomplete lumis.

Fixes #4013

Please review, I have tested all completely but the doChange code path after Line #188. @hufnagel could you please look at that path in particular, we have runs in the WMAT0 to test it a second look before trying it would be best.
