### PR TITLE
add DQMIO as valid DQM data tier to Express

### DIFF
--- a/src/python/T0/WMSpec/StdSpecs/Express.py
+++ b/src/python/T0/WMSpec/StdSpecs/Express.py
@@ -227,7 +227,7 @@ class ExpressWorkloadFactory(StdBase):
 
                 mergeTask = self.addExpressMergeTask(expressTask, expressRecoStepName, expressOutLabel)
 
-                if expressOutInfo['dataTier'] in [ "DQM", "DQMROOT" ]:
+                if expressOutInfo['dataTier'] in [ "DQM", "DQMIO" ]:
 
                     self.addDQMHarvestTask(mergeTask, "Merged",
                                            uploadProxy = self.dqmUploadProxy,


### PR DESCRIPTION
Its a bug that it is missing, replace DQMROOT (which isn't used anymore) with DQMIO.