### PR TITLE
make express dqm harvest interval configurable

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -434,6 +434,7 @@ addExpressConfig(tier0Config, "HIExpress",
                  maxInputSize = 2 * 1024 * 1024 * 1024,
                  maxInputFiles = 500,
                  maxLatency = 5 * 23,
+                 periodicHarvestInterval = 20 * 60,
                  blockCloseDelay = 3600,
                  versionOverride = expressVersionOverride)
 
@@ -449,6 +450,7 @@ addExpressConfig(tier0Config, "Express",
                  maxInputSize = 2 * 1024 * 1024 * 1024,
                  maxInputFiles = 500,
                  maxLatency = 15 * 23,
+                 periodicHarvestInterval = 20 * 60,
                  blockCloseDelay = 3600,
                  versionOverride = expressVersionOverride)
 
@@ -462,6 +464,7 @@ addExpressConfig(tier0Config, "ExpressCosmics",
                  maxInputSize = 2 * 1024 * 1024 * 1024,
                  maxInputFiles = 500,
                  maxLatency = 15 * 23,
+                 periodicHarvestInterval = 20 * 60,
                  blockCloseDelay = 3600,
                  versionOverride = expressVersionOverride)
 

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -434,6 +434,7 @@ addExpressConfig(tier0Config, "HIExpress",
                  maxInputSize = 2 * 1024 * 1024 * 1024,
                  maxInputFiles = 500,
                  maxLatency = 5 * 23,
+                 periodicHarvestInterval = 20 * 60,
                  blockCloseDelay = 1200,
                  versionOverride = expressVersionOverride)
 
@@ -449,6 +450,7 @@ addExpressConfig(tier0Config, "Express",
                  maxInputSize = 2 * 1024 * 1024 * 1024,
                  maxInputFiles = 500,
                  maxLatency = 15 * 23,
+                 periodicHarvestInterval = 20 * 60,
                  blockCloseDelay = 1200,
                  versionOverride = expressVersionOverride)
 
@@ -462,6 +464,7 @@ addExpressConfig(tier0Config, "ExpressCosmics",
                  maxInputSize = 2 * 1024 * 1024 * 1024,
                  maxInputFiles = 500,
                  maxLatency = 15 * 23,
+                 periodicHarvestInterval = 20 * 60,
                  blockCloseDelay = 1200,
                  versionOverride = expressVersionOverride)
 

--- a/src/python/T0/RunConfig/RunConfigAPI.py
+++ b/src/python/T0/RunConfig/RunConfigAPI.py
@@ -329,6 +329,7 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
                                    'MAX_SIZE' : streamConfig.Express.MaxInputSize,
                                    'MAX_FILES' : streamConfig.Express.MaxInputFiles,
                                    'MAX_LATENCY' : streamConfig.Express.MaxLatency,
+                                   'DQM_INTERVAL' : streamConfig.Express.PeriodicHarvestInterval,
                                    'BLOCK_DELAY' : streamConfig.Express.BlockCloseDelay,
                                    'CMSSW' : streamConfig.Express.CMSSWVersion,
                                    'SCRAM_ARCH' : streamConfig.Express.ScramArch,
@@ -500,6 +501,8 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
             specArguments['DQMUploadUrl'] = runInfo['dqmuploadurl']
             specArguments['StreamName'] = stream
             specArguments['SpecialDataset'] = specialDataset
+
+            specArguments['PeriodicHarvestInterval'] = streamConfig.Express.PeriodicHarvestInterval
 
             specArguments['BlockCloseDelay'] = streamConfig.Express.BlockCloseDelay
 

--- a/src/python/T0/RunConfig/Tier0Config.py
+++ b/src/python/T0/RunConfig/Tier0Config.py
@@ -115,6 +115,8 @@ Tier0Configuration - Global configuration object
 |             |     |
 |             |     |--> MaxLatency - max latency to trigger express merge job
 |             |     |
+|             |     |--> DqmInterval - periodic DQM harvesting interval
+|             |     |
 |             |     |--> BlockCloseDelay - delay to close block in WMAgent
 |             |
 |             |
