### PR TITLE
fix subscription creation

### DIFF
--- a/src/python/T0/RunConfig/RunConfigAPI.py
+++ b/src/python/T0/RunConfig/RunConfigAPI.py
@@ -750,28 +750,19 @@ def releasePromptReco(tier0Config, specDirectory, dqmUploadProxy):
 
             phedexConfig = phedexConfigs[dataset]
 
-            if datasetConfig.WriteAOD:
+            # do things different based on whether we have TapeNode/DiskNode or ArchivalNode
+            if phedexConfig['tape_node'] != None and phedexConfig['disk_node'] != None:
 
-                custodialSites = []
-                nonCustodialSites = []
-                autoApproveSites = []
-
-                if phedexConfig['tape_node'] != None:
-                    custodialSites.append(phedexConfig['tape_node'])
-                if phedexConfig['disk_node'] != None:
-                    nonCustodialSites.append(phedexConfig['disk_node'])
-                    autoApproveSites.append(phedexConfig['disk_node'])
-
-                subscriptions.append( { 'custodialSites' : custodialSites,
+                if datasetConfig.WriteAOD:
+                    subscriptions.append( { 'custodialSites' : [phedexConfig['tape_node']],
                                             'custodialSubType' : "Replica",
-                                            'nonCustodialSites' : nonCustodialSites,
-                                            'autoApproveSites' : autoApproveSites,
+                                            'nonCustodialSites' : [phedexConfig['disk_node']],
+                                            'autoApproveSites' : [phedexConfig['disk_node']],
                                             'priority' : "high",
                                             'primaryDataset' : dataset,
                                             'dataTier' : "AOD" } )
 
-            if len(datasetConfig.AlcaSkims) > 0:
-                if phedexConfig['tape_node'] != None:
+                if len(datasetConfig.AlcaSkims) > 0:
                     subscriptions.append( { 'custodialSites' : [phedexConfig['tape_node']],
                                             'custodialSubType' : "Replica",
                                             'nonCustodialSites' : [],
@@ -779,8 +770,8 @@ def releasePromptReco(tier0Config, specDirectory, dqmUploadProxy):
                                             'priority' : "high",
                                             'primaryDataset' : dataset,
                                             'dataTier' : "ALCARECO" } )
-            if datasetConfig.WriteDQM:
-                if phedexConfig['tape_node'] != None:
+
+                if datasetConfig.WriteDQM:
                     subscriptions.append( { 'custodialSites' : [phedexConfig['tape_node']],
                                             'custodialSubType' : "Replica",
                                             'nonCustodialSites' : [],
@@ -789,14 +780,51 @@ def releasePromptReco(tier0Config, specDirectory, dqmUploadProxy):
                                             'primaryDataset' : dataset,
                                             'dataTier' : tier0Config.Global.DQMDataTier } )
 
-            if datasetConfig.WriteRECO:
-                if phedexConfig['disk_node'] != None:
+                if datasetConfig.WriteRECO:
                     subscriptions.append( { 'custodialSites' : [],
                                             'nonCustodialSites' : [phedexConfig['disk_node']],
                                             'autoApproveSites' : [phedexConfig['disk_node']],
                                             'priority' : "high",
                                             'primaryDataset' : dataset,
                                             'dataTier' : "RECO" } )
+
+            elif phedexConfig['archival_node'] != None:
+
+                    if datasetConfig.WriteAOD:
+                        subscriptions.append( { 'custodialSites' : [phedexConfig['archival_node']],
+                                                'custodialSubType' : "Replica",
+                                                'nonCustodialSites' : [],
+                                                'autoApproveSites' : [phedexConfig['archival_node']],
+                                                'priority' : "high",
+                                                'primaryDataset' : dataset,
+                                                'dataTier' : "AOD" } )
+
+                    if len(datasetConfig.AlcaSkims) > 0:
+                        subscriptions.append( { 'custodialSites' : [phedexConfig['archival_node']],
+                                                'custodialSubType' : "Replica",
+                                                'nonCustodialSites' : [],
+                                                'autoApproveSites' : [phedexConfig['archival_node']],
+                                                'priority' : "high",
+                                                'primaryDataset' : dataset,
+                                                'dataTier' : "ALCARECO" } )
+
+                    if datasetConfig.WriteDQM:
+                        subscriptions.append( { 'custodialSites' : [phedexConfig['archival_node']],
+                                                'custodialSubType' : "Replica",
+                                                'nonCustodialSites' : [],
+                                                'autoApproveSites' : [phedexConfig['archival_node']],
+                                                'priority' : "high",
+                                                'primaryDataset' : dataset,
+                                                'dataTier' : tier0Config.Global.DQMDataTier } )
+
+                    if datasetConfig.WriteRECO:
+                        subscriptions.append( { 'custodialSites' : [phedexConfig['archival_node']],
+                                                'custodialSubType' : "Replica",
+                                                'nonCustodialSites' : [],
+                                                'autoApproveSites' : [phedexConfig['archival_node']],
+                                                'priority' : "high",
+                                                'primaryDataset' : dataset,
+                                                'dataTier' : "RECO" } )
 
             writeTiers = []
             if datasetConfig.WriteRECO:

--- a/src/python/T0/RunConfig/Tier0Config.py
+++ b/src/python/T0/RunConfig/Tier0Config.py
@@ -389,11 +389,20 @@ def addDataset(config, datasetName, **settings):
     else:
         datasetConfig.GlobalTagConnect = settings.get('global_tag_connect', None)
 
-
     if hasattr(datasetConfig, "ArchivalNode"):
         datasetConfig.ArchivalNode = settings.get('archival_node', datasetConfig.ArchivalNode)
     else:
         datasetConfig.ArchivalNode = settings.get('archival_node', None)
+
+    if hasattr(datasetConfig, "TapeNode"):
+        datasetConfig.TapeNode = settings.get('tape_node', datasetConfig.TapeNode)
+    else:
+        datasetConfig.TapeNode = settings.get('tape_node', None)
+
+    if hasattr(datasetConfig, "DiskNode"):
+        datasetConfig.DiskNode = settings.get('disk_node', datasetConfig.DiskNode)
+    else:
+        datasetConfig.DiskNode = settings.get('disk_node', None)
 
     if hasattr(datasetConfig, "Multicore"):
         datasetConfig.Multicore = settings.get('multicore', datasetConfig.Multicore)
@@ -418,9 +427,6 @@ def addDataset(config, datasetName, **settings):
     #
     datasetConfig.AlcaSkims = settings.get("alca_producers", [])
     datasetConfig.DqmSequences = settings.get("dqm_sequences", [])
-
-    datasetConfig.TapeNode = settings.get("tape_node", None)
-    datasetConfig.DiskNode = settings.get("disk_node", None)
 
     return
 
@@ -616,9 +622,6 @@ def addRepackConfig(config, streamName, **options):
         streamConfig.Repack.BlockCloseDelay = options.get("blockCloseDelay", streamConfig.Repack.BlockCloseDelay)
     else:
         streamConfig.Repack.BlockCloseDelay = options.get("blockCloseDelay", 24 * 3600)
-
-    streamConfig.Repack.TapeNodes = options.get("tapeNodes", [])
-    streamConfig.Repack.DiskNodes = options.get("diskNodes", [])
 
     return
 


### PR DESCRIPTION
Support both the old archive_node syntax (used for replays) and the tape_node and disk_node syntax (used for production).

Also allow to use tape_node and disk_node syntax for the Default dataset definition and have it automatically apply to all datasets if not explicitly overridden.