### PR TITLE
make express block closing delay configurable

### DIFF
--- a/src/python/T0/RunConfig/RunConfigAPI.py
+++ b/src/python/T0/RunConfig/RunConfigAPI.py
@@ -304,6 +304,7 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
                                    'MAX_SIZE' : streamConfig.Express.MaxInputSize,
                                    'MAX_FILES' : streamConfig.Express.MaxInputFiles,
                                    'MAX_LATENCY' : streamConfig.Express.MaxLatency,
+                                   'BLOCK_DELAY' : streamConfig.Express.BlockCloseDelay,
                                    'ALCA_SKIM' : alcaSkim,
                                    'DQM_SEQ' : dqmSeq }
 
@@ -442,6 +443,7 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
             specArguments['MaxInputSize'] = streamConfig.Express.MaxInputSize
             specArguments['MaxInputFiles'] = streamConfig.Express.MaxInputFiles
             specArguments['MaxLatency'] = streamConfig.Express.MaxLatency
+            specArguments['BlockCloseDelay'] = streamConfig.Express.BlockCloseDelay
             specArguments['AlcaSkims'] = streamConfig.Express.AlcaSkims
             specArguments['DqmSequences'] = streamConfig.Express.DqmSequences
             specArguments['UnmergedLFNBase'] = "%s/t0temp/express" % runInfo['lfn_prefix']

--- a/src/python/T0/RunConfig/Tier0Config.py
+++ b/src/python/T0/RunConfig/Tier0Config.py
@@ -103,6 +103,8 @@ Tier0Configuration - Global configuration object
 |             |     |--> MaxInputFiles - max input files for express merge job
 |             |     |
 |             |     |--> MaxLatency - max latency to trigger express merge job
+|             |     |
+|             |     |--> BlockCloseDelay - delay to close block in WMAgent
 |             |
 |             |
 |             |--> Register - Configuration section for register streams
@@ -566,6 +568,8 @@ def addExpressConfig(config, streamName, **options):
     streamConfig.Express.MaxInputSize = options.get("maxInputSize", 2 * 1024 * 1024 * 1024)
     streamConfig.Express.MaxInputFiles = options.get("maxInputFiles", 500)
     streamConfig.Express.MaxLatency = options.get("maxLatency", 15 * 23)
+
+    streamConfig.Express.BlockCloseDelay = options.get("blockCloseDelay", 3600)
 
     return
 

--- a/src/python/T0/WMBS/Oracle/Create.py
+++ b/src/python/T0/WMBS/Oracle/Create.py
@@ -271,6 +271,7 @@ class Create(DBCreator):
                  max_size       int             not null,
                  max_files      int             not null,
                  max_latency    int             not null,
+                 block_delay    int             not null,
                  alca_skim      varchar2(1000),
                  dqm_seq        varchar2(1000),
                  primary key (run_id, stream_id)

--- a/src/python/T0/WMBS/Oracle/RunConfig/InsertExpressConfig.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/InsertExpressConfig.py
@@ -13,7 +13,8 @@ class InsertExpressConfig(DBFormatter):
 
         sql = """INSERT INTO express_config
                  (RUN_ID, STREAM_ID, PROC_VERSION, WRITE_TIERS, GLOBAL_TAG,
-                  MAX_EVENTS, MAX_SIZE, MAX_FILES, MAX_LATENCY, ALCA_SKIM, DQM_SEQ)
+                  MAX_EVENTS, MAX_SIZE, MAX_FILES, MAX_LATENCY, BLOCK_DELAY,
+                  ALCA_SKIM, DQM_SEQ)
                  VALUES (:RUN,
                          (SELECT id FROM stream WHERE name = :STREAM),
                          :PROC_VER,
@@ -23,6 +24,7 @@ class InsertExpressConfig(DBFormatter):
                          :MAX_SIZE,
                          :MAX_FILES,
                          :MAX_LATENCY,
+                         :BLOCK_DELAY,
                          :ALCA_SKIM,
                          :DQM_SEQ)
                  """

--- a/src/python/T0/WMSpec/StdSpecs/Express.py
+++ b/src/python/T0/WMSpec/StdSpecs/Express.py
@@ -168,6 +168,11 @@ class ExpressWorkloadFactory(StdBase):
                                            periodic_harvest_interval = 20 * 60,
                                            doLogCollect = True)
 
+        workload.setBlockCloseSettings(self.blockCloseDelay,
+                                       workload.getBlockCloseMaxFiles(),
+                                       workload.getBlockCloseMaxEvents(),
+                                       workload.getBlockCloseMaxSize())
+
         return workload
 
     def addExpressMergeTask(self, parentTask, parentOutputModuleName):
@@ -370,6 +375,7 @@ class ExpressWorkloadFactory(StdBase):
         self.alcaHarvestTimeout = arguments['AlcaHarvestTimeout']
         self.alcaHarvestDir = arguments['AlcaHarvestDir']
         self.streamName = arguments['StreamName']
+        self.blockCloseDelay = arguments['BlockCloseDelay']
 
         # job splitting parameters (also required parameters)
         self.expressSplitArgs = {}


### PR DESCRIPTION
WMAgent will close blocks a certain time after the block was created. This timeout is hardcoded, but can be overridden in the Spec. Express blocks need to be closed quicker, make the delay for them configurable (default is one hour).