@@ -616,6 +618,8 @@ def addExpressConfig(config, streamName, **options):
     streamConfig.Express.MaxInputSize = options.get("maxInputSize", 2 * 1024 * 1024 * 1024)
     streamConfig.Express.MaxInputFiles = options.get("maxInputFiles", 500)
     streamConfig.Express.MaxLatency = options.get("maxLatency", 15 * 23)
+
+    streamConfig.Express.PeriodicHarvestInterval = options.get("periodicHarvestInterval", 0)
 
     streamConfig.Express.BlockCloseDelay = options.get("blockCloseDelay", 3600)
 

--- a/src/python/T0/WMBS/Oracle/Create.py
+++ b/src/python/T0/WMBS/Oracle/Create.py
@@ -273,6 +273,7 @@ class Create(DBCreator):
                  max_size        int           not null,
                  max_files       int           not null,
                  max_latency     int           not null,
+                 dqm_interval    int           not null,
                  block_delay     int           not null,
                  cmssw_id        int           not null,
                  scram_arch      varchar2(50)  not null,

--- a/src/python/T0/WMBS/Oracle/RunConfig/GetExpressConfig.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/GetExpressConfig.py
@@ -20,6 +20,7 @@ class GetExpressConfig(DBFormatter):
                         express_config.max_size AS max_size,
                         express_config.max_files AS max_files,
                         express_config.max_latency AS max_latency,
+                        express_config.dqm_interval AS dqm_interval,
                         express_config.block_delay AS block_delay,
                         stream_version.name AS cmssw,
                         express_config.scram_arch AS scram_arch,

