### PR TITLE
fix number of events per job parameter passing to PromptReco Spec

### DIFF
--- a/src/python/T0/RunConfig/RunConfigAPI.py
+++ b/src/python/T0/RunConfig/RunConfigAPI.py
@@ -754,7 +754,8 @@ def releasePromptReco(tier0Config, specDirectory, dqmUploadProxy):
 
                 specArguments['RunNumber'] = run
 
-                specArguments['StdJobSplitArgs'] = {'events_per_job' : datasetConfig.RecoSplit}
+                specArguments['SplittingAlgo'] = "EventBased"
+                specArguments['EventsPerJob'] = datasetConfig.RecoSplit
 
                 specArguments['ProcessingString'] = "PromptReco"
                 specArguments['ProcessingVersion'] = datasetConfig.ProcessingVersion


### PR DESCRIPTION
The PromptReco Spec was changed and the old method of overriding the number of events per job didn't work anymore. Fix this.
