### PR TITLE
optimize the active split streamer query

### DIFF
--- a/src/python/T0/JobSplitting/Express.py
+++ b/src/python/T0/JobSplitting/Express.py
@@ -91,7 +91,8 @@ class Express(JobFactory):
                 self.markComplete(lumiStreamerList)
                 continue
 
-            createdMultipleJobs = False
+            createdJobs = 0
+            nFiles = len(lumiStreamerList)
             while len(lumiStreamerList) > 0:
 
                 eventsTotal = 0
@@ -120,12 +121,11 @@ class Express(JobFactory):
                 for streamer in streamerList:
                     lumiStreamerList.remove(streamer)
 
-                if len(lumiStreamerList) > 0:
-                    createdMultipleJobs = True
+                createdJobs += 1
 
-            if createdMultipleJobs:
+            if createdJobs > 1:
                 splitLumis.append( { 'SUB' : self.subscription["id"],
-                                     'LUMI' : lumi } )
+                                     'LUMI' : lumi, 'NFILES' : nFiles } )
 
         if len(splitLumis) > 0:
             self.insertSplitLumisDAO.execute(binds = splitLumis)

--- a/src/python/T0/JobSplitting/Repack.py
+++ b/src/python/T0/JobSplitting/Repack.py
@@ -153,7 +153,8 @@ class Repack(JobFactory):
                     jobEventsTotal = 0
                     jobStreamerList = []
 
-                createdMultipleJobs = False
+                createdJobs = 0
+                nFiles = len(lumiStreamerList)
                 while len(lumiStreamerList) > 0:
 
                     eventsTotal = 0
@@ -186,12 +187,11 @@ class Repack(JobFactory):
                     for streamer in streamerList:
                         lumiStreamerList.remove(streamer)
 
-                    if len(lumiStreamerList) > 0:
-                        createdMultipleJobs = True
+                    createdJobs += 1
 
-                if createdMultipleJobs:
+                if createdJobs > 1:
                     splitLumis.append( { 'SUB' : self.subscription["id"],
-                                         'LUMI' : lumi } )
+                                         'LUMI' : lumi, 'NFILES' : nFiles } )
 
             # lumi is smaller than split limits
             # check if it can be combined with previous lumi(s)

--- a/src/python/T0/WMBS/Oracle/Create.py
+++ b/src/python/T0/WMBS/Oracle/Create.py
@@ -229,6 +229,7 @@ class Create(DBCreator):
                  subscription   int not null,
                  run_id         int not null,
                  lumi_id        int not null,
+                 nfiles         int not null,
                  primary key(subscription, run_id, lumi_id)
                ) ORGANIZATION INDEX"""
 

--- a/src/python/T0/WMBS/Oracle/JobSplitting/InsertSplitLumis.py
+++ b/src/python/T0/WMBS/Oracle/JobSplitting/InsertSplitLumis.py
@@ -10,8 +10,8 @@ from WMCore.Database.DBFormatter import DBFormatter
 class InsertSplitLumis(DBFormatter):
 
     sql = """INSERT INTO lumi_section_split_active
-             (run_id, subscription, lumi_id)
-             SELECT run_id, :SUB, :LUMI
+             (run_id, subscription, lumi_id, nfiles)
+             SELECT run_id, :SUB, :LUMI, :NFILES
              FROM run_stream_fileset_assoc
              WHERE fileset = (SELECT fileset FROM wmbs_subscription WHERE id = :SUB)
              """

--- a/src/python/T0/WMBS/Oracle/RunLumiCloseout/CheckActiveSplitLumis.py
+++ b/src/python/T0/WMBS/Oracle/RunLumiCloseout/CheckActiveSplitLumis.py
@@ -5,8 +5,9 @@ Oracle implementation of CheckActiveSplitLumis
 
 Check active split lumis for completetion and delete if complete.
 
-An active split lumi is complete if there are no available, acquired
-or failed files for the run/stream/subscription combination.
+An active split lumi is complete if the number of complete
+file records is equal to the total numbers of streamer files
+in that lumi.
 
 """
 import time
