### PR TITLE
remove JobUpdater from Tier0 configuration

### DIFF
--- a/bin/tier0-mod-config
+++ b/bin/tier0-mod-config
@@ -73,6 +73,9 @@ def modifyConfiguration(config, **args):
 
     config.BossAir.pluginNames = ["LsfPlugin"]
 
+    if hasattr(config, "JobUpdater"):
+        delattr(config, "JobUpdater")
+
     if 'confdb_url' in args:
         config.section_("HLTConfDatabase")
         config.HLTConfDatabase.connectUrl = args['confdb_url']


### PR DESCRIPTION
As the subject says, this patch removes the JobUpdater component from the Tier0 configuration. It doesn't work in a Tier0 environment as we don't have a RequestManager.
