### PR TITLE
make replica instead of move subscriptions

### DIFF
--- a/src/python/T0/RunConfig/RunConfigAPI.py
+++ b/src/python/T0/RunConfig/RunConfigAPI.py
@@ -381,6 +381,7 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
 
                 if len(custodialSites) + len(nonCustodialSites) > 0:
                     subscriptions['Bulk'].append( { 'custodialSites' : custodialSites,
+                                                    'custodialSubType' : "Replica",
                                                     'nonCustodialSites' : nonCustodialSites,
                                                     'autoApproveSites' : autoApproveSites,
                                                     'priority' : datasetConfig.CustodialPriority,


### PR DESCRIPTION
Custodial subscriptions are by design move subscriptions in the agent, the Tier0 changed that to a copy with a configuration parameter. This parameters was removed, there is a switch in the spec now, change the Tier0 code accordingly.