@@ -18,55 +19,24 @@ class CheckActiveSplitLumis(DBFormatter):
     def execute(self, conn = None, transaction = False):
 
         sql = """DELETE FROM lumi_section_split_active
-                 WHERE ( lumi_section_split_active.run_id,
-                         lumi_section_split_active.subscription,
+                 WHERE ( lumi_section_split_active.subscription,
+                         lumi_section_split_active.run_id,
                          lumi_section_split_active.lumi_id )
                  IN (
-                   SELECT lumi_section_split_active.run_id,
-                          lumi_section_split_active.subscription,
+                   SELECT lumi_section_split_active.subscription,
+                          lumi_section_split_active.run_id,
                           lumi_section_split_active.lumi_id
                    FROM lumi_section_split_active
-                   LEFT OUTER JOIN (
-                     SELECT lumi_section_split_active.run_id,
-                            wmbs_sub_files_available.subscription,
+                   INNER JOIN wmbs_sub_files_complete ON
+                     wmbs_sub_files_complete.subscription = lumi_section_split_active.subscription
+                   INNER JOIN wmbs_file_runlumi_map ON
+                     wmbs_file_runlumi_map.fileid = wmbs_sub_files_complete.fileid AND
+                     wmbs_file_runlumi_map.run = lumi_section_split_active.run_id AND
+                     wmbs_file_runlumi_map.lumi = lumi_section_split_active.lumi_id
+                   GROUP BY lumi_section_split_active.subscription,
+                            lumi_section_split_active.run_id,
                             lumi_section_split_active.lumi_id
-                     FROM wmbs_sub_files_available
-                     INNER JOIN lumi_section_split_active ON
-                       lumi_section_split_active.subscription = wmbs_sub_files_available.subscription
-                     INNER JOIN wmbs_file_runlumi_map ON
-                       wmbs_file_runlumi_map.fileid = wmbs_sub_files_available.fileid AND
-                       wmbs_file_runlumi_map.run = lumi_section_split_active.run_id AND
-                       wmbs_file_runlumi_map.lumi = lumi_section_split_active.lumi_id
-                     UNION ALL
-                     SELECT lumi_section_split_active.run_id,
-                            wmbs_sub_files_acquired.subscription,
-                            lumi_section_split_active.lumi_id
-                     FROM wmbs_sub_files_acquired
-                     INNER JOIN lumi_section_split_active ON
-                       lumi_section_split_active.subscription = wmbs_sub_files_acquired.subscription
-                     INNER JOIN wmbs_file_runlumi_map ON
-                       wmbs_file_runlumi_map.fileid = wmbs_sub_files_acquired.fileid AND
-                       wmbs_file_runlumi_map.run = lumi_section_split_active.run_id AND
-                       wmbs_file_runlumi_map.lumi = lumi_section_split_active.lumi_id
-                     UNION ALL
-                     SELECT lumi_section_split_active.run_id,
-                            wmbs_sub_files_failed.subscription,
-                            lumi_section_split_active.lumi_id
-                     FROM wmbs_sub_files_failed
-                     INNER JOIN lumi_section_split_active ON
-                       lumi_section_split_active.subscription = wmbs_sub_files_failed.subscription
-                     INNER JOIN wmbs_file_runlumi_map ON
-                       wmbs_file_runlumi_map.fileid = wmbs_sub_files_failed.fileid AND
-                       wmbs_file_runlumi_map.run = lumi_section_split_active.run_id AND
-                       wmbs_file_runlumi_map.lumi = lumi_section_split_active.lumi_id
-                   ) incomplete_files ON
-                     incomplete_files.run_id = lumi_section_split_active.run_id AND
-                     incomplete_files.subscription = lumi_section_split_active.subscription AND
-                     incomplete_files.lumi_id = lumi_section_split_active.lumi_id
-                   GROUP BY lumi_section_split_active.run_id,
-                            lumi_section_split_active.subscription,
-                            lumi_section_split_active.lumi_id
-                   HAVING COUNT(incomplete_files.run_id) = 0
+                   HAVING COUNT(*) = MAX(lumi_section_split_active.nfiles)
                  )
                  """
 


### PR DESCRIPTION
Instead of using the logic of "delete a split lumi record when there are no available, acquired or failed files in that lumi", switch to storing the number of streamer files in the lumi and use the logic of "delete a split lumi when are are as many completed files as there are streamer files".