### PR TITLE
support a connect string passed with global tag

### DIFF
--- a/src/python/T0/RunConfig/RunConfigAPI.py
+++ b/src/python/T0/RunConfig/RunConfigAPI.py
@@ -535,6 +535,8 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
 
             specArguments['GlobalTag'] = streamConfig.Express.GlobalTag
             specArguments['GlobalTagTransaction'] = "Express_%d" % run
+            specArguments['GlobalTagConnect'] = streamConfig.Express.GlobalTagConnect
+
             specArguments['MaxInputRate'] = streamConfig.Express.MaxInputRate
             specArguments['MaxInputEvents'] = streamConfig.Express.MaxInputEvents
             specArguments['MaxInputSize'] = streamConfig.Express.MaxInputSize
@@ -854,7 +856,9 @@ def releasePromptReco(tier0Config, specDirectory, dqmUploadProxy):
                 specArguments['ProcessingString'] = "PromptReco"
                 specArguments['ProcessingVersion'] = datasetConfig.ProcessingVersion
                 specArguments['Scenario'] = datasetConfig.Scenario
+
                 specArguments['GlobalTag'] = datasetConfig.GlobalTag
+                specArguments['GlobalTagConnect'] = datasetConfig.GlobalTagConnect
 
                 specArguments['InputDataset'] = "/%s/%s-%s/RAW" % (dataset, runInfo['acq_era'], repackProcVer)
 

--- a/src/python/T0/RunConfig/Tier0Config.py
+++ b/src/python/T0/RunConfig/Tier0Config.py
@@ -286,6 +286,7 @@ def addDataset(config, datasetName, **settings):
       proc_version - processing version for all outputs
       cmssw_version - framework version
       global_tag - the global tag to use
+      global_tag_connect - connect straing for global tag
       reco_split - number of events to process per reco job
       write_reco - whether the reco jobs writes RECO output
       write_aod - whether the reco job writes AOD output
@@ -376,6 +377,12 @@ def addDataset(config, datasetName, **settings):
     elif not hasattr(datasetConfig, "WriteDQM"):
         msg = "Tier0Config.addDataset : no write_dqm defined for dataset %s or Default" % datasetName
         raise RuntimeError, msg
+
+    if hasattr(datasetConfig, "GlobalTagConnect"):
+        datasetConfig.GlobalTagConnect = settings.get('global_tag_connect', datasetConfig.GlobalTagConnect)
+    else:
+        datasetConfig.GlobalTagConnect = settings.get('global_tag_connect', None)
+
 
     if hasattr(datasetConfig, "ArchivalNode"):
         datasetConfig.ArchivalNode = settings.get('archival_node', datasetConfig.ArchivalNode)
@@ -607,8 +614,6 @@ def addExpressConfig(config, streamName, **options):
         msg = "Tier0Config.addExpressConfig : no scenario defined for stream %s" % streamName
         raise RuntimeError, msg
 
-    proc_config = options.get("proc_config", None)
-
     data_tiers = options.get("data_tiers", [])
     if type(data_tiers) != list or len(data_tiers) == 0:
         msg = "Tier0Config.addExpressConfig : data_tiers needs to be list with at least one tier"
@@ -618,8 +623,6 @@ def addExpressConfig(config, streamName, **options):
     if "ALCARECO" in data_tiers:
         alcamerge_config = options.get("alcamerge_config", None)
 
-    global_tag = options.get("global_tag", None)
-
     streamConfig = retrieveStreamConfig(config, streamName)
     streamConfig.ProcessingStyle = "Express"
     streamConfig.VersionOverride = options.get("versionOverride", {})
@@ -628,7 +631,9 @@ def addExpressConfig(config, streamName, **options):
 
     streamConfig.Express.Scenario = scenario
     streamConfig.Express.DataTiers = data_tiers
-    streamConfig.Express.GlobalTag = global_tag
+    streamConfig.Express.GlobalTag = options.get("global_tag", None)
+
+    streamConfig.Express.GlobalTagConnect = options.get("global_tag_connect", None)
 
     streamConfig.Express.RecoCMSSWVersion = options.get("reco_version", None)
 

--- a/src/python/T0/WMSpec/StdSpecs/Express.py
+++ b/src/python/T0/WMSpec/StdSpecs/Express.py
@@ -73,15 +73,20 @@ class ExpressWorkloadFactory(StdBase):
 
             expressRecoStepName = "cmsRun1"
 
