### PR TITLE
fix some problems with handling of empty lumis in repackmerge, fixes #4014

### DIFF
--- a/src/python/T0/JobSplitting/Repack.py
+++ b/src/python/T0/JobSplitting/Repack.py
@@ -66,22 +66,23 @@ class Repack(JobFactory):
         if lumiList[0] > 1:
             maxLumiWithJob = maxLumiWithJobDAO.execute(self.subscription["id"])
 
-        # do we have lumi holes ?
-        detectEmptyLumis = False
-        if lumiList[0] > maxLumiWithJob + 1:
-            detectEmptyLumis = True
-        elif lumiList[0] == maxLumiWithJob + 1:
-            for lumi in range(lumiList[0], lumiList[-1] + 1):
-                if lumi not in lumiList:
-                    detectEmptyLumis = True
-        else:
+        # consistency check
+        if lumiList[0] <= maxLumiWithJob:
             logging.error("ERROR: finding data that can't be there, bailing out...")
             return
+
+        # do we have lumi holes ?
+        detectEmptyLumis = False
+        lumi = maxLumiWithJob + 1
+        while lumi in lumiList:
+            lumi += 1
+        if lumi < lumiList[-1]:
+            detectEmptyLumis = True
 
         # empty and closed lumis
         emptyLumis = []
         if detectEmptyLumis:
-            emptyLumis = getClosedEmptyLumisDAO.execute(self.subscription["id"])
+            emptyLumis = getClosedEmptyLumisDAO.execute(self.subscription["id"], maxLumiWithJob)
 
         # figure out lumi range to create jobs for
         streamersByLumi = {}

--- a/src/python/T0/WMBS/Oracle/JobSplitting/GetClosedEmptyLumis.py
+++ b/src/python/T0/WMBS/Oracle/JobSplitting/GetClosedEmptyLumis.py
@@ -3,9 +3,9 @@ _GetClosedEmptyLumis_
 
 Oracle implementation of GetClosedEmptyLumis
 
-For a given subscription return the closed, but
-empty lumis in it's input data. Use a special
-association table filled by Tier0Feeder.
+For a given repack subscription return the
+closed, but empty lumis in it's input data. Only
+look at lumis above a provided lumi threshold.
 """
 
 from WMCore.Database.DBFormatter import DBFormatter
@@ -17,15 +17,17 @@ class GetClosedEmptyLumis(DBFormatter):
              INNER JOIN lumi_section_closed ON
                lumi_section_closed.run_id = run_stream_fileset_assoc.run_id AND
                lumi_section_closed.stream_id = run_stream_fileset_assoc.stream_id AND
+               lumi_section_closed.lumi_id > :firstlumi AND
                lumi_section_closed.close_time > 0 AND
                lumi_section_closed.filecount = 0
              WHERE run_stream_fileset_assoc.fileset =
                (SELECT fileset FROM wmbs_subscription WHERE id = :subscription)
              """
 
-    def execute(self, subscription, conn = None, transaction = False):
+    def execute(self, subscription, firstlumi, conn = None, transaction = False):
 
