### PR TITLE
create uploaded file before conditions upload

### DIFF
--- a/src/python/T0Component/Tier0Feeder/Tier0FeederPoller.py
+++ b/src/python/T0Component/Tier0Feeder/Tier0FeederPoller.py
@@ -54,6 +54,8 @@ class Tier0FeederPoller(BaseWorkerThread):
                 self.transferSystemBaseDir = None
 
         self.dqmUploadProxy = getattr(config.Tier0Feeder, "dqmUploadProxy", None)
+        self.serviceCert = getattr(config.Tier0Feeder, "serviceCert", None)
+        self.serviceKey = getattr(config.Tier0Feeder, "serviceKey", None)
 
         self.localSummaryCouchDB = WMStatsWriter(config.AnalyticsDataCollector.localWMStatsURL)
 
@@ -255,7 +257,8 @@ class Tier0FeederPoller(BaseWorkerThread):
         #
         # upload PCL conditions to DropBox
         #
-        ConditionUploadAPI.uploadConditions(self.dropboxuser, self.dropboxpass)
+        ConditionUploadAPI.uploadConditions(self.dropboxuser, self.dropboxpass,
+                                            self.serviceCert, self.serviceKey)
 
         return
 


### PR DESCRIPTION
The PCL monitoring needs to know if we uploaded to prod or validation. Create a file in EOS with that information before we upload the conditions to the dropbox.

Adds two new parameters to Tier0Feeder configuration: serviceCert and serviceKey. They need to be set to the Tier0 service certificate, so that the xrdcp copy can be authenticated.
