### PR TITLE
change the way PhEDex subscriptions are made

### DIFF
--- a/src/python/T0/RunConfig/Tier0Config.py
+++ b/src/python/T0/RunConfig/Tier0Config.py
@@ -160,14 +160,11 @@ Tier0Configuration - Global configuration object
             |--> RecoDelayOffset - Time before PromptReco is released for which
             |                      settings are locked in and reco looks released
             |
-            |--> CustodialNode - The custodial PhEDEx storage node for this dataset
-            |
             |--> ArchivalNode - The archival PhEDEx node (should always be CERN T0)
             |
-            |--> CustodialPriority - The priority of the custodial subscription
+            |--> TapeNode - The tape PhEDEx node (should be T1 _MSS)
             |
-            |--> CustodialAutoApprove - Determine whether or not the custodial
-            |                           subscription will be auto approved.
+            |--> DiskNode - The disk PhEDEx node (should be T1 _Disk)
             |
             |--> ProcessingVersion - Used for all output from PromptReco
             |
@@ -371,14 +368,14 @@ def addDataset(config, datasetName, **settings):
         msg = "Tier0Config.addDataset : no write_dqm defined for dataset %s or Default" % datasetName
         raise RuntimeError, msg
 
-    #
-    # some optional parameters, Default rules are still used
-    #
     if hasattr(datasetConfig, "ArchivalNode"):
         datasetConfig.ArchivalNode = settings.get('archival_node', datasetConfig.ArchivalNode)
     else:
         datasetConfig.ArchivalNode = settings.get('archival_node', None)
 
+    #
+    # optional parameter, Default rule is still used
+    #
     if hasattr(datasetConfig, "BlockCloseDelay"):
         datasetConfig.BlockCloseDelay = settings.get("blockCloseDelay", datasetConfig.BlockCloseDelay)
     else:
@@ -390,9 +387,8 @@ def addDataset(config, datasetName, **settings):
     datasetConfig.AlcaSkims = settings.get("alca_producers", [])
     datasetConfig.DqmSequences = settings.get("dqm_sequences", [])
 
-    datasetConfig.CustodialNode = settings.get("custodial_node", None)
-    datasetConfig.CustodialPriority = settings.get("custodial_priority", "high")
-    datasetConfig.CustodialAutoApprove = settings.get("custodial_auto_approve", False)
+    datasetConfig.TapeNode = settings.get("tape_node", None)
+    datasetConfig.DiskNode = settings.get("disk_node", None)
 
     return
 
@@ -570,6 +566,9 @@ def addRepackConfig(config, streamName, **options):
         streamConfig.Repack.BlockCloseDelay = options.get("blockCloseDelay", streamConfig.Repack.BlockCloseDelay)
     else:
         streamConfig.Repack.BlockCloseDelay = options.get("blockCloseDelay", 24 * 3600)
+
+    streamConfig.Repack.TapeNodes = options.get("tapeNodes", [])
+    streamConfig.Repack.DiskNodes = options.get("diskNodes", [])
 
     return
 

--- a/src/python/T0/WMBS/Oracle/Create.py
+++ b/src/python/T0/WMBS/Oracle/Create.py
@@ -326,13 +326,12 @@ class Create(DBCreator):
 
         self.create[len(self.create)] = \
             """CREATE TABLE phedex_config (
-                 run_id         int          not null,
-                 primds_id      int          not null,
-                 node_id        int          not null,
-                 custodial      int          not null,
-                 request_only   char(1)      not null,
-                 priority       varchar2(10) not null,
-                 primary key (run_id, primds_id, node_id)
+                 run_id           int not null,
+                 primds_id        int not null,
+                 archival_node_id int,
+                 tape_node_id     int,
+                 disk_node_id     int,
+                 primary key (run_id, primds_id)
                ) ORGANIZATION INDEX"""
 
         self.create[len(self.create)] = \
@@ -762,8 +761,20 @@ class Create(DBCreator):
 
         self.constraints[len(self.constraints)] = \
             """ALTER TABLE phedex_config
-                 ADD CONSTRAINT phe_con_nod_id_fk
-                 FOREIGN KEY (node_id)
+                 ADD CONSTRAINT phe_con_arc_nod_id_fk
+                 FOREIGN KEY (archival_node_id)
+                 REFERENCES storage_node(id)"""
+
+        self.constraints[len(self.constraints)] = \
+            """ALTER TABLE phedex_config
+                 ADD CONSTRAINT phe_con_tap_nod_id_fk
+                 FOREIGN KEY (tape_node_id)
+                 REFERENCES storage_node(id)"""
+
+        self.constraints[len(self.constraints)] = \
+            """ALTER TABLE phedex_config
+                 ADD CONSTRAINT phe_con_dis_nod_id_fk
+                 FOREIGN KEY (disk_node_id)
                  REFERENCES storage_node(id)"""
 
         self.constraints[len(self.constraints)] = \

