### PR TITLE
override LFN in Workload

### DIFF
--- a/src/python/T0/WMSpec/StdSpecs/Express.py
+++ b/src/python/T0/WMSpec/StdSpecs/Express.py
@@ -217,10 +217,16 @@ class ExpressWorkloadFactory(StdBase):
                                        workload.getBlockCloseMaxFiles(),
                                        workload.getBlockCloseMaxEvents(),
                                        workload.getBlockCloseMaxSize())
+
         # setting the parameters which need to be set for all the tasks
         # sets acquisitionEra, processingVersion, processingString
         workload.setTaskPropertiesFromWorkload()
-        
+
+        # set the LFN bases (normally done by request manager)
+        # also pass run number to add run based directories
+        workload.setLFNBase(self.mergedLFNBase, self.unmergedLFNBase,
+                            runNumber = self.runNumber)
+
         return workload
 
     def addExpressMergeTask(self, parentTask, parentStepName, parentOutputModuleName):

--- a/src/python/T0/WMSpec/StdSpecs/Repack.py
+++ b/src/python/T0/WMSpec/StdSpecs/Repack.py
@@ -77,6 +77,11 @@ class RepackWorkloadFactory(StdBase):
         # sets acquisitionEra, processingVersion, processingString
         workload.setTaskPropertiesFromWorkload()
 
+        # set the LFN bases (normally done by request manager)
+        # also pass run number to add run based directories
+        workload.setLFNBase(self.mergedLFNBase, self.unmergedLFNBase,
+                            runNumber = self.runNumber)
+
         return workload
 
     def addRepackMergeTask(self, parentTask, parentOutputModuleName):


### PR DESCRIPTION
After #4053, Workload internal LFN override what the Tier0 configures in the Spec.
Override the Workload LFNs back and also pass the run number to construct the
Tier0 specific LFN with directories based on the run number.

Need to wait for corresponding WMCore patch to be merged first.
