### PR TITLE
fix problem in lumi closing query

### DIFF
--- a/src/python/T0/WMBS/Oracle/RunLumiCloseout/FindClosedLumis.py
+++ b/src/python/T0/WMBS/Oracle/RunLumiCloseout/FindClosedLumis.py
@@ -26,28 +26,86 @@ class FindClosedLumis(DBFormatter):
 
     def execute(self, binds, conn = None, transaction = False):
 
-        sql = """SELECT b.runnumber, a.stream, a.lumisection, SUM(a.filecount)
-                 FROM CMS_STOMGR.runs b
-                 LEFT OUTER JOIN CMS_STOMGR.streams a ON
-                   a.runnumber = b.runnumber AND
-                   a.instance = b.instance AND
-                   a.stream = :STREAM AND
-                   a.lumisection > :LUMI
-                 WHERE b.runnumber = :RUN
-                 GROUP BY b.runnumber, a.stream, a.lumisection
-                 HAVING COUNT(b.runnumber) = MAX(b.n_instances)
-                 AND (
-                   COUNT(a.runnumber) = COUNT(b.runnumber) OR
-                   COUNT(a.runnumber) = SUM(CASE
-                                              WHEN b.status = 1 THEN 1000
-                                              WHEN b.n_lumisections < a.lumisection THEN 0
-                                              ELSE 1
-                                            END)
-                 )
+        # query has problems because of the way the join work
+        # can create two groups for the same run/stream/lumi
+        # first counting comparison doesn't work then
+##         sql = """SELECT b.runnumber, a.stream, a.lumisection, SUM(a.filecount)
+##                  FROM CMS_STOMGR.runs b
+##                  LEFT OUTER JOIN CMS_STOMGR.streams a ON
+##                    a.runnumber = b.runnumber AND
+##                    a.instance = b.instance AND
+##                    a.stream = :STREAM AND
+##                    a.lumisection > :LUMI
+##                  WHERE b.runnumber = :RUN
+##                  GROUP BY b.runnumber, a.stream, a.lumisection
+##                  HAVING COUNT(b.runnumber) = MAX(b.n_instances)
+##                  AND (
+##                    COUNT(a.runnumber) = COUNT(b.runnumber) OR
+##                    COUNT(a.runnumber) = SUM(CASE
+##                                               WHEN b.status = 1 THEN 1000
+##                                               WHEN b.n_lumisections < a.lumisection THEN 0
+##                                               ELSE 1
+##                                             END)
+##                  )
+##                  """
+
+        sql = """SELECT a.runnumber
+                 FROM CMS_STOMGR.runs a
+                 WHERE a.runnumber = :RUN
+                 GROUP BY a.runnumber
+                 HAVING COUNT(*) = MAX(a.n_instances)
+                 """
+
+        bindVars = []
+        for b in binds:
+            bindVars.append( { 'RUN' : b['RUN'] } )
+
+        results = self.dbi.processData(sql, bindVars, conn = conn,
+                                       transaction = transaction)[0].fetchall()
+
+        goodRuns = []
+        for result in results:
+            goodRuns.append(result[0])
+
+        bindVars = []
+        for b in binds:
+            if b['RUN'] in goodRuns:
+                bindVars.append(b)
+
+        if len(bindVars) == 0:
+            return []
+
+        sql = """SELECT a.runnumber, a.stream, a.lumisection, SUM(a.filecount)
+                 FROM CMS_STOMGR.streams a
+                 INNER JOIN CMS_STOMGR.runs b ON
+                   b.runnumber = a.runnumber AND
+                   b.instance = a.instance
+                 WHERE a.runnumber = :RUN
+                 AND a.stream = :STREAM
+                 AND a.lumisection > :LUMI
+                 GROUP BY a.runnumber, a.stream, a.lumisection
+                 HAVING ( COUNT(*) = ( SELECT COUNT(*)
+                                       FROM CMS_STOMGR.runs c
+                                       WHERE c.runnumber = a.runnumber ) AND
+                          COUNT(*) = ( SELECT MAX(c.n_instances)
+                                       FROM CMS_STOMGR.runs c
+                                       WHERE c.runnumber = a.runnumber ) )
+                 OR ( COUNT(*) = SUM(CASE
+                                       WHEN b.status = 1 THEN 1000
+                                       WHEN b.n_lumisections < a.lumisection THEN 0
+                                       ELSE 1
+                                     END) AND
+                      COUNT(*) = ( SELECT SUM(CASE
+                                                WHEN c.status = 1 THEN 1000
+                                                WHEN c.n_lumisections < a.lumisection THEN 0
+                                                ELSE 1
+                                              END)
+                                          FROM CMS_STOMGR.runs c
+                                          WHERE c.runnumber = a.runnumber ) )
                  """
 
         try:
-            results = self.dbi.processData(sql, binds, conn = conn,
+            results = self.dbi.processData(sql, bindVars, conn = conn,
                                            transaction = transaction)[0].fetchall()
         except DatabaseError, ex:
             logging.error("ERROR: DatabaseError exception when checking for closed run/stream/lumi")


### PR DESCRIPTION
I added a consistency to the discovery of closed lumis
in the SM database and tried to be clever by integrating
it into the discovery query. Turns out I was too clever
as the new query has a problem and doesn't find all
closed lumis. Revert to the previous discovery version
query and add the check as an extra query in the same DAO.
Maybe not as efficient, but it's safer and it's also the
same way this is implemented in the old Tier0.