+            scenarioArgs = { 'globalTag' : self.globalTag,
+                             'globalTagTransaction' : self.globalTagTransaction,
+                             'skims' : self.alcaSkims,
+                             'dqmSeq' : self.dqmSequences,
+                             'outputs' : self.outputs,
+                             'inputSource' : "DAT" }
+
+            if self.globalTagConnect:
+                scenarioArgs['globalTagConnect'] = self.globalTagConnect
+
             expressOutMods = self.setupProcessingTask(expressTask, taskType,
                                                       scenarioName = self.procScenario,
                                                       scenarioFunc = "expressProcessing",
-                                                      scenarioArgs = { 'globalTag' : self.globalTag,
-                                                                       'globalTagTransaction' : self.globalTagTransaction,
-                                                                       'skims' : self.alcaSkims,
-                                                                       'dqmSeq' : self.dqmSequences,
-                                                                       'outputs' : self.outputs,
-                                                                       'inputSource' : "DAT" },
+                                                      scenarioArgs = scenarioArgs,
                                                       splitAlgo = "Express",
                                                       splitArgs = mySplitArgs,
                                                       stepType = cmsswStepType,
@@ -138,6 +143,9 @@ class ExpressWorkloadFactory(StdBase):
                              'outputs' : self.outputs,
                              'inputSource' : "EDM" }
 
+            if self.globalTagConnect:
+                scenarioArgs['globalTagConnect'] = self.globalTagConnect
+
             configOutput = self.determineOutputModules(scenarioFunc, scenarioArgs)
 
             expressOutMods = {}
@@ -157,7 +165,9 @@ class ExpressWorkloadFactory(StdBase):
             if 'primaryDataset' in scenarioArgs:
                 del scenarioArgs['primaryDataset']
 
-            stepTwoCmsswHelper.setDataProcessingConfig(self.procScenario, scenarioFunc, **scenarioArgs)
+            stepTwoCmsswHelper.setDataProcessingConfig(self.procScenario,
+                                                       scenarioFunc,
+                                                       **scenarioArgs)
 
 
         expressTask.setTaskType("Express")
@@ -177,13 +187,18 @@ class ExpressWorkloadFactory(StdBase):
                 alcaSkimTask.setInputReference(expressTask.getStep(expressRecoStepName),
                                                outputModule = expressOutLabel)
 
+                scenarioArgs = { 'globalTag' : self.globalTag,
+                                 'globalTagTransaction' : self.globalTagTransaction,
+                                 'skims' : self.alcaSkims,
+                                 'primaryDataset' : self.specialDataset }
+
+                if self.globalTagConnect:
+                    scenarioArgs['globalTagConnect'] = self.globalTagConnect
+
                 alcaSkimOutMods = self.setupProcessingTask(alcaSkimTask, taskType,
                                                            scenarioName = self.procScenario,
                                                            scenarioFunc = "alcaSkim",
-                                                           scenarioArgs = { 'globalTag' : self.globalTag,
-                                                                            'globalTagTransaction' : self.globalTagTransaction,
-                                                                            'skims' : self.alcaSkims,
-                                                                            'primaryDataset' : self.specialDataset },
+                                                           scenarioArgs = scenarioArgs,
                                                            splitAlgo = "ExpressMerge",
                                                            splitArgs = mySplitArgs,
                                                            stepType = cmsswStepType,
@@ -355,12 +370,18 @@ class ExpressWorkloadFactory(StdBase):
         harvestTask.setSplittingAlgorithm("AlcaHarvest",
                                           **mySplitArgs)
 
-        harvestTaskCmsswHelper.setDataProcessingConfig(self.procScenario, "alcaHarvesting",
-                                                       globalTag = self.globalTag,
-                                                       datasetName = "/%s/%s/%s" % (getattr(parentOutputModule, "primaryDataset"),
-                                                                                    getattr(parentOutputModule, "processedDataset"),
-                                                                                    getattr(parentOutputModule, "dataTier")),
-                                                       runNumber = self.runNumber)
+        scenarioArgs = { 'globalTag' : self.globalTag,
+                         'datasetName' : "/%s/%s/%s" % (getattr(parentOutputModule, "primaryDataset"),
+                                                        getattr(parentOutputModule, "processedDataset"),
+                                                        getattr(parentOutputModule, "dataTier")),
+                         'runNumber' : self.runNumber }
+
+        if self.globalTagConnect:
+            scenarioArgs['globalTagConnect'] = self.globalTagConnect
+
+        harvestTaskCmsswHelper.setDataProcessingConfig(self.procScenario,
+                                                       "alcaHarvesting",
+                                                       **scenarioArgs)
 
         harvestTaskConditionHelper = harvestTaskCondition.getTypeHelper()
         harvestTaskConditionHelper.setRunNumber(self.runNumber)


### PR DESCRIPTION
Changes to the Express spec to use connect strings passed with the global tag. Also adjust Tier0Config and RunConfig to add configuration options for it and forward it to the spec.

Please note: the connect string is not saved in the WMBS RunConfig copy.
