### PR TITLE
take the PromptReco delay from the configuration file

### DIFF
--- a/src/python/T0/WMBS/Oracle/RunConfig/FindRecoReleaseDatasets.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/FindRecoReleaseDatasets.py
@@ -1,0 +1,35 @@
+"""
+_FindRecoReleaseDatasets_
+
+Oracle implementation of FindRecoReleaseDatasets
+
+Return a list of datasets in any runs that wait
+for PromptReco release.
+
+"""
+
+from WMCore.Database.DBFormatter import DBFormatter
+
+class FindRecoReleaseDatasets(DBFormatter):
+
+    def execute(self, conn = None, transaction = False):
+
+        sql = """SELECT primary_dataset.name
+                 FROM reco_release_config
+                 INNER JOIN run ON
+                   run.run_id = reco_release_config.run_id
+                 INNER JOIN primary_dataset ON
+                   primary_dataset.id = reco_release_config.primds_id
+                 WHERE checkForZeroOneState(reco_release_config.released) = 0
+                 AND run.end_time > 0
+                 GROUP BY primary_dataset.name
+                 """
+
+        results = self.dbi.processData(sql, binds = {}, conn = conn,
+                                       transaction = transaction)[0].fetchall()
+
+        datasets = []
+        for result in results:
+            datasets.append(result[0])
+
+        return datasets

--- a/src/python/T0/WMBS/Oracle/RunConfig/InsertRecoReleaseConfig.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/InsertRecoReleaseConfig.py
@@ -15,8 +15,8 @@ class InsertRecoReleaseConfig(DBFormatter):
                  VALUES (:RUN,
                          (SELECT id FROM primary_dataset WHERE name = :PRIMDS),
                          :FILESET,
-                         :RECODELAY,
-                         :RECODELAYOFFSET)
+                         0,
+                         0)
                  """
 
         self.dbi.processData(sql, binds, conn = conn,

--- a/src/python/T0/WMBS/Oracle/RunConfig/ReleasePromptReco.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/ReleasePromptReco.py
@@ -1,10 +1,7 @@
 """
 _ReleasePromptReco_
-
 Oracle implementation of ReleasePromptReco
-
 Release PromptReco for given run and primary dataset.
-
 """
 
 from WMCore.Database.DBFormatter import DBFormatter


### PR DESCRIPTION
Instead of fixing the PromptReco delay at the time the stream is configured for repack, always use the latest values from the Tier0 configuration.