### PR TITLE
Activate LogCollect for Tier-0 specs

### DIFF
--- a/src/python/T0/RunConfig/RunConfigAPI.py
+++ b/src/python/T0/RunConfig/RunConfigAPI.py
@@ -735,8 +735,6 @@ def releasePromptReco(tier0Config, specDirectory, dqmUploadProxy = None):
                 specArguments['OverrideCatalog'] = "trivialcatalog_file:/afs/cern.ch/cms/SITECONF/T0_CH_CERN/Tier0/override_catalog.xml?protocol=override"
                 specArguments['DQMUploadProxy'] = dqmUploadProxy
 
-                specArguments['DoLogCollect'] = False
-
                 wmSpec = promptrecoWorkload(workflowName, specArguments)
 
                 wmSpec.setPhEDExInjectionOverride(runInfo['bulk_data_loc'])

--- a/src/python/T0/WMSpec/StdSpecs/Express.py
+++ b/src/python/T0/WMSpec/StdSpecs/Express.py
@@ -113,6 +113,8 @@ class ExpressWorkloadFactory(StdBase):
 
         expressTask.setTaskType("Express")
 
+        self.addLogCollectTask(expressTask)
+
         for expressOutLabel, expressOutInfo in expressOutMods.items():
 
             if expressOutInfo['dataTier'] == "ALCARECO":
@@ -140,6 +142,7 @@ class ExpressWorkloadFactory(StdBase):
 
                 alcaSkimTask.setTaskType("Express")
 
+                self.addLogCollectTask(alcaSkimTask, taskName = "%s%sAlcaSkimLogCollect" % (expressTask.name(), expressOutLabel))
                 self.addCleanupTask(expressTask, expressOutLabel)
 
                 for alcaSkimOutLabel, alcaSkimOutInfo in alcaSkimOutMods.items():
@@ -150,7 +153,7 @@ class ExpressWorkloadFactory(StdBase):
                                                               condOutLabel = self.alcaHarvestOutLabel,
                                                               condUploadDir = self.alcaHarvestDir,
                                                               uploadProxy = self.dqmUploadProxy,
-                                                              doLogCollect = False)
+                                                              doLogCollect = True)
 
                         self.addConditionTask(harvestTask, self.alcaHarvestOutLabel)
 
@@ -162,7 +165,7 @@ class ExpressWorkloadFactory(StdBase):
 
                     self.addDQMHarvestTask(mergeTask, "Merged",
                                            uploadProxy = self.dqmUploadProxy,
-                                           doLogCollect = False)
+                                           doLogCollect = True)
 
         return workload
 
@@ -194,6 +197,8 @@ class ExpressWorkloadFactory(StdBase):
         mergeTaskLogArch.setStepType("LogArchive")
 
         mergeTask.setTaskLogBaseLFN(self.unmergedLFNBase)
+
+        self.addLogCollectTask(mergeTask, taskName = "%s%sMergeLogCollect" % (parentTask.name(), parentOutputModuleName))
 
         mergeTask.applyTemplates()
         mergeTask.setTaskPriority(self.priority + 5)

--- a/src/python/T0/WMSpec/StdSpecs/Repack.py
+++ b/src/python/T0/WMSpec/StdSpecs/Repack.py
@@ -96,6 +96,8 @@ class RepackWorkloadFactory(StdBase):
 
         repackTask.setTaskType("Repack")
 
+        self.addLogCollectTask(repackTask)
+
         for repackOutLabel, repackOutInfo in repackOutMods.items():
             self.addRepackMergeTask(repackTask, repackOutLabel)
 
@@ -119,6 +121,8 @@ class RepackWorkloadFactory(StdBase):
         mergeTaskLogArch.setStepType("LogArchive")
 
         mergeTask.setTaskLogBaseLFN(self.unmergedLFNBase)
+
+        self.addLogCollectTask(mergeTask, taskName = "%s%sMergeLogCollect" % (parentTask.name(), parentOutputModuleName))
 
         mergeTask.applyTemplates()
         mergeTask.setTaskPriority(self.priority + 5)


### PR DESCRIPTION
Enable LogCollect tasks for tier-0 specs, CERN stage-in fix (https://github.com/dmwm/WMCore/pull/4349)
is required for jobs to succeed.
