### PR TITLE
fix problem with subscriptions of PromptReco data

### DIFF
--- a/src/python/T0/RunConfig/RunConfigAPI.py
+++ b/src/python/T0/RunConfig/RunConfigAPI.py
@@ -655,7 +655,7 @@ def releasePromptReco(tier0Config, specDirectory, dqmUploadProxy = None):
                                       'DQM_SEQ' : dqmSeq,
                                       'GLOBAL_TAG' : datasetConfig.Reco.GlobalTag } )
 
-            phedexConfig = phedexConfigs.get("dataset", {})
+            phedexConfig = phedexConfigs.get(dataset, {})
 
             custodialSites = []
             nonCustodialSites = []


### PR DESCRIPTION
Due to a typo, PromptReco data wasn't using the configured PhEDEx subscriptions. Fix this.
