### PR TITLE
support doing express in separate repack and reco steps, fixes #4038

### DIFF
--- a/src/python/T0/RunConfig/Tier0Config.py
+++ b/src/python/T0/RunConfig/Tier0Config.py
@@ -90,6 +90,10 @@ Tier0Configuration - Global configuration object
 |             |     |
 |             |     |--> GlobalTag - Global tag used for processing
 |             |     |
+|             |     |--> CMSSWVersion - Framework version used for processing. This only
+|             |     |                   needs to be filled if we want to run the reco
+|             |     |                   step separate from the repacking step.
+|             |     |
 |             |     |--> AlcaSkims - List of alca skims active for this stream.
 |             |     |
 |             |     |--> DqmSequences - List of dqm sequences active for this stream.
@@ -569,6 +573,8 @@ def addExpressConfig(config, streamName, **options):
     streamConfig.Express.Scenario = scenario
     streamConfig.Express.DataTiers = data_tiers
     streamConfig.Express.GlobalTag = global_tag
+
+    streamConfig.Express.CMSSWVersion = options.get("reco_version", None)
 
     streamConfig.Express.AlcaSkims = options.get("alca_producers", [])
     streamConfig.Express.DqmSequences = options.get("dqm_sequences", [])

--- a/src/python/T0/WMBS/Oracle/Create.py
+++ b/src/python/T0/WMBS/Oracle/Create.py
@@ -272,6 +272,7 @@ class Create(DBCreator):
                  max_files      int             not null,
                  max_latency    int             not null,
                  block_delay    int             not null,
+                 cmssw_id       int,
                  alca_skim      varchar2(1000),
                  dqm_seq        varchar2(1000),
                  primary key (run_id, stream_id)
@@ -685,6 +686,12 @@ class Create(DBCreator):
                  ADD CONSTRAINT exp_con_str_id_fk
                  FOREIGN KEY (stream_id)
                  REFERENCES stream(id)"""
+
+        self.constraints[len(self.constraints)] = \
+            """ALTER TABLE express_config
+                 ADD CONSTRAINT exp_con_cms_id_fk
+                 FOREIGN KEY (cmssw_id)
+                 REFERENCES cmssw_version(id)"""
 
         self.constraints[len(self.constraints)] = \
             """ALTER TABLE prompt_calib

