### PR TITLE
minimize creation of lumi split records

### DIFF
--- a/src/python/T0/JobSplitting/Repack.py
+++ b/src/python/T0/JobSplitting/Repack.py
@@ -144,9 +144,6 @@ class Repack(JobFactory):
             if lumiSizeTotal > self.maxSizeSingleLumi or \
                    lumiEventsTotal > self.maxInputEvents:
 
-                splitLumis.append( { 'SUB' : self.subscription["id"],
-                                     'LUMI' : lumi } )
-
                 # repack what we have to preserve order
                 if len(jobStreamerList) > 0:
                     self.createJob(jobStreamerList)
@@ -154,6 +151,7 @@ class Repack(JobFactory):
                     jobEventsTotal = 0
                     jobStreamerList = []
 
+                createdMultipleJobs = False
                 while len(lumiStreamerList) > 0:
 
                     eventsTotal = 0
@@ -181,6 +179,13 @@ class Repack(JobFactory):
 
                     for streamer in streamerList:
                         lumiStreamerList.remove(streamer)
+
+                    if len(lumiStreamerList) > 0:
+                        createdMultipleJobs = True
+
+                if createdMultipleJobs:
+                    splitLumis.append( { 'SUB' : self.subscription["id"],
+                                         'LUMI' : lumi } )
 
             # lumi is smaller than split limits
             # check if it can be combined with previous lumi(s)

--- a/src/python/T0/WMSpec/StdSpecs/Repack.py
+++ b/src/python/T0/WMSpec/StdSpecs/Repack.py
@@ -64,7 +64,8 @@ class RepackWorkloadFactory(StdBase):
                                                  scenarioArgs = { 'outputs' : self.outputs },
                                                  splitAlgo = "Repack",
                                                  splitArgs = mySplitArgs,
-                                                 stepType = cmsswStepType)
+                                                 stepType = cmsswStepType,
+                                                 forceUnmerged = True)
 
         repackTask.setTaskType("Repack")
 


### PR DESCRIPTION
The new DAQ is creating single files per lumi section, sometimes over the repack split limits. As the files can't be individually split though, we still won't split process the lumi, therefor do not create a lumi split record for these cases.
