### PR TITLE
fix a race condition in some insert queries

### DIFF
--- a/src/python/T0/WMBS/Oracle/RunConfig/InsertCMSSWVersion.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/InsertCMSSWVersion.py
@@ -11,13 +11,25 @@ class InsertCMSSWVersion(DBFormatter):
 
     def execute(self, binds, conn = None, transaction = False):
 
-        sql = """INSERT INTO cmssw_version
-                 (ID, NAME)
-                 SELECT cmssw_version_SEQ.nextval, :VERSION
-                 FROM DUAL
-                 WHERE NOT EXISTS (
-                   SELECT * FROM cmssw_version WHERE NAME = :VERSION
-                 )"""
+        sql = """DECLARE
+                   cnt NUMBER(1);
+                 BEGIN
+                   SELECT COUNT(*)
+                   INTO cnt
+                   FROM cmssw_version
+                   WHERE name = :VERSION
+                   ;
+                   IF (cnt = 0)
+                   THEN
+                     INSERT INTO cmssw_version
+                     (ID, NAME)
+                     VALUES(cmssw_version_SEQ.nextval, :VERSION)
+                     ;
+                   END IF;
+                 EXCEPTION
+                   WHEN DUP_VAL_ON_INDEX THEN NULL;
+                 END;
+                 """
 
         self.dbi.processData(sql, binds, conn = conn,
                              transaction = transaction)

--- a/src/python/T0/WMBS/Oracle/RunConfig/InsertLumiSection.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/InsertLumiSection.py
@@ -11,16 +11,26 @@ class InsertLumiSection(DBFormatter):
 
     def execute(self, binds, conn = None, transaction = False):
 
-        sql = """INSERT INTO lumi_section
-                 (RUN_ID, LUMI_ID)
-                 SELECT :RUN,
-                        :LUMI
-                 FROM DUAL
-                 WHERE NOT EXISTS (
-                   SELECT * FROM lumi_section
+        sql = """DECLARE
+                   cnt NUMBER(1);
+                 BEGIN
+                   SELECT COUNT(*)
+                   INTO cnt
+                   FROM lumi_section
                    WHERE run_id = :RUN
                    AND lumi_id = :LUMI
-                 )"""
+                   ;
+                   IF (cnt = 0)
+                   THEN
+                     INSERT INTO lumi_section
+                     (RUN_ID, LUMI_ID)
+                     VALUES(:RUN, :LUMI)
+                     ;
+                   END IF;
+                 EXCEPTION
+                   WHEN DUP_VAL_ON_INDEX THEN NULL;
+                 END;
+                 """
 
         self.dbi.processData(sql, binds, conn = conn,
                              transaction = transaction)

--- a/src/python/T0/WMBS/Oracle/RunConfig/InsertStream.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/InsertStream.py
@@ -11,27 +11,25 @@ class InsertStream(DBFormatter):
 
     def execute(self, binds, conn = None, transaction = False):
 
-        sql = """INSERT INTO stream
-                 (ID, NAME)
-                 SELECT stream_SEQ.nextval, :STREAM
-                 FROM DUAL
-                 WHERE NOT EXISTS (
-                   SELECT * FROM stream WHERE NAME = :STREAM
-                 )"""
-
-##         sql = """BEGIN
-##                    INSERT INTO stream
-##                    (ID, NAME)
-##                    SELECT stream_SEQ.nextval, :STREAM
-##                    FROM DUAL
-##                    WHERE NOT EXISTS (
-##                      SELECT * FROM stream WHERE NAME = :STREAM
-##                    )
-##                  EXCEPTION
-##                    WHEN DUP_VAL_ON_INDEX THEN NULL;
-##                    WHEN OTHERS THEN RAISE;
-##                  END; 
-##                  """
+        sql = """DECLARE
+                   cnt NUMBER(1);
+                 BEGIN
+                   SELECT COUNT(*)
+                   INTO cnt
+                   FROM stream
+                   WHERE name = :STREAM
+                   ;
+                   IF (cnt = 0)
+                   THEN
+                     INSERT INTO stream
+                     (ID, NAME)
+                     VALUES(stream_SEQ.nextval, :STREAM)
+                     ;
+                   END IF;
+                 EXCEPTION
+                   WHEN DUP_VAL_ON_INDEX THEN NULL;
+                 END;
+                 """
 
         self.dbi.processData(sql, binds, conn = conn,
                              transaction = transaction)


### PR DESCRIPTION
Both the Tier0Injector from the P5 transfer system and the Tier0Feeder WMAT0 components insert into the cmssw_version, stream and lumi_section tables, potentially the same values at the same time. A simple 'INSERT ... WHERE NOT EXISTS...' statement has turned out not to be sufficient because both 'WHERE NOT EXISTS' clauses can run at the same time, both returning a 'NOT EXISTS' and then both inserts are attempted, with one for them throwing an Oracle exception. Wrap these calls into another layer of Oracle exception handling (catching and ignoring an insert on duplicate exception).
