### PR TITLE
change from t0temp to unmerged

### DIFF
--- a/src/python/T0/RunConfig/RunConfigAPI.py
+++ b/src/python/T0/RunConfig/RunConfigAPI.py
@@ -460,8 +460,8 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
             specArguments['MaxOverSize'] = streamConfig.Repack.MaxOverSize
             specArguments['MaxInputEvents'] = streamConfig.Repack.MaxInputEvents
             specArguments['MaxInputFiles'] = streamConfig.Repack.MaxInputFiles
-            specArguments['UnmergedLFNBase'] = "%s/t0temp/%s" % (runInfo['lfn_prefix'],
-                                                                 runInfo['bulk_data_type'])
+            specArguments['UnmergedLFNBase'] = "%s/unmerged/%s" % (runInfo['lfn_prefix'],
+                                                                   runInfo['bulk_data_type'])
             specArguments['MergedLFNBase'] = "%s/%s" % (runInfo['lfn_prefix'],
                                                         runInfo['bulk_data_type'])
 
@@ -493,7 +493,7 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
             specArguments['MaxLatency'] = streamConfig.Express.MaxLatency
             specArguments['AlcaSkims'] = streamConfig.Express.AlcaSkims
             specArguments['DqmSequences'] = streamConfig.Express.DqmSequences
-            specArguments['UnmergedLFNBase'] = "%s/t0temp/express" % runInfo['lfn_prefix']
+            specArguments['UnmergedLFNBase'] = "%s/unmerged/express" % runInfo['lfn_prefix']
             specArguments['MergedLFNBase'] = "%s/express" % runInfo['lfn_prefix']
             specArguments['AlcaHarvestTimeout'] = runInfo['ah_timeout']
             specArguments['AlcaHarvestDir'] = runInfo['ah_dir']
@@ -761,8 +761,8 @@ def releasePromptReco(tier0Config, specDirectory, dqmUploadProxy = None):
                 specArguments['AlcaSkims'] = datasetConfig.AlcaSkims
                 specArguments['DqmSequences'] = datasetConfig.DqmSequences
 
-                specArguments['UnmergedLFNBase'] = "%s/t0temp/%s" % (runInfo['lfn_prefix'],
-                                                                     runInfo['bulk_data_type'])
+                specArguments['UnmergedLFNBase'] = "%s/unmerged/%s" % (runInfo['lfn_prefix'],
+                                                                       runInfo['bulk_data_type'])
                 specArguments['MergedLFNBase'] = "%s/%s" % (runInfo['lfn_prefix'],
                                                             runInfo['bulk_data_type'])
 


### PR DESCRIPTION
We only use a single EOS instance for Tier0 and regular production at CERN now. It's easier if both systems use the same space for unmerged files, therefor change the Tier0 from t0temp to unmerged.
