### PR TITLE
make Repack, Express and PromptReco block closing timeout configurable

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -138,6 +138,7 @@ addRepackConfig(tier0Config, "Default",
                 maxOverSize = 8 * 1024 * 1024 * 1024,
                 maxInputEvents = 10 * 1000 * 1000,
                 maxInputFiles = 1000,
+                blockCloseDelay = 24 * 3600,
                 versionOverride = repackVersionOverride)
 
 addDataset(tier0Config, "Default",
@@ -150,6 +151,7 @@ addDataset(tier0Config, "Default",
            cmssw_version = defaultCMSSWVersion,
            global_tag = promptrecoGlobalTag,
            archival_node = "T0_CH_CERN",
+           blockCloseDelay = 24 * 3600,
            scenario = "pp")
 
 

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -138,6 +138,7 @@ addRepackConfig(tier0Config, "Default",
                 maxOverSize = 8 * 1024 * 1024 * 1024,
                 maxInputEvents = 10 * 1000 * 1000,
                 maxInputFiles = 1000,
+                blockCloseDelay = 1200,
                 versionOverride = repackVersionOverride)
 
 addDataset(tier0Config, "Default",
@@ -150,6 +151,7 @@ addDataset(tier0Config, "Default",
            cmssw_version = defaultCMSSWVersion,
            global_tag = promptrecoGlobalTag,
            archival_node = "T0_CH_CERN",
+           blockCloseDelay = 1200,
            scenario = "pp")
 
 
@@ -459,7 +461,7 @@ addExpressConfig(tier0Config, "HIExpress",
                  maxInputSize = 2 * 1024 * 1024 * 1024,
                  maxInputFiles = 500,
                  maxLatency = 5 * 23,
-                 blockCloseDelay = 3600,
+                 blockCloseDelay = 1200,
                  versionOverride = expressVersionOverride)
 
 addExpressConfig(tier0Config, "Express",
@@ -474,7 +476,7 @@ addExpressConfig(tier0Config, "Express",
                  maxInputSize = 2 * 1024 * 1024 * 1024,
                  maxInputFiles = 500,
                  maxLatency = 15 * 23,
-                 blockCloseDelay = 3600,
+                 blockCloseDelay = 1200,
                  versionOverride = expressVersionOverride)
 
 addExpressConfig(tier0Config, "ExpressCosmics",
@@ -487,7 +489,7 @@ addExpressConfig(tier0Config, "ExpressCosmics",
                  maxInputSize = 2 * 1024 * 1024 * 1024,
                  maxInputFiles = 500,
                  maxLatency = 15 * 23,
-                 blockCloseDelay = 3600,
+                 blockCloseDelay = 1200,
                  versionOverride = expressVersionOverride)
 
 addExpressConfig(tier0Config, "HLTMON",
@@ -499,7 +501,7 @@ addExpressConfig(tier0Config, "HLTMON",
                  maxInputSize = 2 * 1024 * 1024 * 1024,
                  maxInputFiles = 500,
                  maxLatency = 15 * 23,
-                 blockCloseDelay = 3600,
+                 blockCloseDelay = 1200,
                  versionOverride = hltmonVersionOverride)
 
 

--- a/src/python/T0/RunConfig/RunConfigAPI.py
+++ b/src/python/T0/RunConfig/RunConfigAPI.py
@@ -252,6 +252,7 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
                                   'MAX_OVER_SIZE' : streamConfig.Repack.MaxOverSize,
                                   'MAX_EVENTS' : streamConfig.Repack.MaxInputEvents,
                                   'MAX_FILES' : streamConfig.Repack.MaxInputFiles,
+                                  'BLOCK_DELAY' : streamConfig.Repack.BlockCloseDelay,
                                   'CMSSW' : streamConfig.Repack.CMSSWVersion,
                                   'SCRAM_ARCH' : streamConfig.Repack.ScramArch }
 
@@ -462,6 +463,9 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
                                                                  runInfo['bulk_data_type'])
             specArguments['MergedLFNBase'] = "%s/%s" % (runInfo['lfn_prefix'],
                                                         runInfo['bulk_data_type'])
+
+            specArguments['BlockCloseDelay'] = streamConfig.Repack.BlockCloseDelay
+
         elif streamConfig.ProcessingStyle == "Express":
 
             taskName = "Express"
@@ -486,7 +490,6 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
             specArguments['MaxInputSize'] = streamConfig.Express.MaxInputSize
             specArguments['MaxInputFiles'] = streamConfig.Express.MaxInputFiles
             specArguments['MaxLatency'] = streamConfig.Express.MaxLatency
-            specArguments['BlockCloseDelay'] = streamConfig.Express.BlockCloseDelay
             specArguments['AlcaSkims'] = streamConfig.Express.AlcaSkims
             specArguments['DqmSequences'] = streamConfig.Express.DqmSequences
             specArguments['UnmergedLFNBase'] = "%s/t0temp/express" % runInfo['lfn_prefix']
@@ -497,6 +500,8 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
             specArguments['DQMUploadUrl'] = runInfo['dqmuploadurl']
             specArguments['StreamName'] = stream
             specArguments['SpecialDataset'] = specialDataset
+
+            specArguments['BlockCloseDelay'] = streamConfig.Express.BlockCloseDelay
 
         if streamConfig.ProcessingStyle in [ 'Bulk', 'Express' ]:
             specArguments['RunNumber'] = run
@@ -678,8 +683,6 @@ def releasePromptReco(tier0Config, specDirectory, dqmUploadProxy = None):
             bindsRecoConfig.append( { 'RUN' : run,
                                       'PRIMDS' : dataset,
                                       'DO_RECO' : int(datasetConfig.DoReco),
-                                      'CMSSW' : datasetConfig.CMSSWVersion,
-                                      'SCRAM_ARCH' : datasetConfig.ScramArch,
                                       'RECO_SPLIT' : datasetConfig.RecoSplit,
                                       'WRITE_RECO' : int(datasetConfig.WriteRECO),
                                       'WRITE_DQM' : int(datasetConfig.WriteDQM),
@@ -687,6 +690,9 @@ def releasePromptReco(tier0Config, specDirectory, dqmUploadProxy = None):
                                       'PROC_VER' : datasetConfig.ProcessingVersion,
                                       'ALCA_SKIM' : alcaSkim,
                                       'DQM_SEQ' : dqmSeq,
+                                      'BLOCK_DELAY' : datasetConfig.BlockCloseDelay,
+                                      'CMSSW' : datasetConfig.CMSSWVersion,
+                                      'SCRAM_ARCH' : datasetConfig.ScramArch,
                                       'GLOBAL_TAG' : datasetConfig.GlobalTag } )
 
             phedexConfig = phedexConfigs.get(dataset, {})
@@ -763,6 +769,8 @@ def releasePromptReco(tier0Config, specDirectory, dqmUploadProxy = None):
                 specArguments['EnableHarvesting'] = "True"
                 specArguments['DQMUploadProxy'] = dqmUploadProxy
                 specArguments['DQMUploadUrl'] = runInfo['dqmuploadurl']
+
+                specArguments['BlockCloseDelay'] = datasetConfig.BlockCloseDelay
 
                 # not used, but needed by the validation
                 specArguments['CouchURL'] = "http://fakehost:1234"

--- a/src/python/T0/RunConfig/Tier0Config.py
+++ b/src/python/T0/RunConfig/Tier0Config.py
@@ -86,6 +86,8 @@ Tier0Configuration - Global configuration object
 |             |     |--> MaxInputEvents - max input events for repack and repack merge job
 |             |     |
 |             |     |--> MaxInputFiles - max input files for repack and repack merge job
+|             |     |
+|             |     |--> BlockCloseDelay - delay to close block in WMAgent
 |             |
 |             |--> Express - Configuration section for express streams
 |             |     |
@@ -176,6 +178,8 @@ Tier0Configuration - Global configuration object
             |--> AlcaSkims - List of alca skims active for this dataset
             |
             |--> DqmSequences - List of dqm sequences active for this dataset
+            |
+            |--> BlockCloseDelay - Delay to close block in WMAgent
 """
 
 import logging
@@ -290,6 +294,7 @@ def addDataset(config, datasetName, **settings):
                            (defaults to high)
       custodial_auto_approve - auto-approve the custodial subscription
                                (defaults to False)
+      blockCloseDelay - block closing timeout in hours
     """
     datasetConfig = retrieveDatasetConfig(config, datasetName)
 
@@ -371,6 +376,11 @@ def addDataset(config, datasetName, **settings):
         datasetConfig.ArchivalNode = settings.get('archival_node', datasetConfig.ArchivalNode)
     else:
         datasetConfig.ArchivalNode = settings.get('archival_node', None)
+
+    if hasattr(datasetConfig, "BlockCloseDelay"):
+        datasetConfig.BlockCloseDelay = settings.get("blockCloseDelay", datasetConfig.BlockCloseDelay)
+    else:
+        datasetConfig.BlockCloseDelay = settings.get("blockCloseDelay", 24 * 3600)
 
     #
     # finally some parameters for which Default isn't used
@@ -553,6 +563,11 @@ def addRepackConfig(config, streamName, **options):
 
     if streamConfig.Repack.MaxOverSize > streamConfig.Repack.MaxEdmSize:
         streamConfig.Repack.MaxOverSize = streamConfig.Repack.MaxEdmSize
+
+    if hasattr(streamConfig.Repack, "BlockCloseDelay"):
+        streamConfig.Repack.BlockCloseDelay = options.get("blockCloseDelay", streamConfig.Repack.BlockCloseDelay)
+    else:
+        streamConfig.Repack.BlockCloseDelay = options.get("blockCloseDelay", 24 * 3600)
 
     return
 

--- a/src/python/T0/WMBS/Oracle/Create.py
+++ b/src/python/T0/WMBS/Oracle/Create.py
@@ -256,6 +256,7 @@ class Create(DBCreator):
                  max_over_size        int          not null,
                  max_events           int          not null,
                  max_files            int          not null,
+                 block_delay          int          not null,
                  cmssw_id             int          not null,
                  scram_arch           varchar2(50) not null,
                  primary key (run_id, stream_id)
@@ -309,6 +310,7 @@ class Create(DBCreator):
                  write_dqm      int            not null,
                  write_aod      int            not null,
                  proc_version   int            not null,
+                 block_delay    int            not null,
                  cmssw_id       int            not null,
                  scram_arch     varchar2(50)   not null,
                  global_tag     varchar2(50)   not null,

--- a/src/python/T0/WMBS/Oracle/RunConfig/GetExpressConfig.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/GetExpressConfig.py
@@ -20,6 +20,7 @@ class GetExpressConfig(DBFormatter):
                         express_config.max_size AS max_size,
                         express_config.max_files AS max_files,
                         express_config.max_latency AS max_latency,
+                        express_config.block_delay AS block_delay,
                         stream_version.name AS cmssw,
                         express_config.scram_arch AS scram_arch,
                         reco_version.name AS reco_cmssw,

--- a/src/python/T0/WMBS/Oracle/RunConfig/GetRecoConfig.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/GetRecoConfig.py
@@ -22,6 +22,7 @@ class GetRecoConfig(DBFormatter):
                         reco_config.proc_version,
                         reco_config.alca_skim,
                         reco_config.dqm_seq,
+                        reco_config.block_delay,
                         cmssw_version.name,
                         reco_config.scram_arch,
                         reco_config.global_tag,
@@ -64,9 +65,10 @@ class GetRecoConfig(DBFormatter):
             resultDict[primds]['proc_ver'] = result[6]
             resultDict[primds]['alca_skim'] = result[7]
             resultDict[primds]['dqm_seq'] = result[8]
-            resultDict[primds]['cmssw'] = result[9]
-            resultDict[primds]['scram_arch'] = result[10]
-            resultDict[primds]['global_tag'] = result[11]
-            resultDict[primds]['scenario'] = result[12]
+            resultDict[primds]['block_delay'] = result[9]
+            resultDict[primds]['cmssw'] = result[10]
+            resultDict[primds]['scram_arch'] = result[11]
+            resultDict[primds]['global_tag'] = result[12]
+            resultDict[primds]['scenario'] = result[13]
 
         return resultDict

--- a/src/python/T0/WMBS/Oracle/RunConfig/GetRepackConfig.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/GetRepackConfig.py
@@ -22,6 +22,7 @@ class GetRepackConfig(DBFormatter):
                         repack_config.max_over_size AS max_over_size,
                         repack_config.max_events AS max_events,
                         repack_config.max_files AS max_files,
+                        repack_config.block_delay AS block_delay,
                         cmssw_version.name AS cmssw,
                         repack_config.scram_arch AS scram_arch
                  FROM repack_config

--- a/src/python/T0/WMBS/Oracle/RunConfig/InsertRecoConfig.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/InsertRecoConfig.py
@@ -13,7 +13,7 @@ class InsertRecoConfig(DBFormatter):
 
         sql = """INSERT INTO reco_config
                  (RUN_ID, PRIMDS_ID, DO_RECO, RECO_SPLIT, WRITE_RECO, WRITE_DQM, WRITE_AOD,
-                  PROC_VERSION, ALCA_SKIM, DQM_SEQ, CMSSW_ID, SCRAM_ARCH, GLOBAL_TAG)
+                  PROC_VERSION, ALCA_SKIM, DQM_SEQ, BLOCK_DELAY, CMSSW_ID, SCRAM_ARCH, GLOBAL_TAG)
                  VALUES (:RUN,
                          (SELECT id FROM primary_dataset WHERE name = :PRIMDS),
                          :DO_RECO,
@@ -24,6 +24,7 @@ class InsertRecoConfig(DBFormatter):
                          :PROC_VER,
                          :ALCA_SKIM,
                          :DQM_SEQ,
+                         :BLOCK_DELAY,
                          (SELECT id FROM cmssw_version WHERE name = :CMSSW),
                          :SCRAM_ARCH,
                          :GLOBAL_TAG)

--- a/src/python/T0/WMBS/Oracle/RunConfig/InsertRepackConfig.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/InsertRepackConfig.py
@@ -14,7 +14,7 @@ class InsertRepackConfig(DBFormatter):
         sql = """INSERT INTO repack_config
                  (RUN_ID, STREAM_ID, PROC_VERSION, MAX_SIZE_SINGLE_LUMI, MAX_SIZE_MULTI_LUMI,
                   MIN_SIZE, MAX_SIZE, MAX_EDM_SIZE, MAX_OVER_SIZE, MAX_EVENTS, MAX_FILES,
-                  CMSSW_ID, SCRAM_ARCH)
+                  BLOCK_DELAY, CMSSW_ID, SCRAM_ARCH)
                  VALUES (:RUN,
                          (SELECT id FROM stream WHERE name = :STREAM),
                          :PROC_VER,
@@ -26,6 +26,7 @@ class InsertRepackConfig(DBFormatter):
                          :MAX_OVER_SIZE,
                          :MAX_EVENTS,
                          :MAX_FILES,
+                         :BLOCK_DELAY,
                          (SELECT id FROM cmssw_version WHERE name = :CMSSW),
                          :SCRAM_ARCH)
                  """

--- a/src/python/T0/WMSpec/StdSpecs/Express.py
+++ b/src/python/T0/WMSpec/StdSpecs/Express.py
@@ -470,15 +470,15 @@ class ExpressWorkloadFactory(StdBase):
                     "AlcaHarvestDir" : {"default" : None, "type" : str,
                                         "optional" : False, "validate" : None,
                                         "attr" : "alcaHarvestDir", "null" : True},
-                    "BlockCloseDelay" : {"default" : None, "type" : int,
-                                         "optional" : False, "validate" : lambda x : x > 0,
-                                         "attr" : "blockCloseDelay", "null" : False},
                     "AlcaSkims" : {"default" : None, "type" : makeList,
                                    "optional" : False, "validate" : None,
                                    "attr" : "alcaSkims", "null" : False},
                     "DqmSequences" : {"default" : None, "type" : makeList,
                                       "optional" : False, "validate" : None,
                                       "attr" : "dqmSequences", "null" : False},
+                    "BlockCloseDelay" : {"default" : None, "type" : int,
+                                         "optional" : False, "validate" : lambda x : x > 0,
+                                         "attr" : "blockCloseDelay", "null" : False},
                     }
         baseArgs.update(specArgs)
         return baseArgs

--- a/src/python/T0/WMSpec/StdSpecs/Repack.py
+++ b/src/python/T0/WMSpec/StdSpecs/Repack.py
@@ -72,7 +72,12 @@ class RepackWorkloadFactory(StdBase):
 
         for repackOutLabel, repackOutInfo in repackOutMods.items():
             self.addRepackMergeTask(repackTask, repackOutLabel)
-        
+
+        workload.setBlockCloseSettings(self.blockCloseDelay,
+                                       workload.getBlockCloseMaxFiles(),
+                                       workload.getBlockCloseMaxEvents(),
+                                       workload.getBlockCloseMaxSize())
+
         # setting the parameters which need to be set for all the tasks
         # sets acquisitionEra, processingVersion, processingString
         workload.setTaskPropertiesFromWorkload()
@@ -189,6 +194,9 @@ class RepackWorkloadFactory(StdBase):
                     "GlobalTag" : {"default" : "fake", "type" : str,
                                    "optional" : True, "validate" : None,
                                    "attr" : "globalTag", "null" : False},
+                    "BlockCloseDelay" : {"default" : None, "type" : int,
+                                         "optional" : False, "validate" : lambda x : x > 0,
+                                         "attr" : "blockCloseDelay", "null" : False},
                     }
         baseArgs.update(specArgs)
         return baseArgs


### PR DESCRIPTION
Defaults are 24 hours for Repack and PromptReco and 1 hour for Express.
