### PR TITLE
allow force releaseing PromptReco

### DIFF
--- a/src/python/T0/WMBS/Oracle/RunConfig/FindRecoRelease.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/FindRecoRelease.py
@@ -73,7 +73,6 @@ class FindRecoRelease(DBFormatter):
                    repack_config.stream_id = run_primds_stream_assoc.stream_id
                  WHERE checkForZeroOneState(reco_release_config.released) = 1
                  AND run.end_time + reco_release_config.delay < :NOW
-                 AND run.end_time > 0
                  """
 
         results = self.dbi.processData(sql, binds, conn = conn,


### PR DESCRIPTION
Allow force releasing PromptReco by removing a normally redundant check in a query.