### PR TITLE
don't wait for PCL uploads from runs with no data

### DIFF
--- a/src/python/T0/ConditionUpload/ConditionUploadAPI.py
+++ b/src/python/T0/ConditionUpload/ConditionUploadAPI.py
@@ -45,15 +45,17 @@ def uploadConditions(username, password, serviceProxy):
                             logger = logging,
                             dbinterface = myThread.dbi)
 
-    findConditionsDAO = daoFactory(classname = "ConditionUpload.GetConditions")
+    getConditionsDAO = daoFactory(classname = "ConditionUpload.GetConditions")
     completeFilesDAO = daoFactory(classname = "ConditionUpload.CompleteFiles")
+
+    finishPCLforEmptyExpressDAO = daoFactory(classname = "ConditionUpload.FinishPCLforEmptyExpress")
 
     isPromptCalibrationFinishedDAO = daoFactory(classname = "ConditionUpload.IsPromptCalibrationFinished")
     markPromptCalibrationFinishedDAO = daoFactory(classname = "ConditionUpload.MarkPromptCalibrationFinished")
 
     # look at all runs which are finished with conditions uploads
     # check for late arriving payloads and upload them
-    conditions = findConditionsDAO.execute(finished = True, transaction = False)
+    conditions = getConditionsDAO.execute(finished = True, transaction = False)
 
     for (index, run) in enumerate(sorted(conditions.keys()), 1):
 
@@ -85,9 +87,14 @@ def uploadConditions(username, password, serviceProxy):
                     else:
                         myThread.transaction.commit()
 
+
+    # check for pathological runs with no express data that will never
+    # create conditions for upload and set them to finished
+    finishPCLforEmptyExpressDAO.execute(transaction = False)
+
     # look at all runs not completely finished with condition uploads
     # return acquired (to be uploaded) files for them 
-    conditions = findConditionsDAO.execute(finished = False, transaction = False)
+    conditions = getConditionsDAO.execute(finished = False, transaction = False)
 
     for (index, run) in enumerate(sorted(conditions.keys()), 1):
 

--- a/src/python/T0/JobSplitting/Express.py
+++ b/src/python/T0/JobSplitting/Express.py
@@ -91,7 +91,7 @@ class Express(JobFactory):
 
             # check if we are over the max allowed rate
             if lumiEventsTotal > self.maxInputRate:
-                self.markComplete(lumiStreamerList)
+                self.markFailed(lumiStreamerList)
                 continue
 
             createdJobs = 0
@@ -171,16 +171,16 @@ class Express(JobFactory):
         return
 
 
-    def markComplete(self, streamerList):
+    def markFailed(self, streamerList):
         """
-        _markComplete_
+        _markFailed_
 
-        mark all streamers as complete
+        mark all streamers as failed
         """
         fileList = []
         for streamer in streamerList:
             fileList.append( File(id = streamer['id'],
                                   lfn = streamer['lfn']) )
-        self.subscription.completeFiles(fileList)
+        self.subscription.failFiles(fileList)
 
         return

--- a/src/python/T0/WMBS/Oracle/ConditionUpload/FinishPCLforEmptyExpress.py
+++ b/src/python/T0/WMBS/Oracle/ConditionUpload/FinishPCLforEmptyExpress.py
@@ -1,0 +1,70 @@
+"""
+_FinishPCLforEmptyExpress_
+
+Oracle implementation of FinishPCLforEmptyExpress
+
+Run/stream with data where processing of that data
+completely fails will never produce conditions,
+therefor set PCL to finished for these.
+
+Second query covers the case where an Express
+workflow is cleaned up before the first query
+can run, also set PCL to finish for these.
+
+"""
+
+from WMCore.Database.DBFormatter import DBFormatter
+
+class FinishPCLforEmptyExpress(DBFormatter):
+
+    def execute(self, conn = None, transaction = False):
+
+        sql = """UPDATE prompt_calib
+                 SET finished = 1
+                 WHERE (run_id, stream_id) IN (
+                   SELECT prompt_calib.run_id, prompt_calib.stream_id
+                   FROM prompt_calib
+                   INNER JOIN run_stream_fileset_assoc ON
+                     run_stream_fileset_assoc.run_id = prompt_calib.run_id AND
+                     run_stream_fileset_assoc.stream_id = prompt_calib.stream_id
+                   INNER JOIN wmbs_fileset ON
+                     wmbs_fileset.id = run_stream_fileset_assoc.fileset AND
+                     wmbs_fileset.open = 0
+                   INNER JOIN wmbs_subscription ON
+                     wmbs_subscription.fileset = run_stream_fileset_assoc.fileset
+                   INNER JOIN wmbs_sub_files_failed ON
+                     wmbs_sub_files_failed.subscription = wmbs_subscription.id
+                   LEFT OUTER JOIN wmbs_sub_files_available ON
+                     wmbs_sub_files_available.subscription = wmbs_subscription.id
+                   LEFT OUTER JOIN wmbs_sub_files_acquired ON
+                     wmbs_sub_files_acquired.subscription = wmbs_subscription.id
+                   LEFT OUTER JOIN wmbs_sub_files_complete ON
+                     wmbs_sub_files_complete.subscription = wmbs_subscription.id
+                   WHERE checkForZeroState(prompt_calib.finished) = 0
+                   AND wmbs_sub_files_available.subscription IS NULL
+                   AND wmbs_sub_files_acquired.subscription IS NULL
+                   AND wmbs_sub_files_complete.subscription IS NULL
+                   GROUP BY prompt_calib.run_id, prompt_calib.stream_id
+                 )
+                 """
+
+        results = self.dbi.processData(sql, {}, conn = conn,
+                                       transaction = transaction)
+
+        sql = """UPDATE prompt_calib
+                 SET finished = 1
+                 WHERE (run_id, stream_id) IN (
+                   SELECT prompt_calib.run_id, prompt_calib.stream_id
+                   FROM prompt_calib
+                   LEFT OUTER JOIN run_stream_fileset_assoc ON
+                     run_stream_fileset_assoc.run_id = prompt_calib.run_id AND
+                     run_stream_fileset_assoc.stream_id = prompt_calib.stream_id
+                   WHERE checkForZeroState(prompt_calib.finished) = 0
+                   AND run_stream_fileset_assoc.run_id IS NULL
+                 )
+                 """
+
+        results = self.dbi.processData(sql, {}, conn = conn,
+                                       transaction = transaction)
+
+        return


### PR DESCRIPTION
Express lumis over a certain threshold are not processed. Express jobs can also fail. This can lead to an Express workflow with input data that does not and never will create PCL conditions. Fix the conditions upload logic to not wait for these runs to produce payloads.