### PR TITLE
enable periodic dqm harvesting for express

### DIFF
--- a/src/python/T0/WMSpec/StdSpecs/Express.py
+++ b/src/python/T0/WMSpec/StdSpecs/Express.py
@@ -165,6 +165,7 @@ class ExpressWorkloadFactory(StdBase):
 
                     self.addDQMHarvestTask(mergeTask, "Merged",
                                            uploadProxy = self.dqmUploadProxy,
+                                           periodic_harvest_interval = 20 * 60,
                                            doLogCollect = True)
 
         return workload


### PR DESCRIPTION
Enable periodic DQM harvesting for express. 20 minutes cycle hardcoded.
