### PR TITLE
Add new script to alarm on late workflows

### DIFF
--- a/bin/cmst0_late_workflows.py
+++ b/bin/cmst0_late_workflows.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python
+"""
+_cmst0-late-workflows_
+
+Check for workflows that are taking longer than expected,
+configuration is provided in an external configuration file.
+
+Availability metrics are defined as:
+
+0 - At least one Express or Repack workflow is late
+50 - At least one PromptReco workflow is late
+100 - No workflow is late
+"""
+
+import traceback
+import time
+import re
+import os
+import sys
+
+from WMCore.Services.WMStats.WMStatsReader import WMStatsReader
+from WMCore.Configuration import loadConfigurationFile
+
+promptRecoRegexp = re.compile(r'^PromptReco_.*$')
+repackRegexp     = re.compile(r'^Repack_.*$')
+expressRegexp    = re.compile(r'^Express_.*$')
+
+regexpMapping = {'Express' : expressRegexp,
+                 'Repack'  : repackRegexp,
+                 'PromptReco' : promptRecoRegexp}
+
+def loadLimitsFromConfig(config):
+    """
+    _loadLimitsFromConfig_
+
+    Loads the time limits for the different workflows and states
+    from the configuration file. Formats it as a dictionary.
+    """
+    limits = {}
+    for workflowType in config.cmst0_late_workflows.WorkflowTimeouts.listSections_():
+        limits[workflowType] = {}
+        workflowTypeInfo = getattr(config.cmst0_late_workflows.WorkflowTimeouts, workflowType)
+        for state in getattr(workflowTypeInfo, "states"):
+            limits[workflowType][state] = getattr(workflowTypeInfo, state)
+    return limits
+
+def processWorkflows(wmStats, workflowLimits):
+    """
+    _processWorkflows_
+
+    The core logic of the tool, it gets a WMStatsReader object
+    and checks all the available workflows in it. It uses the
+    workflowLimits to check which workflows have remained in a state
+    longer than expected, finally it returns a dictionary with the problematic
+    workflows, their states and the time spent in them.
+    """
+
+    workflowStates = wmStats.workflowStatus(stale = False)
+    workflowStates = dict(map(lambda (key, value): (key.replace(' ', ''), value), workflowStates.items()))
+    problematicWorkflows = []
+    currentTime = int(time.time())
+    for workflowType in workflowLimits:
+        for state in workflowLimits[workflowType]:
+            if state in workflowStates:
+                workflows = filter(regexpMapping[workflowType].match, workflowStates[state])
+                for workflow in workflows:
+                    stateTime = workflowStates[state][workflow]
+                    if currentTime - stateTime > 3600 * float(workflowLimits[workflowType][state]):
+                        problematicWorkflows.append({'workflow' : workflow,
+                                                     'elapsedTime' : currentTime - stateTime,
+                                                     'state' : state})
+
+    return problematicWorkflows
+
+def calculateAvailability(data, runBlacklist):
+    """
+    _calculateAvailability_
+
+    Calculates the availability according
+    to the metrics defined in the module
+    documentation. Receives a list
+    of dictionaries with workflow information.
+    Take into account run blacklists.
+    """
+    availability = 100
+    runRegexp = re.compile(r'^.*_Run([0-9]{6})_.*$')
+    for entry in data:
+        if runRegexp.match(entry['workflow']).groups()[0] in runBlacklist:
+            continue
+        if promptRecoRegexp.match(entry['workflow']):
+            availability = 50
+        elif repackRegexp.match(entry['workflow']):
+            availability = 0
+        elif expressRegexp.match(entry['workflow']):
+            availability = 0
+        if not availability:
+            # Already 0, break out
+            break
+
+    return availability
+
+def buildSLSXML(outputFilePath, data, runBlacklist, interventionInfo):
+    """
+    _buildSLSXML_
+
+    Builds an XML file for SLS updates based
+    on the information in data.
+    """
+    textLines = ""
+    for entry in sorted(data, key = lambda x : x['elapsedTime'], reverse = True):
+        textLines += "\t\t%s has been in %s for %4.1f hours\n" % (entry['workflow'],
+                                                                  entry['state'],
+                                                                  entry['elapsedTime'] / 3600.0)
+    textLines = textLines.rstrip('\n')
+
+    availability = calculateAvailability(data, runBlacklist)
+    timezone = str(int(-time.timezone / 3600)).zfill(2)
+    timestamp = time.strftime("%Y-%m-%dT%H:%M:%S+")
+    timestamp += "%s:00" % timezone
+
+    intervention = ""
+    if interventionInfo:
+        inteventionTemplate = """        <interventions>
+            <intervention start="{startTime}" length="PT{duration}H">
+                {message}
+            </intervention>
+        </interventions>"""
+
+        intervention = inteventionTemplate.format(**interventionInfo)
+
+    template = """<?xml version="1.0" encoding="utf-8"?>
+    <serviceupdate xmlns="http://sls.cern.ch/SLS/XML/update">
+        <id>CMST0-late-workflows</id>
+        <availability>{availability}</availability>
+        <timestamp>{timestamp}</timestamp>
+        <data>
+{data}
+        </data>
+{intervention}
+    </serviceupdate>\n"""
+
+    xml = template.format(data = textLines, availability = availability,
+                          timestamp = timestamp, intervention = intervention)
+
+    try:
+        outputFile = open(outputFilePath, 'w')
+        outputFile.write(xml)
+    except:
+        print "Couldn't write the XML file"
+        traceback.print_exc()
+    finally:
+        outputFile.close()
+
+    return
+
+def main():
+
+    agentConfig = loadConfigurationFile(os.environ["WMAGENT_CONFIG"])
+    localWMStatsURL = agentConfig.AnalyticsDataCollector.localWMStatsURL
+    wmstatsReader = WMStatsReader(couchURL = localWMStatsURL)
+
+    alarmConfigPath = os.path.join(os.environ.get("SLS_CONFIG") or
+                                   os.environ["T0_ROOT"], 'etc/operations/SLSAlarmsConfig.py')
+    alarmConfig = loadConfigurationFile(alarmConfigPath)
+
+    workflowLimits = loadLimitsFromConfig(alarmConfig)
+    data = processWorkflows(wmstatsReader, workflowLimits)
+
+    interventionInfo = {}
+    if hasattr(alarmConfig.cmst0_late_workflows, "Intervention"):
+        startTime = alarmConfig.cmst0_late_workflows.Intervention.startTime
+        duration = alarmConfig.cmst0_late_workflows.Intervention.duration
+        message = alarmConfig.cmst0_late_workflows.Intervention.message
+
+        # Check that the intervention is present or in the future
+        structStartTime = time.strptime(startTime, "%Y-%m-%dT%H:%M:%S")
+        startTimeSeconds = time.mktime(structStartTime)
+        if (startTimeSeconds + duration * 3600) >= time.time():
+            interventionInfo = {'startTime' : startTime,
+                                'duration' : duration,
+                                'message' : message}
+            
+    runBlacklist = getattr(alarmConfig.cmst0_late_workflows, "runBlacklist", [])
+
+    xmlFile = getattr(alarmConfig.cmst0_late_workflows, "xmlFile", None) or "cmst0_late_workflows.xml"
+    xmlPath = os.path.join(alarmConfig.Settings.xmlDir, xmlFile)
+    buildSLSXML(xmlPath, data, runBlacklist, interventionInfo)
+
+    return
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/etc/operations/SLSAlarmsConfig.py
+++ b/etc/operations/SLSAlarmsConfig.py
@@ -1,0 +1,50 @@
+from WMCore.Configuration import Configuration
+
+config = Configuration()
+
+# General configuration
+config.section_("Settings")
+config.Settings.xmlDir = "/afs/cern.ch/user/c/cmsprod/www/sls"
+
+# Late workflows alarm
+config.section_("cmst0_late_workflows")
+config.cmst0_late_workflows.section_("WorkflowTimeouts")
+config.cmst0_late_workflows.WorkflowTimeouts.section_("Express")
+config.cmst0_late_workflows.WorkflowTimeouts.Express.states = ["Closed", "Merge", "Harvesting", "ProcessingDone"]
+config.cmst0_late_workflows.WorkflowTimeouts.Express.Closed = 3
+config.cmst0_late_workflows.WorkflowTimeouts.Express.Merge = 2
+config.cmst0_late_workflows.WorkflowTimeouts.Express.Harvesting = 1
+config.cmst0_late_workflows.WorkflowTimeouts.Express.ProcessingDone = 2
+config.cmst0_late_workflows.WorkflowTimeouts.section_("Repack")
+config.cmst0_late_workflows.WorkflowTimeouts.Repack.states = ["Closed", "Merge", "ProcessingDone"]
+config.cmst0_late_workflows.WorkflowTimeouts.Repack.Closed = 4
+config.cmst0_late_workflows.WorkflowTimeouts.Repack.Merge = 4
+config.cmst0_late_workflows.WorkflowTimeouts.Repack.ProcessingDone = 52
+config.cmst0_late_workflows.WorkflowTimeouts.section_("PromptReco")
+config.cmst0_late_workflows.WorkflowTimeouts.PromptReco.states = ["Closed", "AlcaSkim",
+                                                                "Merge", "Harvesting",
+                                                                "ProcessingDone"]
+config.cmst0_late_workflows.WorkflowTimeouts.PromptReco.Closed = 14
+config.cmst0_late_workflows.WorkflowTimeouts.PromptReco.AlcaSkim = 4
+config.cmst0_late_workflows.WorkflowTimeouts.PromptReco.Merge = 4
+config.cmst0_late_workflows.WorkflowTimeouts.PromptReco.Harvesting = 1
+config.cmst0_late_workflows.WorkflowTimeouts.PromptReco.ProcessingDone = 1
+config.cmst0_late_workflows.runBlacklist = ["000000"]
+config.cmst0_late_workflows.xmlFile = "cmst0_late_workflows.xml"
+config.cmst0_late_workflows.section_("Intervention")
+config.cmst0_late_workflows.Intervention.startTime = "2012-12-06T23:00:00"
+config.cmst0_late_workflows.Intervention.duration = 2
+config.cmst0_late_workflows.Intervention.message = "Test intervention"
+
+# Backlog alarm
+config.section_("cmst0_backlog_wma")
+config.cmst0_backlog_wma.xmlFile = "cmst0-backlog-wma.xml"
+config.cmst0_backlog_wma.express = 2000
+config.cmst0_backlog_wma.repack = 50
+config.cmst0_backlog_wma.promptreco = 15000
+config.cmst0_backlog_wma.section_("Intervention")
+config.cmst0_backlog_wma.Intervention.startTime = "2012-12-05T23:00:00"
+config.cmst0_backlog_wma.Intervention.duration = 2
+config.cmst0_backlog_wma.Intervention.message = "Test intervention"
+
+


### PR DESCRIPTION
Implement it under bin/ it uses an external
JSON file to get the limits and support run blacklists
writes the file to: /afs/cern.ch/user/c/cmsprod/www/sls/cmst0-late-workflows.xml
Service name in the XML is CMST0-late-workflows

Also move the backlog alarm to bin/ and add an example
of the JSON file to etc/operations.

Here's there is something to dicuss. I propose the following file organization:

etc/operations -> general operations data such as JSON files to configure the alarms, only basic functional examples. We wouldn't pull request any changes there unless there is a change in the format and therefore in the scripts as wel..
bin/ -> Executable scripts such as these two and the one in #4016

The alarms shouldn't have run blacklists or information we would want to change often in the code but rather in external JSON (straightforward format) files. Note that this first version still uses some hardcoded run blacklists.

@hufnagel, @samircury comments?
