### PR TITLE
adjust unmerged backfill lfn

### DIFF
--- a/src/python/T0/RunConfig/RunConfigAPI.py
+++ b/src/python/T0/RunConfig/RunConfigAPI.py
@@ -60,7 +60,7 @@ def configureRun(tier0Config, run, hltConfig, referenceHltConfig = None):
         bindsUpdateRun = { 'RUN' : run,
                            'PROCESS' : hltConfig['process'],
                            'ACQERA' : tier0Config.Global.AcquisitionEra,
-                           'LFNPREFIX' : tier0Config.Global.LFNPrefix,
+                           'BACKFILL' : tier0Config.Global.Backfill,
                            'BULKDATATYPE' : tier0Config.Global.BulkDataType,
                            'BULKDATALOC' : tier0Config.Global.BulkDataLocation,
                            'DQMUPLOADURL' : tier0Config.Global.DQMUploadUrl,
@@ -107,7 +107,7 @@ def configureRun(tier0Config, run, hltConfig, referenceHltConfig = None):
         bindsUpdateRun = { 'RUN' : run,
                            'PROCESS' : "FakeProcessName",
                            'ACQERA' : "FakeAcquisitionEra",
-                           'LFNPREFIX' : "/fakelfnprefix",
+                           'BACKFILL' : None,
                            'BULKDATATYPE' : "FakeBulkDataType",
                            'AHTIMEOUT' : None,
                            'AHDIR' : None,
@@ -460,10 +460,13 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
             specArguments['MaxOverSize'] = streamConfig.Repack.MaxOverSize
             specArguments['MaxInputEvents'] = streamConfig.Repack.MaxInputEvents
             specArguments['MaxInputFiles'] = streamConfig.Repack.MaxInputFiles
-            specArguments['UnmergedLFNBase'] = "%s/unmerged/%s" % (runInfo['lfn_prefix'],
-                                                                   runInfo['bulk_data_type'])
-            specArguments['MergedLFNBase'] = "%s/%s" % (runInfo['lfn_prefix'],
-                                                        runInfo['bulk_data_type'])
+
+            specArguments['UnmergedLFNBase'] = "/store/unmerged/%s" % runInfo['bulk_data_type']
+            if runInfo['backfill']:
+                specArguments['MergedLFNBase'] = "/store/backfill/%s/%s" % (runInfo['backfill'],
+                                                                            runInfo['bulk_data_type'])
+            else:
+                specArguments['MergedLFNBase'] = "/store/%s" % runInfo['bulk_data_type']
 
             specArguments['BlockCloseDelay'] = streamConfig.Repack.BlockCloseDelay
 
@@ -501,14 +504,19 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
             specArguments['MaxLatency'] = streamConfig.Express.MaxLatency
             specArguments['AlcaSkims'] = streamConfig.Express.AlcaSkims
             specArguments['DqmSequences'] = streamConfig.Express.DqmSequences
-            specArguments['UnmergedLFNBase'] = "%s/unmerged/express" % runInfo['lfn_prefix']
-            specArguments['MergedLFNBase'] = "%s/express" % runInfo['lfn_prefix']
             specArguments['AlcaHarvestTimeout'] = runInfo['ah_timeout']
             specArguments['AlcaHarvestDir'] = runInfo['ah_dir']
             specArguments['DQMUploadProxy'] = dqmUploadProxy
             specArguments['DQMUploadUrl'] = runInfo['dqmuploadurl']
             specArguments['StreamName'] = stream
             specArguments['SpecialDataset'] = specialDataset
+
+            specArguments['UnmergedLFNBase'] = "/store/unmerged/express"
+            specArguments['MergedLFNBase'] = "/store/express"
+            if runInfo['backfill']:
+                specArguments['MergedLFNBase'] = "/store/backfill/%s/express" % runInfo['backfill']
+            else:
+                specArguments['MergedLFNBase'] = "/store/express"
 
             specArguments['PeriodicHarvestInterval'] = streamConfig.Express.PeriodicHarvestInterval
 
@@ -806,10 +814,12 @@ def releasePromptReco(tier0Config, specDirectory, dqmUploadProxy):
                 specArguments['AlcaSkims'] = datasetConfig.AlcaSkims
                 specArguments['DqmSequences'] = datasetConfig.DqmSequences
 
-                specArguments['UnmergedLFNBase'] = "%s/unmerged/%s" % (runInfo['lfn_prefix'],
-                                                                       runInfo['bulk_data_type'])
-                specArguments['MergedLFNBase'] = "%s/%s" % (runInfo['lfn_prefix'],
-                                                            runInfo['bulk_data_type'])
+                specArguments['UnmergedLFNBase'] = "/store/unmerged/%s" % runInfo['bulk_data_type']
+                if runInfo['backfill']:
+                    specArguments['MergedLFNBase'] = "/store/backfill/%s/%s" % (runInfo['backfill'],
+                                                                                runInfo['bulk_data_type'])
+                else:
+                    specArguments['MergedLFNBase'] = "/store/%s" % runInfo['bulk_data_type']
 
                 specArguments['ValidStatus'] = "VALID"
 

--- a/src/python/T0/RunConfig/Tier0Config.py
+++ b/src/python/T0/RunConfig/Tier0Config.py
@@ -14,7 +14,7 @@ Tier0Configuration - Global configuration object
 | |       |
 | |       |--> AcquisitionEra - The acquisition era for the run
 | |       |
-| |       |--> LFNPrefix - The LFN prefix for the run
+| |       |--> Backfill - The backfill mode, can be None, 1 or 2
 | |       |
 | |       |--> BulkDataType - The bulk data type for the run
 | |       |
@@ -200,6 +200,7 @@ def createTier0Config():
     tier0Config.section_("Global")
 
     tier0Config.Global.ScramArches = {}
+    tier0Config.Global.Backfill = None
 
     return tier0Config
 
@@ -419,13 +420,17 @@ def setDefaultScramArch(config, arch):
     config.Global.DefaultScramArch = arch
     return
 
-def setLFNPrefix(config, prefix):
+def setBackfill(config, mode):
     """
-    _setLFNPrefix_
+    _setBackfill_
 
-    Set the LFN prefix in the configuration.
+    Set the backfill mode in the configuration.
     """
-    config.Global.LFNPrefix = prefix
+    if mode not in [ None, 1, 2 ]:
+        msg = "Tier0Config.setBackfill : %s is not a valid backfill mode" % mode
+        raise RuntimeError, msg
+
+    config.Global.Backfill = mode
     return
 
 def setBulkDataType(config, type):

--- a/src/python/T0/WMBS/Oracle/Create.py
+++ b/src/python/T0/WMBS/Oracle/Create.py
@@ -121,7 +121,7 @@ class Create(DBCreator):
                  lumicount          int           default 0 not null,
                  process            varchar2(255),
                  acq_era            varchar2(255),
-                 lfn_prefix         varchar2(255),
+                 backfill           varchar2(255),
                  bulk_data_type     varchar2(255),
                  bulk_data_loc      varchar2(255),
                  dqmuploadurl       varchar2(255),

--- a/src/python/T0/WMBS/Oracle/RunConfig/GetRunInfo.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/GetRunInfo.py
@@ -17,7 +17,7 @@ class GetRunInfo(DBFormatter):
                         hltkey,
                         process,
                         acq_era,
-                        lfn_prefix,
+                        backfill,
                         bulk_data_type,
                         bulk_data_loc,
                         dqmuploadurl,

--- a/src/python/T0/WMBS/Oracle/RunConfig/UpdateRun.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/UpdateRun.py
@@ -14,7 +14,7 @@ class UpdateRun(DBFormatter):
         sql = """UPDATE run
                  SET process = :PROCESS,
                      acq_era = :ACQERA,
-                     lfn_prefix = :LFNPREFIX,
+                     backfill = :BACKFILL,
                      bulk_data_type = :BULKDATATYPE,
                      bulk_data_loc = :BULKDATALOC,
                      dqmuploadurl = :DQMUPLOADURL,

--- a/test/python/T0Component_t/Tier0Feeder_t/ExampleConfig.py
+++ b/test/python/T0Component_t/Tier0Feeder_t/ExampleConfig.py
@@ -9,7 +9,7 @@ from T0.RunConfig.Tier0Config import createTier0Config
 from T0.RunConfig.Tier0Config import setAcquisitionEra
 from T0.RunConfig.Tier0Config import setScramArch
 from T0.RunConfig.Tier0Config import setDefaultScramArch
-from T0.RunConfig.Tier0Config import setLFNPrefix
+from T0.RunConfig.Tier0Config import setBackfill
 from T0.RunConfig.Tier0Config import setBulkDataType
 from T0.RunConfig.Tier0Config import setBulkDataLocation
 from T0.RunConfig.Tier0Config import setDQMUploadUrl
@@ -29,10 +29,10 @@ setConfigVersion(tier0Config, "replace with real version")
 
 # Set global parameters:
 #  acquisition era
-#  LFN prefix
+#  backfill mode 
 #  data type
 setAcquisitionEra(tier0Config, "ExampleConfig_UnitTest")
-setLFNPrefix(tier0Config, "/store")
+setBackfill(tier0Config, None)
 setBulkDataType(tier0Config, "data")
 setBulkDataLocation(tier0Config, "T2_CH_CERN")
 setDQMUploadUrl(tier0Config, "https://cmsweb.cern.ch/dqm/dev")

--- a/test/python/T0_t/WMBS_t/RunConfig_t/ExampleConfig.py
+++ b/test/python/T0_t/WMBS_t/RunConfig_t/ExampleConfig.py
@@ -9,7 +9,7 @@ from T0.RunConfig.Tier0Config import createTier0Config
 from T0.RunConfig.Tier0Config import setAcquisitionEra
 from T0.RunConfig.Tier0Config import setScramArch
 from T0.RunConfig.Tier0Config import setDefaultScramArch
-from T0.RunConfig.Tier0Config import setLFNPrefix
+from T0.RunConfig.Tier0Config import setBackfill
 from T0.RunConfig.Tier0Config import setBulkDataType
 from T0.RunConfig.Tier0Config import setBulkDataLocation
 from T0.RunConfig.Tier0Config import setDQMUploadUrl
@@ -29,10 +29,10 @@ setConfigVersion(tier0Config, "replace with real version")
 
 # Set global parameters:
 #  acquisition era
-#  LFN prefix
+#  backfill mode
 #  data type
 setAcquisitionEra(tier0Config, "ExampleConfig_UnitTest")
-setLFNPrefix(tier0Config, "/store")
+setBackfill(tier0Config, None)
 setBulkDataType(tier0Config, "data")
 setBulkDataLocation(tier0Config, "T2_CH_CERN")
 setDQMUploadUrl(tier0Config, "https://cmsweb.cern.ch/dqm/dev")

--- a/test/python/T0_t/WMBS_t/RunConfig_t/RunConfig_t.py
+++ b/test/python/T0_t/WMBS_t/RunConfig_t/RunConfig_t.py
@@ -18,6 +18,8 @@ from WMCore.Configuration import loadConfigurationFile
 
 from T0.RunConfig import RunConfigAPI
 
+from T0.RunConfig.Tier0Config import setBackfill
+
 
 class RunConfigTest(unittest.TestCase):
     """
@@ -145,7 +147,7 @@ class RunConfigTest(unittest.TestCase):
         self.tier0Config = loadConfigurationFile("ExampleConfig.py")
 
         self.referenceRunInfo = [ { 'status': 1,
-                                    'lfn_prefix' : "/store",
+                                    'backfill' : None,
                                     'bulk_data_type' : "data",
                                     'bulk_data_loc' : "T2_CH_CERN",
                                     'dqmuploadurl' : "https://cmsweb.cern.ch/dqm/dev",
@@ -1601,6 +1603,31 @@ class RunConfigTest(unittest.TestCase):
 
         self.assertEqual(results[0][1], 1,
                          "ERROR: not all created workflows marked as injected")
+
+        return
+
+    def test01(self):
+        """
+        _test01_
+
+        Test setting backfill mode
+
+        """
+        myThread = threading.currentThread()
+
+        setBackfill(self.tier0Config, 2)
+        self.referenceRunInfo[0]['backfill'] = "2"
+
+        RunConfigAPI.configureRun(self.tier0Config, 176161,
+                                  self.hltConfig,
+                                  { 'process' : "HLT",
+                                    'mapping' : self.referenceMapping })
+
+        runInfo = self.getRunInfoDAO.execute(176161,
+                                             transaction = False)
+
+        self.assertEqual(runInfo, self.referenceRunInfo,
+                         "ERROR: run info does not match reference")
 
         return
 


### PR DESCRIPTION
Trigger for this change is to write unmerged backfill to /store/unmerged instead of /store/backfill. Take this opportunity to adjust the LFN configuration, locking it down. Instead of configuring the LFN prefix, now only can specify if no backfill or backfill 1 or 2 are used.
