### PR TITLE
remove setTaskPriority calls from Repack and Express Specs

### DIFF
--- a/src/python/T0/WMSpec/StdSpecs/Express.py
+++ b/src/python/T0/WMSpec/StdSpecs/Express.py
@@ -202,7 +202,6 @@ class ExpressWorkloadFactory(StdBase):
         self.addLogCollectTask(mergeTask, taskName = "%s%sMergeLogCollect" % (parentTask.name(), parentOutputModuleName))
 
         mergeTask.applyTemplates()
-        mergeTask.setTaskPriority(self.priority + 5)
 
         mergeTaskCmsswHelper = mergeTaskCmssw.getTypeHelper()
         mergeTaskStageHelper = mergeTaskStageOut.getTypeHelper()
@@ -273,7 +272,6 @@ class ExpressWorkloadFactory(StdBase):
 
         harvestTask.setTaskType("Harvesting")
         harvestTask.applyTemplates()
-        harvestTask.setTaskPriority(self.priority + 5)
 
         harvestTaskCmsswHelper = harvestTaskCmssw.getTypeHelper()
         harvestTaskCmsswHelper.cmsswSetup(self.frameworkVersion, softwareEnvironment = "",
@@ -344,7 +342,6 @@ class ExpressWorkloadFactory(StdBase):
         conditionTask.setInputReference(parentTaskCmssw, outputModule = parentOutputModuleName)
 
         conditionTask.applyTemplates()
-        conditionTask.setTaskPriority(self.priority + 5)
 
         conditionTask.setTaskType("Harvesting")
 

--- a/src/python/T0/WMSpec/StdSpecs/Repack.py
+++ b/src/python/T0/WMSpec/StdSpecs/Repack.py
@@ -125,7 +125,6 @@ class RepackWorkloadFactory(StdBase):
         self.addLogCollectTask(mergeTask, taskName = "%s%sMergeLogCollect" % (parentTask.name(), parentOutputModuleName))
 
         mergeTask.applyTemplates()
-        mergeTask.setTaskPriority(self.priority + 5)
 
         parentTaskCmssw = parentTask.getStep("cmsRun1")
         parentOutputModule = parentTaskCmssw.getOutputModule(parentOutputModuleName)


### PR DESCRIPTION
The setTaskPriority call is no longer supported in
Specs, remove them from the Repack and Express Specs.
