### PR TITLE
configurable request priority

### DIFF
--- a/src/python/T0/RunConfig/RunConfigAPI.py
+++ b/src/python/T0/RunConfig/RunConfigAPI.py
@@ -471,7 +471,7 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
             specArguments['SizePerEvent'] = 200
             specArguments['Memory'] = 1800
 
-            specArguments['RequestPriority'] = 0
+            specArguments['RequestPriority'] = tier0Config.Global.BaseRequestPriority + 5000
 
             specArguments['CMSSWVersion'] = streamConfig.Repack.CMSSWVersion
             specArguments['ScramArch'] = streamConfig.Repack.ScramArch
@@ -510,7 +510,7 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
                 specArguments['Multicore'] = streamConfig.Express.Multicore
                 specArguments['Memory'] = 1800 * streamConfig.Express.Multicore
 
-            specArguments['RequestPriority'] = 0
+            specArguments['RequestPriority'] = tier0Config.Global.BaseRequestPriority + 10000
 
             specArguments['ProcessingString'] = "Express"
             specArguments['ProcessingVersion'] = streamConfig.Express.ProcessingVersion
@@ -854,7 +854,7 @@ def releasePromptReco(tier0Config, specDirectory, dqmUploadProxy):
                     specArguments['Multicore'] = datasetConfig.Multicore
                     specArguments['Memory'] = 1800 * datasetConfig.Multicore
 
-                specArguments['RequestPriority'] = 0
+                specArguments['RequestPriority'] = tier0Config.Global.BaseRequestPriority
 
                 specArguments['AcquisitionEra'] = runInfo['acq_era']
                 specArguments['CMSSWVersion'] = datasetConfig.CMSSWVersion

--- a/src/python/T0/RunConfig/Tier0Config.py
+++ b/src/python/T0/RunConfig/Tier0Config.py
@@ -48,6 +48,8 @@ Tier0Configuration - Global configuration object
 | |       |--> ScramArches - Dictionary containig CMSSW release and corresponding ScramArch
 | |       |
 | |       |--> DefaultScramArch - Default ScramArch if nothing else is specified for release
+| |       |
+| |       |--> BaseRequestPriority - Base for request priorities for PromptReco/Repack/Express
 | |
 | |
 | |--> Streams - Configuration parameters that belong to a particular stream
@@ -215,6 +217,8 @@ def createTier0Config():
     tier0Config.Global.Backfill = None
 
     tier0Config.Global.DQMDataTier = "DQMIO"
+
+    tier0Config.Global.BaseRequestPriority = 150000
 
     return tier0Config
 
@@ -446,6 +450,15 @@ def setScramArch(config, cmssw, arch):
     Set the default scram arch in this configuration.
     """
     config.Global.ScramArches[cmssw] = arch
+    return
+
+def setBaseRequestPriority(config, priority):
+    """
+    _setBaseRequestPriority_
+
+    Set the base request priority.
+    """
+    config.Global.BaseRequestPriority = priority
     return
 
 def setDefaultScramArch(config, arch):


### PR DESCRIPTION
Allow to configure a base priority, which is used for PromtReco (as-is), Repack (+5k) and Express (+10k). Default is 150k.