### PR TITLE
tweak time and size event numbers in repack and express job splitter

### DIFF
--- a/src/python/T0/JobSplitting/Express.py
+++ b/src/python/T0/JobSplitting/Express.py
@@ -160,14 +160,13 @@ class Express(JobFactory):
         #   - 5 min initialization
         #   - 0.5MB/s repack speed
         #   - 45s/evt reco speed
-        #   - checksum calculation at 5MB/s (twice)
+        #   - checksum calculation at 5MB/s
         #   - stageout at 5MB/s
         # job disk based on
-        #   - streamer on local disk (factor 1)
-        #   - RAW on local disk (factor 1)
+        #   - streamer or RAW on local disk (factor 1)
         #   - FEVT/ALCARECO/DQM on local disk (factor 4)
-        jobTime = 300 + jobSize/500000 + jobEvents*45 + (jobSize*4*3)/5000000
-        self.currentJob.addResourceEstimates(jobTime = jobTime, disk = (jobSize*6)/1024, memory = memoryRequirement)
+        jobTime = 300 + jobSize/500000 + jobEvents*45 + (jobSize*4*2)/5000000
+        self.currentJob.addResourceEstimates(jobTime = jobTime, disk = (jobSize*5)/1024, memory = memoryRequirement)
 
         return
 

--- a/src/python/T0/JobSplitting/ExpressMerge.py
+++ b/src/python/T0/JobSplitting/ExpressMerge.py
@@ -181,12 +181,12 @@ class ExpressMerge(JobFactory):
         # job time based on
         #   - 5 min initialization
         #   - 5MB/s merge speed
-        #   - checksum calculation at 5MB/s (twice)
+        #   - checksum calculation at 5MB/s
         #   - stageout at 5MB/s
         # job disk based on
         #  - input for largest file on local disk
         #  - output on local disk (factor 1)
-        jobTime = 300 + (jobSize*4)/5000000
+        jobTime = 300 + (jobSize*3)/5000000
         self.currentJob.addResourceEstimates(jobTime = jobTime, disk = (jobSize+largestFile)/1024)
 
         return

--- a/src/python/T0/JobSplitting/Repack.py
+++ b/src/python/T0/JobSplitting/Repack.py
@@ -267,11 +267,11 @@ class Repack(JobFactory):
         # job time based on
         #   - 5 min initialization
         #   - 0.5MB/s repack speed
-        #   - checksum calculation at 5MB/s (twice)
+        #   - checksum calculation at 5MB/s
         #   - stageout at 5MB/s
         # job disk based on
         #   - RAW on local disk (factor 1)
-        jobTime = 300 + jobSize/500000 + (jobSize*3)/5000000
+        jobTime = 300 + jobSize/500000 + (jobSize*2)/5000000
         self.currentJob.addResourceEstimates(jobTime = jobTime, disk = jobSize/1024, memory = memoryRequirement)
 
         return

--- a/src/python/T0/JobSplitting/RepackMerge.py
+++ b/src/python/T0/JobSplitting/RepackMerge.py
@@ -289,12 +289,12 @@ class RepackMerge(JobFactory):
         # job time based on
         #   - 5 min initialization
         #   - 5MB/s merge speed
-        #   - checksum calculation at 5MB/s (twice)
+        #   - checksum calculation at 5MB/s
         #   - stageout at 5MB/s
         # job disk based on
         #  - input for largest file on local disk
         #  - output on local disk (factor 1)
-        jobTime = 300 + (jobSize*4)/5000000
+        jobTime = 300 + (jobSize*3)/5000000
         self.currentJob.addResourceEstimates(jobTime = jobTime, disk = (jobSize+largestFile)/1024)
 
         return


### PR DESCRIPTION
Adjusting for single reads for checksum calculation and repacking never using lazy-download.