### PR TITLE
make dropbox upload for express optional

### DIFF
--- a/src/python/T0/ConditionUpload/ConditionUploadAPI.py
+++ b/src/python/T0/ConditionUpload/ConditionUploadAPI.py
@@ -188,19 +188,24 @@ def uploadPayload(filenamePrefix, sqliteFile, metaFile, dropboxHost, validationM
 
     shutil.copy2(filenameTXT, metaFile['pfn'] + ".uploaded")
 
-    uploadStatus = True
-    try:
-        upload.uploadTier0Files([filenameDB], username, password)
-    except:
-        logging.exception("Something went wrong with the Dropbox upload...")
-        uploadStatus = False
-
-    if uploadStatus:
+    if username == None or password == None:
         completeFiles.append(sqliteFile)
         completeFiles.append(metaFile)
-        logging.info("  ==> Upload succeeded for payload %s" % filenamePrefix)
+        logging.info("No username/password provided for DropBox upload...")
+        logging.info("  ==> Upload skipped for payload %s" % filenamePrefix)
     else:
-        logging.error("  ==> Upload failed for payload %s" % filenamePrefix)
+        uploadStatus = True
+        try:
+            upload.uploadTier0Files([filenameDB], username, password)
+        except:
+            logging.exception("Something went wrong with the Dropbox upload...")
+
+        if uploadStatus:
+            completeFiles.append(sqliteFile)
+            completeFiles.append(metaFile)
+            logging.info("  ==> Upload succeeded for payload %s" % filenamePrefix)
+        else:
+            logging.error("  ==> Upload failed for payload %s" % filenamePrefix)
 
     for file2delete in files2delete:
         os.remove(file2delete)

--- a/src/python/T0Component/Tier0Feeder/Tier0FeederPoller.py
+++ b/src/python/T0Component/Tier0Feeder/Tier0FeederPoller.py
@@ -45,8 +45,8 @@ class Tier0FeederPoller(BaseWorkerThread):
 
         self.tier0ConfigFile = config.Tier0Feeder.tier0ConfigFile
         self.specDirectory = config.Tier0Feeder.specDirectory
-        self.dropboxuser = config.Tier0Feeder.dropboxuser
-        self.dropboxpass = config.Tier0Feeder.dropboxpass
+        self.dropboxuser = getattr(config.Tier0Feeder, "dropboxuser", None)
+        self.dropboxpass = getattr(config.Tier0Feeder, "dropboxpass", None)
 
         self.transferSystemBaseDir = getattr(config.Tier0Feeder, "transferSystemBaseDir", None)
         if self.transferSystemBaseDir != None:


### PR DESCRIPTION
Make specifying dropbox username and password optional. If not specified and the express workflow contains alcaharvesting, just finish there and do not attempt an upload to the dropbox.