--- a/src/python/T0/WMBS/Oracle/RunConfig/GetPhEDExConfig.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/GetPhEDExConfig.py
@@ -14,19 +14,19 @@ class GetPhEDExConfig(DBFormatter):
     def execute(self, run, conn = None, transaction = False):
 
         sql = """SELECT primary_dataset.name,
-                        storage_node.name,
-                        phedex_config.custodial,
-                        phedex_config.request_only,
-                        phedex_config.priority
-                 FROM run_primds_stream_assoc
-                 INNER JOIN phedex_config ON
-                   phedex_config.run_id = run_primds_stream_assoc.run_id AND
-                   phedex_config.primds_id = run_primds_stream_assoc.primds_id
+                        archival_node.name,
+                        tape_node.name,
+                        disk_node.name
+                 FROM phedex_config
                  INNER JOIN primary_dataset ON
                    primary_dataset.id = phedex_config.primds_id
-                 INNER JOIN storage_node ON
-                   storage_node.id = phedex_config.node_id
-                 WHERE run_primds_stream_assoc.run_id = :RUN
+                 LEFT OUTER JOIN storage_node archival_node ON
+                   archival_node.id = phedex_config.archival_node_id
+                 LEFT OUTER JOIN storage_node tape_node ON
+                   tape_node.id = phedex_config.tape_node_id
+                 LEFT OUTER JOIN storage_node disk_node ON
+                   disk_node.id = phedex_config.disk_node_id
+                 WHERE phedex_config.run_id = :RUN
                  """
 
         binds = { 'RUN' : run }
@@ -38,14 +38,12 @@ class GetPhEDExConfig(DBFormatter):
         for result in results:
 
             primds = result[0]
-            node = result[1]
 
             if not resultDict.has_key(primds):
                 resultDict[primds] = {}
 
-            resultDict[primds][node] = {}
-            resultDict[primds][node]['custodial'] = result[2]
-            resultDict[primds][node]['request_only'] = result[3]
-            resultDict[primds][node]['priority'] = result[4]
+            resultDict[primds]['archival_node'] = result[1]
+            resultDict[primds]['tape_node'] = result[2]
+            resultDict[primds]['disk_node'] = result[3]
 
         return resultDict

--- a/src/python/T0/WMBS/Oracle/RunConfig/InsertPhEDExConfig.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/InsertPhEDExConfig.py
@@ -12,15 +12,15 @@ class InsertPhEDExConfig(DBFormatter):
     def execute(self, binds, conn = None, transaction = False):
 
         sql = """INSERT INTO phedex_config
-                 (RUN_ID, PRIMDS_ID, NODE_ID, CUSTODIAL, REQUEST_ONLY, PRIORITY)
-                 VALUES (:run,
+                 (RUN_ID, PRIMDS_ID, ARCHIVAL_NODE_ID, TAPE_NODE_ID, DISK_NODE_ID)
+                 VALUES (:RUN,
                          (SELECT id FROM primary_dataset WHERE name = :PRIMDS),
-                         (SELECT id FROM storage_node WHERE name = :NODE),
-                         :CUSTODIAL,
-                         :REQ_ONLY,
-                         :PRIO)
+                         (SELECT id FROM storage_node WHERE name = :ARCHIVAL_NODE),
+                         (SELECT id FROM storage_node WHERE name = :TAPE_NODE),
+                         (SELECT id FROM storage_node WHERE name = :DISK_NODE))
                  """
 
         self.dbi.processData(sql, binds, conn = conn,
                              transaction = transaction)
+
         return

