### PR TITLE
workaround for bad HLT menu

### DIFF
--- a/src/python/T0/RunConfig/RunConfigAPI.py
+++ b/src/python/T0/RunConfig/RunConfigAPI.py
@@ -323,6 +323,10 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
 
         for dataset, paths in datasetTriggers.items():
 
+            if dataset == "Unassigned path":
+                if run == 210178 and stream == "Express":
+                    continue
+
             datasetConfig = retrieveDatasetConfig(tier0Config, dataset)
 
             selectEvents = []


### PR DESCRIPTION
The HLT menu for run 210178 is broken for the Express stream,
having an unassigned path and corresponding "Unassigned path"
dataset. Ignore that dataset (just for this run and stream).
