### PR TITLE
support different scram archs for different Tier0 parts

### DIFF
--- a/src/python/T0/RunConfig/RunConfigAPI.py
+++ b/src/python/T0/RunConfig/RunConfigAPI.py
@@ -630,7 +630,8 @@ def releasePromptReco(tier0Config, specDirectory, dqmUploadProxy = None):
                                            'PRIMDS' : dataset,
                                            'SCENARIO' : datasetConfig.Scenario } )
 
-            bindsCMSSWVersion.append( { 'VERSION' : datasetConfig.Reco.CMSSWVersion } )
+            if datasetConfig.Reco.CMSSWVersion != None:
+                bindsCMSSWVersion.append( { 'VERSION' : datasetConfig.Reco.CMSSWVersion } )
 
             alcaSkim = None
             if len(datasetConfig.Reco.AlcaSkims) > 0:
@@ -644,6 +645,7 @@ def releasePromptReco(tier0Config, specDirectory, dqmUploadProxy = None):
                                       'PRIMDS' : dataset,
                                       'DO_RECO' : int(datasetConfig.Reco.DoReco),
                                       'CMSSW' : datasetConfig.Reco.CMSSWVersion,
+                                      'SCRAM_ARCH' : datasetConfig.Reco.ScramArch,
                                       'RECO_SPLIT' : datasetConfig.Reco.EventSplit,
                                       'WRITE_RECO' : int(datasetConfig.Reco.WriteRECO),
                                       'WRITE_DQM' : int(datasetConfig.Reco.WriteDQM),
@@ -653,7 +655,7 @@ def releasePromptReco(tier0Config, specDirectory, dqmUploadProxy = None):
                                       'DQM_SEQ' : dqmSeq,
                                       'GLOBAL_TAG' : datasetConfig.Reco.GlobalTag } )
 
-            phedexConfig = phedexConfigs[dataset]
+            phedexConfig = phedexConfigs.get("dataset", {})
 
             custodialSites = []
             nonCustodialSites = []
@@ -722,6 +724,7 @@ def releasePromptReco(tier0Config, specDirectory, dqmUploadProxy = None):
 
                 specArguments['AcquisitionEra'] = runInfo['acq_era']
                 specArguments['CMSSWVersion'] = datasetConfig.Reco.CMSSWVersion
+                specArguments['ScramArch'] = datasetConfig.Reco.ScramArch
 
                 specArguments['RunNumber'] = run
 

--- a/src/python/T0/WMBS/Oracle/Create.py
+++ b/src/python/T0/WMBS/Oracle/Create.py
@@ -299,15 +299,16 @@ class Create(DBCreator):
                  run_id         int            not null,
                  primds_id      int            not null,
                  do_reco        int            not null,
-                 cmssw_id       int            not null,
                  reco_split     int            not null,
                  write_reco     int            not null,
                  write_dqm      int            not null,
                  write_aod      int            not null,
                  proc_version   int            not null,
+                 cmssw_id       int,
+                 scram_arch     varchar2(255),
+                 global_tag     varchar2(255),
                  alca_skim      varchar2(1000),
                  dqm_seq        varchar2(1000),
-                 global_tag     varchar2(255),
                  primary key (run_id, primds_id)
                ) ORGANIZATION INDEX"""
 

--- a/src/python/T0/WMBS/Oracle/RunConfig/GetRecoConfig.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/GetRecoConfig.py
@@ -23,6 +23,7 @@ class GetRecoConfig(DBFormatter):
                         reco_config.proc_version,
                         reco_config.alca_skim,
                         reco_config.dqm_seq,
+                        reco_config.scram_arch,
                         reco_config.global_tag,
                         event_scenario.name
                  FROM run_primds_stream_assoc
@@ -64,7 +65,8 @@ class GetRecoConfig(DBFormatter):
             resultDict[primds]['proc_ver'] = result[7]
             resultDict[primds]['alca_skim'] = result[8]
             resultDict[primds]['dqm_seq'] = result[9]
-            resultDict[primds]['global_tag'] = result[10]
-            resultDict[primds]['scenario'] = result[11]
+            resultDict[primds]['scram_arch'] = result[10]
+            resultDict[primds]['global_tag'] = result[11]
+            resultDict[primds]['scenario'] = result[12]
 
         return resultDict

--- a/src/python/T0/WMBS/Oracle/RunConfig/InsertRecoConfig.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/InsertRecoConfig.py
@@ -12,12 +12,11 @@ class InsertRecoConfig(DBFormatter):
     def execute(self, binds, conn = None, transaction = False):
 
         sql = """INSERT INTO reco_config