--- a/src/python/T0/WMBS/Oracle/RunConfig/GetExpressConfig.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/GetExpressConfig.py
@@ -14,13 +14,14 @@ class GetExpressConfig(DBFormatter):
     def execute(self, run, stream, conn = None, transaction = False):
 
         sql = """SELECT express_config.proc_version AS proc_ver,
-                        cmssw_version.name AS cmssw,
+                        stream_version.name AS stream_cmssw,
                         express_config.write_tiers AS write_tiers,
                         express_config.global_tag AS global_tag,
                         express_config.max_events AS max_events,
                         express_config.max_size AS max_size,
                         express_config.max_files AS max_files,
                         express_config.max_latency AS max_latency,
+                        reco_version.name AS reco_cmssw,
                         express_config.alca_skim AS alca_skim,
                         express_config.dqm_seq AS dqm_seq,
                         event_scenario.name AS scenario
@@ -33,8 +34,10 @@ class GetExpressConfig(DBFormatter):
                  INNER JOIN run_primds_scenario_assoc ON
                    run_primds_scenario_assoc.run_id = express_config.run_id AND
                    run_primds_scenario_assoc.primds_id = stream_special_primds_assoc.primds_id
-                 INNER JOIN cmssw_version ON
-                   cmssw_version.id = run_stream_cmssw_assoc.override_version
+                 INNER JOIN cmssw_version stream_version ON
+                   stream_version.id = run_stream_cmssw_assoc.override_version
+                 LEFT OUTER JOIN cmssw_version reco_version ON
+                   reco_version.id = express_config.cmssw_id
                  INNER JOIN event_scenario ON
                    event_scenario.id = run_primds_scenario_assoc.scenario_id
                  WHERE express_config.run_id = :RUN

--- a/src/python/T0/WMBS/Oracle/RunConfig/InsertExpressConfig.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/InsertExpressConfig.py
@@ -14,7 +14,7 @@ class InsertExpressConfig(DBFormatter):
         sql = """INSERT INTO express_config
                  (RUN_ID, STREAM_ID, PROC_VERSION, WRITE_TIERS, GLOBAL_TAG,
                   MAX_EVENTS, MAX_SIZE, MAX_FILES, MAX_LATENCY, BLOCK_DELAY,
-                  ALCA_SKIM, DQM_SEQ)
+                  CMSSW_ID, ALCA_SKIM, DQM_SEQ)
                  VALUES (:RUN,
                          (SELECT id FROM stream WHERE name = :STREAM),
                          :PROC_VER,
@@ -25,6 +25,7 @@ class InsertExpressConfig(DBFormatter):
                          :MAX_FILES,
                          :MAX_LATENCY,
                          :BLOCK_DELAY,
+                         (SELECT id FROM cmssw_version WHERE name = :CMSSW),
                          :ALCA_SKIM,
                          :DQM_SEQ)
                  """

--- a/test/python/T0_t/WMBS_t/RunConfig_t/RunConfig_t.py
+++ b/test/python/T0_t/WMBS_t/RunConfig_t/RunConfig_t.py
@@ -148,9 +148,9 @@ class RunConfigTest(unittest.TestCase):
                                     'lfn_prefix' : "/store",
                                     'bulk_data_type' : "data",
                                     'bulk_data_loc' : "T2_CH_CERN",
-                                    'process': "HLT",
+                                    'dqmuploadurl' : "https://cmsweb.cern.ch/dqm/dev",
+                                    'process': 'HLT',
                                     'hltkey': self.hltkey,
-                                    'dqmuploadurl': "https://cmsweb.cern.ch/dqm/dev",
                                     'ah_timeout' : 12*3600,
                                     'ah_dir' : "/some/afs/dir",
                                     'cond_timeout' : 18*3600,
@@ -1206,8 +1206,11 @@ class RunConfigTest(unittest.TestCase):
         self.assertEqual(expressConfig['proc_ver'], 2,
                          "ERROR: wrong processing version for stream Express")
 
-        self.assertEqual(expressConfig['cmssw'], "CMSSW_4_2_8_patch6" ,
-                         "ERROR: wrong CMSSW version for stream Express")
+        self.assertEqual(expressConfig['stream_cmssw'], "CMSSW_4_2_8_patch6",
+                         "ERROR: wrong stream CMSSW version for stream Express")
+
+        self.assertEqual(expressConfig['reco_cmssw'], "CMSSW_4_2_8_patch7",
+                         "ERROR: wrong reco CMSSW version for stream Express")
 
         writeTiers = expressConfig['write_tiers'].split(',')
         self.assertEqual(set(writeTiers), set([ "FEVT", "ALCARECO", "DQM" ]),
@@ -1249,8 +1252,11 @@ class RunConfigTest(unittest.TestCase):
         self.assertEqual(expressConfig['proc_ver'], 3,
                          "ERROR: wrong processing version for stream HLTMON")
 
-        self.assertEqual(expressConfig['cmssw'], "CMSSW_4_2_8_patch7" ,
-                         "ERROR: wrong CMSSW version for stream HLTMON")
+        self.assertEqual(expressConfig['stream_cmssw'], "CMSSW_4_2_8_patch7",
+                         "ERROR: wrong stream CMSSW version for stream HLTMON")
+
+        self.assertEqual(expressConfig['reco_cmssw'], None,
+                         "ERROR: wrong reco CMSSW version for stream HLTMON")
 
         writeTiers = expressConfig['write_tiers'].split(',')
         self.assertEqual(set(writeTiers), set([ "FEVTHLTALL" ]),


### PR DESCRIPTION
Add an option to specify a reco cmssw version for express that is different than the express override version.
If the reco cmssw version is specified (it is optional) and different, than express is done in two steps,
first a conversion from streamer format to EDM and then a reconstruction.