--- a/test/python/T0Component_t/Tier0Feeder_t/ExampleConfig.py
+++ b/test/python/T0Component_t/Tier0Feeder_t/ExampleConfig.py
@@ -114,8 +114,9 @@ addDataset(tier0Config, "Cosmics",
            cmssw_version = "CMSSW_5_3_14",
            global_tag = "GlobalTag4",
            alca_producers = [ "Skim1", "Skim2", "Skim3" ],
-           custodial_node = "Node2",
-           archival_node = "Node3",
+           archival_node = "Node2",
+           tape_node = "Node3",
+           disk_node = "Node4",
            scenario = "cosmics")
 
 addDataset(tier0Config, "MinimumBias",
@@ -125,9 +126,6 @@ addDataset(tier0Config, "MinimumBias",
            cmssw_version = "CMSSW_6_2_4",
            global_tag = "GlobalTag5",
            alca_producers = [],
-           custodial_node = "Node4",
-           custodial_priority = "normal",
-           custodial_auto_approve = True,
            archival_node = "Node5",
            scenario = "pp")
 

--- a/test/python/T0_t/WMBS_t/RunConfig_t/ExampleConfig.py
+++ b/test/python/T0_t/WMBS_t/RunConfig_t/ExampleConfig.py
@@ -114,8 +114,9 @@ addDataset(tier0Config, "Cosmics",
            cmssw_version = "CMSSW_5_3_14",
            global_tag = "GlobalTag4",
            alca_producers = [ "Skim1", "Skim2", "Skim3" ],
-           custodial_node = "Node2",
-           archival_node = "Node3",
+           archival_node = "Node2",
+           tape_node = "Node3",
+           disk_node = "Node4",
            scenario = "cosmics")
 
 addDataset(tier0Config, "MinimumBias",
@@ -125,9 +126,6 @@ addDataset(tier0Config, "MinimumBias",
            cmssw_version = "CMSSW_6_2_4",
            global_tag = "GlobalTag5",
            alca_producers = [],
-           custodial_node = "Node4",
-           custodial_priority = "normal",
-           custodial_auto_approve = True,
            archival_node = "Node5",
            scenario = "pp")
 

--- a/test/python/T0_t/WMBS_t/RunConfig_t/RunConfig_t.py
+++ b/test/python/T0_t/WMBS_t/RunConfig_t/RunConfig_t.py
@@ -1503,76 +1503,46 @@ class RunConfigTest(unittest.TestCase):
 
             if primds == "Cosmics":
 
-                self.assertEquals(set(phedexConfig.keys()), set([ "Node2", "Node3" ]),
+                self.assertEquals(phedexConfig['archival_node'], "Node2",
                                   "ERROR: problem in phedex configuration")
 
-                self.assertEquals(phedexConfig['Node2']['custodial'], 1,
+                self.assertEquals(phedexConfig['tape_node'], "Node3",
                                   "ERROR: problem in phedex configuration")
 
-                self.assertEquals(phedexConfig['Node2']['request_only'], "y",
-                                  "ERROR: problem in phedex configuration")
-
-                self.assertEquals(phedexConfig['Node2']['priority'], "high",
-                                  "ERROR: problem in phedex configuration")
-
-                self.assertEquals(phedexConfig['Node3']['custodial'], 1,
-                                  "ERROR: problem in phedex configuration")
-
-                self.assertEquals(phedexConfig['Node3']['request_only'], "n",
-                                  "ERROR: problem in phedex configuration")
-
-                self.assertEquals(phedexConfig['Node3']['priority'], "high",
+                self.assertEquals(phedexConfig['disk_node'], "Node4",
                                   "ERROR: problem in phedex configuration")
 
             elif primds == "MinimumBias":
 
-                self.assertEquals(set(phedexConfig.keys()), set([ "Node4", "Node5" ]),
+                self.assertEquals(phedexConfig['archival_node'], "Node5",
                                   "ERROR: problem in phedex configuration")
 
-                self.assertEquals(phedexConfig['Node4']['custodial'], 1,
+                self.assertEquals(phedexConfig['tape_node'], None,
                                   "ERROR: problem in phedex configuration")
 
-                self.assertEquals(phedexConfig['Node4']['request_only'], "n",
-                                  "ERROR: problem in phedex configuration")
-
-                self.assertEquals(phedexConfig['Node4']['priority'], "normal",
-                                  "ERROR: problem in phedex configuration")
-
-                self.assertEquals(phedexConfig['Node5']['custodial'], 1,
-                                  "ERROR: problem in phedex configuration")
-
-                self.assertEquals(phedexConfig['Node5']['request_only'], "n",
-                                  "ERROR: problem in phedex configuration")
-
-                self.assertEquals(phedexConfig['Node5']['priority'], "normal",
+                self.assertEquals(phedexConfig['disk_node'], None,
                                   "ERROR: problem in phedex configuration")
 
             elif primds in datasetsStreamA:
 
-                self.assertEquals(set(phedexConfig.keys()), set([ "Node1" ]),
+                self.assertEquals(phedexConfig['archival_node'], "Node1",
                                   "ERROR: problem in phedex configuration")
 
-                self.assertEquals(phedexConfig['Node1']['custodial'], 1,
+                self.assertEquals(phedexConfig['tape_node'], None,
                                   "ERROR: problem in phedex configuration")
 
-                self.assertEquals(phedexConfig['Node1']['request_only'], "n",
-                                  "ERROR: problem in phedex configuration")
-
-                self.assertEquals(phedexConfig['Node1']['priority'], "high",
+                self.assertEquals(phedexConfig['disk_node'], None,
                                   "ERROR: problem in phedex configuration")
 
             else:
 
-                self.assertEquals(set(phedexConfig.keys()), set([ "T2_CH_CERN" ]),
+                self.assertEquals(phedexConfig['archival_node'], None,
                                   "ERROR: problem in phedex configuration")
 
-                self.assertEquals(phedexConfig['T2_CH_CERN']['custodial'], 1,
+                self.assertEquals(phedexConfig['tape_node'], None,
                                   "ERROR: problem in phedex configuration")
 
-                self.assertEquals(phedexConfig['T2_CH_CERN']['request_only'], "n",
-                                  "ERROR: problem in phedex configuration")
-
-                self.assertEquals(phedexConfig['T2_CH_CERN']['priority'], "high",
+                self.assertEquals(phedexConfig['disk_node'], "T2_CH_CERN",
                                   "ERROR: problem in phedex configuration")
 
         #


### PR DESCRIPTION
With the disk/tape separation and a new data placement model, the Tier0 will have to make different type of subscriptions to CERN tape and T1 tape and disk. Implement these changes and also simplify the configuration to only specify the CERN site (archival_node) and the T1 tape and disk endpoints (tape_node and disk_node).