--- a/src/python/T0/WMBS/Oracle/RunConfig/InsertExpressConfig.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/InsertExpressConfig.py
@@ -13,9 +13,9 @@ class InsertExpressConfig(DBFormatter):
 
         sql = """INSERT INTO express_config
                  (RUN_ID, STREAM_ID, PROC_VERSION, WRITE_TIERS, GLOBAL_TAG,
-                  MAX_EVENTS, MAX_SIZE, MAX_FILES, MAX_LATENCY, BLOCK_DELAY,
-                  CMSSW_ID, SCRAM_ARCH, RECO_CMSSW_ID, RECO_SCRAM_ARCH,
-                  ALCA_SKIM, DQM_SEQ)
+                  MAX_EVENTS, MAX_SIZE, MAX_FILES, MAX_LATENCY, DQM_INTERVAL,
+                  BLOCK_DELAY,CMSSW_ID, SCRAM_ARCH, RECO_CMSSW_ID,
+                  RECO_SCRAM_ARCH, ALCA_SKIM, DQM_SEQ)
                  VALUES (:RUN,
                          (SELECT id FROM stream WHERE name = :STREAM),
                          :PROC_VER,
@@ -25,6 +25,7 @@ class InsertExpressConfig(DBFormatter):
                          :MAX_SIZE,
                          :MAX_FILES,
                          :MAX_LATENCY,
+                         :DQM_INTERVAL,
                          :BLOCK_DELAY,
                          (SELECT id FROM cmssw_version WHERE name = :CMSSW),
                          :SCRAM_ARCH,

--- a/src/python/T0/WMSpec/StdSpecs/Express.py
+++ b/src/python/T0/WMSpec/StdSpecs/Express.py
@@ -211,7 +211,7 @@ class ExpressWorkloadFactory(StdBase):
 
                     self.addDQMHarvestTask(mergeTask, "Merged",
                                            uploadProxy = self.dqmUploadProxy,
-                                           periodic_harvest_interval = 20 * 60,
+                                           periodic_harvest_interval = self.periodicHarvestInterval,
                                            doLogCollect = True)
 
         workload.setBlockCloseSettings(self.blockCloseDelay,

--- a/test/python/T0Component_t/Tier0Feeder_t/ExampleConfig.py
+++ b/test/python/T0Component_t/Tier0Feeder_t/ExampleConfig.py
@@ -81,6 +81,8 @@ addExpressConfig(tier0Config, "Express",
                  global_tag = "GlobalTag1",
                  reco_version = "CMSSW_6_2_4",
                  proc_ver = 2,
+                 periodicHarvestInterval = 20 * 60,
+                 blockCloseDelay = 3600,
                  versionOverride = expressVersionOverride)
 
 addExpressConfig(tier0Config, "HLTMON",
@@ -88,47 +90,46 @@ addExpressConfig(tier0Config, "HLTMON",
                  data_tiers = [ "FEVTHLTALL" ],
                  global_tag = "GlobalTag2",
                  proc_ver = 3,
+                 blockCloseDelay = 7200,
                  versionOverride = hltmonVersionOverride)
 
 addDataset(tier0Config, "Default",
-           scenario = "pp",
-           reco_delay = 60, reco_delay_offset = 30,
-           reco_version = "CMSSW_5_3_8",
-           default_proc_ver = 4,
+           do_reco = False,
+           write_reco = False, write_aod = True, write_dqm = True,
+           reco_delay = 60,
+           reco_delay_offset = 30,
+           reco_split = 2000,
+           proc_version = 4,
+           cmssw_version = "CMSSW_5_3_8",
            global_tag = "GlobalTag3",
-           archival_node = "Node1")
+           archival_node = "Node1",
+           blockCloseDelay = 24 * 3600,
+           scenario = "pp")
 
 addDataset(tier0Config, "Cosmics",
-           scenario = "cosmics",
            do_reco = True,
-           global_tag = "GlobalTag4",
+           write_reco = True, write_aod = True, write_dqm = True,
            reco_split = 100,
+           proc_version = 5,
+           cmssw_version = "CMSSW_5_3_14",
+           global_tag = "GlobalTag4",
            alca_producers = [ "Skim1", "Skim2", "Skim3" ],
-           reco_version = "CMSSW_5_3_14",
-           reco_proc_ver = 5,
-           do_alca = True,
            custodial_node = "Node2",
            archival_node = "Node3",
-           write_reco = True,
-           write_aod = True,
-           write_dqm = True)
+           scenario = "cosmics")
 
 addDataset(tier0Config, "MinimumBias",
-           scenario = "pp",
-           do_reco = False,
-           global_tag = "GlobalTag5",
+           write_reco = False, write_aod = False, write_dqm = False,
            reco_split = 200,
+           proc_version = 6,
+           cmssw_version = "CMSSW_6_2_4",
+           global_tag = "GlobalTag5",
            alca_producers = [],
-           reco_version = "CMSSW_6_2_4",
-           reco_proc_ver = 6,
-           do_alca = False,
            custodial_node = "Node4",
-           archival_node = "Node5",
            custodial_priority = "normal",
            custodial_auto_approve = True,
-           write_reco = False,
-           write_aod = False,
-           write_dqm = False)
+           archival_node = "Node5",
+           scenario = "pp")
 
 if __name__ == '__main__':
     print tier0Config

--- a/test/python/T0_t/WMBS_t/RunConfig_t/ExampleConfig.py
+++ b/test/python/T0_t/WMBS_t/RunConfig_t/ExampleConfig.py
@@ -81,6 +81,8 @@ addExpressConfig(tier0Config, "Express",
                  global_tag = "GlobalTag1",
                  reco_version = "CMSSW_6_2_4",
                  proc_ver = 2,
+                 periodicHarvestInterval = 20 * 60,
+                 blockCloseDelay = 3600,
                  versionOverride = expressVersionOverride)
 
 addExpressConfig(tier0Config, "HLTMON",
@@ -88,47 +90,46 @@ addExpressConfig(tier0Config, "HLTMON",
                  data_tiers = [ "FEVTHLTALL" ],
                  global_tag = "GlobalTag2",
                  proc_ver = 3,
+                 blockCloseDelay = 7200,
                  versionOverride = hltmonVersionOverride)
 
 addDataset(tier0Config, "Default",
-           scenario = "pp",
-           reco_delay = 60, reco_delay_offset = 30,
-           reco_version = "CMSSW_5_3_8",
-           default_proc_ver = 4,
+           do_reco = False,
+           write_reco = False, write_aod = True, write_dqm = True,
+           reco_delay = 60,
+           reco_delay_offset = 30,
+           reco_split = 2000,
+           proc_version = 4,
+           cmssw_version = "CMSSW_5_3_8",
            global_tag = "GlobalTag3",
-           archival_node = "Node1")
+           archival_node = "Node1",
+           blockCloseDelay = 24 * 3600,
+           scenario = "pp")
 
 addDataset(tier0Config, "Cosmics",
-           scenario = "cosmics",
            do_reco = True,
-           global_tag = "GlobalTag4",
+           write_reco = True, write_aod = True, write_dqm = True,
            reco_split = 100,
+           proc_version = 5,
+           cmssw_version = "CMSSW_5_3_14",
+           global_tag = "GlobalTag4",
            alca_producers = [ "Skim1", "Skim2", "Skim3" ],
-           reco_version = "CMSSW_5_3_14",
-           reco_proc_ver = 5,
-           do_alca = True,
            custodial_node = "Node2",
            archival_node = "Node3",
-           write_reco = True,
-           write_aod = True,
-           write_dqm = True)
+           scenario = "cosmics")
 
 addDataset(tier0Config, "MinimumBias",
-           scenario = "pp",
-           do_reco = False,
-           global_tag = "GlobalTag5",
+           write_reco = False, write_aod = False, write_dqm = False,
            reco_split = 200,
+           proc_version = 6,
+           cmssw_version = "CMSSW_6_2_4",
+           global_tag = "GlobalTag5",
            alca_producers = [],
-           reco_version = "CMSSW_6_2_4",
-           reco_proc_ver = 6,
-           do_alca = False,
            custodial_node = "Node4",
-           archival_node = "Node5",
            custodial_priority = "normal",
            custodial_auto_approve = True,
-           write_reco = False,
-           write_aod = False,
-           write_dqm = False)
+           archival_node = "Node5",
+           scenario = "pp")
 
 if __name__ == '__main__':
     print tier0Config

--- a/test/python/T0_t/WMBS_t/RunConfig_t/RunConfig_t.py
+++ b/test/python/T0_t/WMBS_t/RunConfig_t/RunConfig_t.py
@@ -1254,6 +1254,12 @@ class RunConfigTest(unittest.TestCase):
         self.assertEqual(expressConfig['scenario'], "pp" ,
                          "ERROR: wrong scenario for stream Express")
 
+        self.assertEqual(expressConfig['dqm_interval'], 20 * 60,
+                         "ERROR: wrong dqm_interval for stream Express")
+
+        self.assertEqual(expressConfig['block_delay'], 3600,
+                         "ERROR: wrong block_delay for stream Express")
+
         expressConfig = self.getExpressConfigDAO.execute(176161, "HLTMON",
                                                          transaction = False)
 
@@ -1288,6 +1294,11 @@ class RunConfigTest(unittest.TestCase):
         self.assertEqual(expressConfig['scenario'], "cosmics" ,
                          "ERROR: wrong scenario for stream HLTMON")
 
+        self.assertEqual(expressConfig['dqm_interval'], 0,
+                         "ERROR: wrong dqm_interval for stream HLTMON")
+
+        self.assertEqual(expressConfig['block_delay'], 7200,
+                         "ERROR: wrong block_delay for stream HLTMON")
         
         recoConfigs = self.getRecoConfigDAO.execute(176161, "A",
                                                    transaction = False)
@@ -1448,7 +1459,7 @@ class RunConfigTest(unittest.TestCase):
                 self.assertEquals(recoConfig['reco_split'], 2000,
                                   "ERROR: problem in reco configuration")
             
-                self.assertEquals(recoConfig['write_reco'], 1,
+                self.assertEquals(recoConfig['write_reco'], 0,
                                   "ERROR: problem in reco configuration")
             
                 self.assertEquals(recoConfig['write_aod'], 1,


### PR DESCRIPTION
Allow to configure the express dqm harvest interval (per stream). Add tests for this to the RunConfig unit test and update the configuration files of the RunConfig and TierFeeder unit tests.