-                 (RUN_ID, PRIMDS_ID, DO_RECO, CMSSW_ID, RECO_SPLIT, WRITE_RECO,
-                  WRITE_DQM, WRITE_AOD, PROC_VERSION, ALCA_SKIM, DQM_SEQ, GLOBAL_TAG)
+                 (RUN_ID, PRIMDS_ID, DO_RECO, RECO_SPLIT, WRITE_RECO, WRITE_DQM, WRITE_AOD,
+                  PROC_VERSION, ALCA_SKIM, DQM_SEQ, CMSSW_ID, SCRAM_ARCH, GLOBAL_TAG)
                  VALUES (:RUN,
                          (SELECT id FROM primary_dataset WHERE name = :PRIMDS),
                          :DO_RECO,
-                         (SELECT id FROM cmssw_version WHERE name = :CMSSW),
                          :RECO_SPLIT,
                          :WRITE_RECO,
                          :WRITE_DQM,
@@ -25,6 +24,8 @@ class InsertRecoConfig(DBFormatter):
                          :PROC_VER,
                          :ALCA_SKIM,
                          :DQM_SEQ,
+                         (SELECT id FROM cmssw_version WHERE name = :CMSSW),
+                         :SCRAM_ARCH,
                          :GLOBAL_TAG)
                  """
 

--- a/test/python/T0Component_t/Tier0Feeder_t/ExampleConfig.py
+++ b/test/python/T0Component_t/Tier0Feeder_t/ExampleConfig.py
@@ -89,6 +89,7 @@ addDataset(tier0Config, "Default",
            scenario = "pp",
            reco_delay = 60, reco_delay_offset = 30,
            reco_version = "CMSSW_4_2_8_patch1",
+           scram_arch = "slc5_amd64_gcc462",
            default_proc_ver = 4,
            global_tag = "GlobalTag3",
            archival_node = "Node1")

--- a/test/python/T0_t/WMBS_t/RunConfig_t/ExampleConfig.py
+++ b/test/python/T0_t/WMBS_t/RunConfig_t/ExampleConfig.py
@@ -89,6 +89,7 @@ addDataset(tier0Config, "Default",
            scenario = "pp",
            reco_delay = 60, reco_delay_offset = 30,
            reco_version = "CMSSW_4_2_8_patch1",
+           scram_arch = "slc5_amd64_gcc462",
            default_proc_ver = 4,
            global_tag = "GlobalTag3",
            archival_node = "Node1")

--- a/test/python/T0_t/WMBS_t/RunConfig_t/RunConfig_t.py
+++ b/test/python/T0_t/WMBS_t/RunConfig_t/RunConfig_t.py
@@ -1345,6 +1345,9 @@ class RunConfigTest(unittest.TestCase):
 
                 self.assertEquals(recoConfig['cmssw'], "CMSSW_4_2_8_patch2",
                                   "ERROR: problem in reco configuration")
+
+                self.assertEquals(recoConfig['scram_arch'], "slc5_amd64_gcc462",
+                                  "ERROR: problem in reco configuration")
             
                 self.assertEquals(recoConfig['reco_split'], 100,
                                   "ERROR: problem in reco configuration")
@@ -1380,7 +1383,10 @@ class RunConfigTest(unittest.TestCase):
             
                 self.assertEquals(recoConfig['cmssw'], "CMSSW_4_2_8_patch3",
                                   "ERROR: problem in reco configuration")
-            
+
+                self.assertEquals(recoConfig['scram_arch'], "slc5_amd64_gcc462",
+                                  "ERROR: problem in reco configuration")
+
                 self.assertEquals(recoConfig['reco_split'], 200,
                                   "ERROR: problem in reco configuration")
             
@@ -1415,7 +1421,10 @@ class RunConfigTest(unittest.TestCase):
             
                 self.assertEquals(recoConfig['cmssw'], "CMSSW_4_2_8_patch1",
                                   "ERROR: problem in reco configuration")
-            
+
+                self.assertEquals(recoConfig['scram_arch'], "slc5_amd64_gcc462",
+                                  "ERROR: problem in reco configuration")
+
                 self.assertEquals(recoConfig['reco_split'], 2000,
                                   "ERROR: problem in reco configuration")
             


### PR DESCRIPTION
Add a mandatory scram_arch parameter to the dataset configuration, this is passed to the PromptReco Spec and allows to use CMSSW releases that aren't available with the hardcoded default ScramArch.
