### PR TITLE
add configuration option to set PromptReco site whitelist

### DIFF
--- a/src/python/T0/RunConfig/RunConfigAPI.py
+++ b/src/python/T0/RunConfig/RunConfigAPI.py
@@ -515,11 +515,15 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
             specArguments['BlockCloseDelay'] = streamConfig.Express.BlockCloseDelay
 
         if streamConfig.ProcessingStyle in [ 'Bulk', 'Express' ]:
+
             specArguments['RunNumber'] = run
             specArguments['AcquisitionEra'] = tier0Config.Global.AcquisitionEra
             specArguments['Outputs'] = outputModuleDetails
             specArguments['OverrideCatalog'] = "trivialcatalog_file:/cvmfs/cms.cern.ch/SITECONF/T2_CH_CERN/Tier0/override_catalog.xml?protocol=override"
             specArguments['ValidStatus'] = "VALID"
+
+            specArguments['SiteWhitelist'] = [ "T2_CH_CERN_T0" ]
+            specArguments['SiteBlacklist'] = []
 
         if streamConfig.ProcessingStyle == "Bulk":
             factory = RepackWorkloadFactory()
@@ -591,7 +595,7 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
                 markWorkflowsInjectedDAO.execute([workflowName], injected = True, conn = myThread.transaction.conn, transaction = True)
         except:
             myThread.transaction.rollback()
-            raise RuntimeError("Problem in configureRunStream() database transaction !"))
+            raise RuntimeError("Problem in configureRunStream() database transaction !")
         else:
             myThread.transaction.commit()
 
@@ -818,6 +822,10 @@ def releasePromptReco(tier0Config, specDirectory, dqmUploadProxy):
                 specArguments['DQMUploadUrl'] = runInfo['dqmuploadurl']
 
                 specArguments['BlockCloseDelay'] = datasetConfig.BlockCloseDelay
+
+                specArguments['SiteWhitelist'] = datasetConfig.SiteWhitelist
+                specArguments['SiteBlacklist'] = []
+                specArguments['TrustSitelists'] = "True"
 
                 # not used, but needed by the validation
                 specArguments['CouchURL'] = "http://fakehost:1234"

--- a/src/python/T0/RunConfig/Tier0Config.py
+++ b/src/python/T0/RunConfig/Tier0Config.py
@@ -179,6 +179,8 @@ Tier0Configuration - Global configuration object
             |--> DqmSequences - List of dqm sequences active for this dataset
             |
             |--> BlockCloseDelay - Delay to close block in WMAgent
+            |
+            |--> SiteWhitelist - Site whitelist for PromptReco
 """
 
 import logging
@@ -380,6 +382,11 @@ def addDataset(config, datasetName, **settings):
         datasetConfig.BlockCloseDelay = settings.get("blockCloseDelay", datasetConfig.BlockCloseDelay)
     else:
         datasetConfig.BlockCloseDelay = settings.get("blockCloseDelay", 24 * 3600)
+
+    if hasattr(datasetConfig, "SiteWhitelist"):
+        datasetConfig.SiteWhitelist = settings.get("siteWhitelist", datasetConfig.SiteWhitelist)
+    else:
+        datasetConfig.SiteWhitelist = settings.get("siteWhitelist", [ "T2_CH_CERN_T0" ])
 
     #
     # finally some parameters for which Default isn't used


### PR DESCRIPTION
PromptReco by default is run at T2_CH_CERN_T0, but add a configurable option to override the site whitelist for PromptReco so it can be run at T1. Also add a hard coded site whitelist T2_CH_CERN_T0 for Repack and Express.