-        results = self.dbi.processData(self.sql, { 'subscription' : subscription },
+        results = self.dbi.processData(self.sql, { 'subscription' : subscription,
+                                                   'firstlumi' : firstlumi },
                                        conn = conn, transaction = transaction)[0].fetchall()
 
         lumiList = []

--- a/src/python/T0/WMBS/Oracle/JobSplitting/GetClosedEmptyLumisFromChildSub.py
+++ b/src/python/T0/WMBS/Oracle/JobSplitting/GetClosedEmptyLumisFromChildSub.py
@@ -3,10 +3,9 @@ _GetClosedEmptyLumisFromChildSub_
 
 Oracle implementation of GetClosedEmptyLumis
 
-For a given child subscription return the closed,
-but empty lumis in the input data for it's patent
-subscription. Use a special association table
-filled by Tier0Feeder.
+For a given repack merge subscription return the
+closed, but empty lumis in it's input data. Only
+look at lumis above a provided lumi threshold.
 """
 
 from WMCore.Database.DBFormatter import DBFormatter
@@ -19,6 +18,7 @@ class GetClosedEmptyLumisFromChildSub(DBFormatter):
                lumi_section_closed.run_id = run_stream_fileset_assoc.run_id AND
                lumi_section_closed.stream_id = run_stream_fileset_assoc.stream_id AND
                lumi_section_closed.close_time > 0 AND
+               lumi_section_closed.lumi_id > :firstlumi AND
                lumi_section_closed.filecount = 0
              INNER JOIN wmbs_subscription parent_subscription ON
                parent_subscription.fileset = run_stream_fileset_assoc.fileset
@@ -29,9 +29,10 @@ class GetClosedEmptyLumisFromChildSub(DBFormatter):
              WHERE child_subscription.id = :subscription
              """
 
-    def execute(self, subscription, conn = None, transaction = False):
+    def execute(self, subscription, firstlumi, conn = None, transaction = False):
 
-        results = self.dbi.processData(self.sql, { 'subscription' : subscription },
+        results = self.dbi.processData(self.sql, { 'subscription' : subscription,
+                                                   'firstlumi' : firstlumi },
                                        conn = conn, transaction = transaction)[0].fetchall()
 
         lumiList = []

--- a/src/python/T0/WMBS/Oracle/JobSplitting/GetCompletedLumisFromChildSub.py
+++ b/src/python/T0/WMBS/Oracle/JobSplitting/GetCompletedLumisFromChildSub.py
@@ -1,0 +1,56 @@
+"""
+_GetCompletedLumisFromChildSub_
+
+Oracle implementation of GetCompletedLumis
+
+For a given repack merge subscription return the
+completely repacked lumis above a provided lumi
+threshold.
+"""
+
+from WMCore.Database.DBFormatter import DBFormatter
+
+class GetCompletedLumisFromChildSub(DBFormatter):
+
+    sql = """SELECT streamer.lumi_id
+             FROM run_stream_fileset_assoc
+             INNER JOIN lumi_section_closed ON
+               lumi_section_closed.run_id = run_stream_fileset_assoc.run_id AND
+               lumi_section_closed.stream_id = run_stream_fileset_assoc.stream_id AND
+               lumi_section_closed.lumi_id > :firstlumi AND
+               lumi_section_closed.close_time > 0 AND
+               lumi_section_closed.filecount > 0
+             INNER JOIN wmbs_subscription parent_subscription ON
+               parent_subscription.fileset = run_stream_fileset_assoc.fileset
+             INNER JOIN wmbs_workflow_output ON
+               wmbs_workflow_output.workflow_id = parent_subscription.workflow
+             INNER JOIN wmbs_subscription child_subscription ON
+               child_subscription.fileset = wmbs_workflow_output.output_fileset AND
+               child_subscription.id = :subscription
+             INNER JOIN streamer ON
+               streamer.run_id = run_stream_fileset_assoc.run_id AND
+               streamer.stream_id = run_stream_fileset_assoc.stream_id AND
+               streamer.lumi_id = lumi_section_closed.lumi_id
+             LEFT OUTER JOIN wmbs_sub_files_available ON
+               wmbs_sub_files_available.fileid = streamer.id AND
+               wmbs_sub_files_available.subscription = parent_subscription.id
+             LEFT OUTER JOIN wmbs_sub_files_acquired ON
+               wmbs_sub_files_acquired.fileid = streamer.id AND
+               wmbs_sub_files_acquired.subscription = parent_subscription.id
+             GROUP BY streamer.lumi_id
+             HAVING COUNT(*) = SUM(streamer.used)
+             AND COUNT(wmbs_sub_files_available.fileid) = 0
+             AND COUNT(wmbs_sub_files_acquired.fileid) = 0
+             """
+
+    def execute(self, subscription, firstlumi, conn = None, transaction = False):
+
+        results = self.dbi.processData(self.sql, { 'subscription' : subscription,
+                                                   'firstlumi' : firstlumi},
+                                       conn = conn, transaction = transaction)[0].fetchall()
+
+        lumiList = []
+        for result in results:
+            lumiList.append(result[0])
+
+        return lumiList


### PR DESCRIPTION
The repackmerge job splitting algorithm enforces lumi order and
only allows holes in the lumi order when there is no streamer
files for that lumi. This is not the only coniditon for which
we don't get RAW data though, it can also be that for that lumi
no events were selected for the dataset in question. Add a
check for that as well. Add a unittest to test this case.

Also simplify the lumi hole detection algorithm a bit and
apply the same simplification to the repack job splitting.
