### PR TITLE
don't pass user proxy with alcaharvest jobs

### DIFF
--- a/src/python/T0/JobSplitting/AlcaHarvest.py
+++ b/src/python/T0/JobSplitting/AlcaHarvest.py
@@ -97,6 +97,3 @@ class AlcaHarvest(JobFactory):
                      lfn = fileInfo['lfn'])
             f.setLocation(fileInfo['location'], immediateSave = False)
             self.currentJob.addFile(f)
-
-        if 'X509_USER_PROXY' in os.environ:
-            self.currentJob['proxyPath'] = os.environ['X509_USER_PROXY']


### PR DESCRIPTION
It breaks the CERN AI use case and should not be needed even for LSF.
