### PR TITLE
make the choice between DQM and DQMIO configurable

### DIFF
--- a/src/python/T0/RunConfig/RunConfigAPI.py
+++ b/src/python/T0/RunConfig/RunConfigAPI.py
@@ -280,8 +280,8 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
                                            'SCENARIO' : streamConfig.Express.Scenario } )
 
             if streamConfig.Express.WriteDQM:
-                outputModuleDetails.append( { 'dataTier' : "DQMIO",
-                                              'eventContent' : "DQMIO",
+                outputModuleDetails.append( { 'dataTier' : tier0Config.Global.DQMDataTier,
+                                              'eventContent' : tier0Config.Global.DQMDataTier,
                                               'primaryDataset' : specialDataset } )
 
             bindsStorageNode.append( { 'NODE' : expressPhEDExSubscribeNode } )
@@ -799,7 +799,7 @@ def releasePromptReco(tier0Config, specDirectory, dqmUploadProxy):
                                             'autoApproveSites' : [],
                                             'priority' : "high",
                                             'primaryDataset' : dataset,
-                                            'dataTier' : "DQMIO" } )
+                                            'dataTier' : tier0Config.Global.DQMDataTier } )
 
             if datasetConfig.WriteRECO:
                 if phedexConfig['disk_node'] != None:
@@ -816,7 +816,7 @@ def releasePromptReco(tier0Config, specDirectory, dqmUploadProxy):
             if datasetConfig.WriteAOD:
                 writeTiers.append("AOD")
             if datasetConfig.WriteDQM:
-                writeTiers.append("DQMIO")
+                writeTiers.append(tier0Config.Global.DQMDataTier)
             if len(datasetConfig.AlcaSkims) > 0:
                 writeTiers.append("ALCARECO")
 

--- a/src/python/T0/RunConfig/Tier0Config.py
+++ b/src/python/T0/RunConfig/Tier0Config.py
@@ -20,6 +20,8 @@ Tier0Configuration - Global configuration object
 | |       |
 | |       |--> BulkDataLocation - The bulk data location for the run (to be used as phedex source site)
 | |       |
+| |       |--> DQMDataTier - The data tier used for DQM (default is DQMIO).
+| |       |
 | |       |--> DQMUploadURL - The URL used for DQM uploads
 | |       |
 | |       |--> AlcaHarvestTimeout - AlcaHarvesting for a run/stream is normally trigered by
@@ -211,6 +213,8 @@ def createTier0Config():
 
     tier0Config.Global.ScramArches = {}
     tier0Config.Global.Backfill = None
+
+    tier0Config.Global.DQMDataTier = "DQMIO"
 
     return tier0Config
 
@@ -477,6 +481,20 @@ def setBulkDataLocation(config, location):
     
     """
     config.Global.BulkDataLocation = location
+    return
+
+def setDQMDataTier(config, datatier):
+    """
+    _setDQMDataTier_
+
+    Set the DQM data tier
+
+    """
+    if datatier not in [ "DQM", "DQMIO" ]:
+        msg = "Tier0Config.setDQMDataTier : %s not an allowed DQM data tier !" % datatier
+        raise RuntimeError, msg
+
+    config.Global.DQMDataTier = datatier
     return
 
 def setDQMUploadUrl(config, dqmuploadurl):


### PR DESCRIPTION
Make the DQM data tier configurable, can be specified as setDQMDataTier(tier0Config, <datatier>). Only "DQM" and "DQMIO" are supported, the latter is the default.
