### PR TITLE
catch up to changes with recent WMCore versions

### DIFF
--- a/src/python/T0/RunConfig/RunConfigAPI.py
+++ b/src/python/T0/RunConfig/RunConfigAPI.py
@@ -21,8 +21,8 @@ from T0.WMSpec.StdSpecs.Repack import getTestArguments as getRepackArguments
 from T0.WMSpec.StdSpecs.Repack import repackWorkload
 from T0.WMSpec.StdSpecs.Express import getTestArguments as getExpressArguments
 from T0.WMSpec.StdSpecs.Express import expressWorkload
-from WMCore.WMSpec.StdSpecs.PromptReco import getTestArguments as getPromptRecoArguments
-from WMCore.WMSpec.StdSpecs.PromptReco import promptrecoWorkload
+
+from WMCore.WMSpec.StdSpecs.PromptReco import PromptRecoWorkloadFactory
 
 def configureRun(tier0Config, run, hltConfig, referenceHltConfig = None):
     """
@@ -707,7 +707,7 @@ def releasePromptReco(tier0Config, specDirectory, dqmUploadProxy = None):
                 #
                 taskName = "Reco"
                 workflowName = "PromptReco_Run%d_%s" % (run, dataset)
-                specArguments = getPromptRecoArguments()
+                specArguments = PromptRecoWorkloadFactory.getTestArguments()
 
                 specArguments['AcquisitionEra'] = runInfo['acq_era']
                 specArguments['CMSSWVersion'] = datasetConfig.Reco.CMSSWVersion
@@ -738,7 +738,11 @@ def releasePromptReco(tier0Config, specDirectory, dqmUploadProxy = None):
                 specArguments['DQMUploadProxy'] = dqmUploadProxy
                 specArguments['DQMUploadUrl'] = runInfo['dqmuploadurl']
 
-                wmSpec = promptrecoWorkload(workflowName, specArguments)
+                # not used, but needed by the validation
+                specArguments['CouchURL'] = "http://fakehost:1234"
+
+                factory = PromptRecoWorkloadFactory()
+                wmSpec = factory.factoryWorkloadConstruction(workflowName, specArguments)
 
                 wmSpec.setPhEDExInjectionOverride(runInfo['bulk_data_loc'])
                 for subscription in subscriptions:

--- a/src/python/T0/WMSpec/StdSpecs/Express.py
+++ b/src/python/T0/WMSpec/StdSpecs/Express.py
@@ -30,6 +30,8 @@ def getTestArguments():
     arguments = {
         "Requestor" : "Dirk.Hufnagel@cern.ch",
 
+        "RequestPriority" : 1,
+
         "ScramArch" : "slc5_amd64_gcc462",
         
         # these must be overridden
@@ -62,6 +64,10 @@ class ExpressWorkloadFactory(StdBase):
         StdBase.__init__(self)
         self.multicore = False
         self.multicoreNCores = 1
+
+        self.inputPrimaryDataset = None
+        self.inputProcessedDataset = None
+
         return
 
     def buildWorkload(self):

--- a/src/python/T0/WMSpec/StdSpecs/Repack.py
+++ b/src/python/T0/WMSpec/StdSpecs/Repack.py
@@ -27,6 +27,8 @@ def getTestArguments():
     arguments = {
         "Requestor": "Dirk.Hufnagel@cern.ch",
 
+        "RequestPriority" : 1,
+
         "ScramArch": "slc5_amd64_gcc462",
 
         # needed, but ultimately not used for anything
@@ -54,6 +56,10 @@ class RepackWorkloadFactory(StdBase):
         StdBase.__init__(self)
         self.multicore = False
         self.multicoreNCores = 1
+
+        self.inputPrimaryDataset = None
+        self.inputProcessedDataset = None
+
         return
 
     def buildWorkload(self):

--- a/test/python/T0Component_t/Tier0Feeder_t/ExampleConfig.py
+++ b/test/python/T0Component_t/Tier0Feeder_t/ExampleConfig.py
@@ -10,6 +10,7 @@ from T0.RunConfig.Tier0Config import setAcquisitionEra
 from T0.RunConfig.Tier0Config import setLFNPrefix
 from T0.RunConfig.Tier0Config import setBulkDataType
 from T0.RunConfig.Tier0Config import setBulkDataLocation
+from T0.RunConfig.Tier0Config import setDQMUploadUrl
 from T0.RunConfig.Tier0Config import setPromptCalibrationConfig
 from T0.RunConfig.Tier0Config import setConfigVersion
 from T0.RunConfig.Tier0Config import ignoreStream
@@ -33,6 +34,7 @@ setAcquisitionEra(tier0Config, "ExampleConfig_UnitTest")
 setLFNPrefix(tier0Config, "/store")
 setBulkDataType(tier0Config, "data")
 setBulkDataLocation(tier0Config, "T2_CH_CERN")
+setDQMUploadUrl(tier0Config, "https://cmsweb.cern.ch/dqm/dev")
 setPromptCalibrationConfig(tier0Config,
                            alcaHarvestTimeout = 12*3600,
                            alcaHarvestDir = "/some/afs/dir",
@@ -52,13 +54,27 @@ hltmonVersionOverride = {
 
 addRepackConfig(tier0Config, "Default",
                 proc_ver = 1,
+                maxSizeSingleLumi = 1234,
+                maxSizeMultiLumi = 1122,
+                minInputSize = 210,
+                maxInputSize = 400,
+                maxEdmSize = 1233,
+                maxOverSize = 1133,
+                maxInputEvents = 500,
+                maxInputFiles = 1111,
                 versionOverride = repackVersionOverride)
 
 addExpressConfig(tier0Config, "Express",
                  scenario = "pp",
                  data_tiers = [ "FEVT", "ALCARECO", "DQM" ],
+                 maxInputEvents = 123,
+                 maxInputSize = 123456789,
+                 maxInputFiles = 1234,
+                 maxLatency = 12 * 23,
                  alca_producers = [ "SiStripCalZeroBias", "PromptCalibProd" ],
+                 dqm_sequences = [ "@common" ],
                  global_tag = "GlobalTag1",
+                 reco_version = "CMSSW_4_2_8_patch7",
                  proc_ver = 2,
                  versionOverride = expressVersionOverride)
 

--- a/test/python/T0Component_t/Tier0Feeder_t/Tier0Feeder_t.py
+++ b/test/python/T0Component_t/Tier0Feeder_t/Tier0Feeder_t.py
@@ -38,7 +38,7 @@ class Tier0FeederTest(unittest.TestCase):
         self.testInit.setLogging()
         self.testInit.setDatabaseConnection()
 
-        self.testInit.setSchema(customModules = ["T0.WMBS"])
+        self.testInit.setSchema(customModules = ["T0.WMBS","WMComponent.DBS3Buffer"])
 
         self.testDir  = self.testInit.generateWorkDir()
 

--- a/test/python/T0_t/WMBS_t/RunConfig_t/ExampleConfig.py
+++ b/test/python/T0_t/WMBS_t/RunConfig_t/ExampleConfig.py
@@ -10,6 +10,7 @@ from T0.RunConfig.Tier0Config import setAcquisitionEra
 from T0.RunConfig.Tier0Config import setLFNPrefix
 from T0.RunConfig.Tier0Config import setBulkDataType
 from T0.RunConfig.Tier0Config import setBulkDataLocation
+from T0.RunConfig.Tier0Config import setDQMUploadUrl
 from T0.RunConfig.Tier0Config import setPromptCalibrationConfig
 from T0.RunConfig.Tier0Config import setConfigVersion
 from T0.RunConfig.Tier0Config import ignoreStream
@@ -33,6 +34,7 @@ setAcquisitionEra(tier0Config, "ExampleConfig_UnitTest")
 setLFNPrefix(tier0Config, "/store")
 setBulkDataType(tier0Config, "data")
 setBulkDataLocation(tier0Config, "T2_CH_CERN")
+setDQMUploadUrl(tier0Config, "https://cmsweb.cern.ch/dqm/dev")
 setPromptCalibrationConfig(tier0Config,
                            alcaHarvestTimeout = 12*3600,
                            alcaHarvestDir = "/some/afs/dir",
@@ -72,6 +74,7 @@ addExpressConfig(tier0Config, "Express",
                  alca_producers = [ "SiStripCalZeroBias", "PromptCalibProd" ],
                  dqm_sequences = [ "@common" ],
                  global_tag = "GlobalTag1",
+                 reco_version = "CMSSW_4_2_8_patch7",
                  proc_ver = 2,
                  versionOverride = expressVersionOverride)
 

--- a/test/python/T0_t/WMBS_t/RunConfig_t/RunConfig_t.py
+++ b/test/python/T0_t/WMBS_t/RunConfig_t/RunConfig_t.py
@@ -35,7 +35,7 @@ class RunConfigTest(unittest.TestCase):
         self.testInit.setLogging()
         self.testInit.setDatabaseConnection()
 
-        self.testInit.setSchema(customModules = ["T0.WMBS"])
+        self.testInit.setSchema(customModules = ["T0.WMBS","WMComponent.DBS3Buffer"])
 
         self.testDir  = self.testInit.generateWorkDir()
 
@@ -148,14 +148,15 @@ class RunConfigTest(unittest.TestCase):
                                     'lfn_prefix' : "/store",
                                     'bulk_data_type' : "data",
                                     'bulk_data_loc' : "T2_CH_CERN",
-                                    'process': 'HLT',
+                                    'process': "HLT",
                                     'hltkey': self.hltkey,
+                                    'dqmuploadurl': "https://cmsweb.cern.ch/dqm/dev",
                                     'ah_timeout' : 12*3600,
                                     'ah_dir' : "/some/afs/dir",
                                     'cond_timeout' : 18*3600,
                                     'db_host' : "webcondvm.cern.ch",
                                     'valid_mode' : int(True),
-                                    'acq_era': 'ExampleConfig_UnitTest' } ]
+                                    'acq_era': "ExampleConfig_UnitTest" } ]
 
         self.referenceMapping = {}
         self.referenceMapping['A'] = {}


### PR DESCRIPTION
Just catching up to the WMCore trunk, making the RunConfig and Tier0Feeder unit tests work again
