### PR TITLE
take pcl files from alcaharvest from EOS

### DIFF
--- a/src/python/T0/WMBS/Oracle/ConditionUpload/GetConditions.py
+++ b/src/python/T0/WMBS/Oracle/ConditionUpload/GetConditions.py
@@ -56,6 +56,6 @@ class GetConditions(DBFormatter):
 
             if result[6] != None:
                 conditions[run]['streams'][streamid]['files'].append( { 'fileid' : result[6],
-                                                                        'pfn' : result[7] } )
+                                                                        'lfn' : result[7] } )
 
         return conditions


### PR DESCRIPTION
Currently the PCL was hardcoded to write output directly to AFS. This will no longer work on AI because the VMs we run there don't have AFS. Switch to write PCL output to EOS instead (location is still configurable).
