### PR TITLE
Configuration updates for 25ns

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -33,10 +33,10 @@ tier0Config = createTier0Config()
 setConfigVersion(tier0Config, "replace with real version")
 
 # Settings up sites
-processingSite = "T2_CH_CERN_T0"
-cernPhedexNode = "T2_CH_CERN"
-#processingSite = "T2_CH_CERN_AI"
-#cernPhedexNode = "T0_CH_CERN_Disk"
+#processingSite = "T2_CH_CERN_T0"
+#cernPhedexNode = "T2_CH_CERN"
+processingSite = "T2_CH_CERN_AI"
+cernPhedexNode = "T0_CH_CERN_Disk"
 
 
 # Set global parameters:
@@ -46,7 +46,7 @@ cernPhedexNode = "T2_CH_CERN"
 #  Data type
 #  Processing site (where jobs run)
 #  PhEDEx locations
-setAcquisitionEra(tier0Config, "Run2015B")
+setAcquisitionEra(tier0Config, "Run2015C")
 setBaseRequestPriority(tier0Config, 250000)
 setBackfill(tier0Config, None)
 setBulkDataType(tier0Config, "data")
@@ -78,13 +78,13 @@ setPromptCalibrationConfig(tier0Config,
 
 
 # Defaults for CMSSW version
-defaultCMSSWVersion = "CMSSW_7_4_7_patch2"
+defaultCMSSWVersion = "CMSSW_7_4_8_patch1"
 
 # Configure ScramArch
 setDefaultScramArch(tier0Config, "slc6_amd64_gcc491")
 
 # Configure scenarios
-ppScenario = "ppRun2B0T"
+ppScenario = "ppRun2"
 cosmicsScenario = "cosmicsRun2"
 hcalnzsScenario = "hcalnzsRun2"
 
@@ -95,7 +95,7 @@ expressProcVersion = 1
 alcarawProcVersion = 1
 
 # Defaults for GlobalTag
-expressGlobalTag = "74X_dataRun2_Express_v0"
+expressGlobalTag = "74X_dataRun2_Express_v1"
 promptrecoGlobalTag = "74X_dataRun2_Prompt_v1"
 alcap0GlobalTag = "74X_dataRun2_Prompt_v1"
 
@@ -113,20 +113,22 @@ alcarawSplitting = 20000 * numberOfCores
 # Setup repack and express mappings
 #
 repackVersionOverride = {
-    "CMSSW_7_4_2" : "CMSSW_7_4_7_patch2",
-    "CMSSW_7_4_3" : "CMSSW_7_4_7_patch2",
-    "CMSSW_7_4_4" : "CMSSW_7_4_7_patch2",
-    "CMSSW_7_4_5" : "CMSSW_7_4_7_patch2",
-    "CMSSW_7_4_6" : "CMSSW_7_4_7_patch2",
-    "CMSSW_7_4_7" : "CMSSW_7_4_7_patch2",
+    "CMSSW_7_4_2" : "CMSSW_7_4_8_patch1",
+    "CMSSW_7_4_3" : "CMSSW_7_4_8_patch1",
+    "CMSSW_7_4_4" : "CMSSW_7_4_8_patch1",
+    "CMSSW_7_4_5" : "CMSSW_7_4_8_patch1",
+    "CMSSW_7_4_6" : "CMSSW_7_4_8_patch1",
+    "CMSSW_7_4_7" : "CMSSW_7_4_8_patch1",
+    "CMSSW_7_4_8" : "CMSSW_7_4_8_patch1",
     }
 expressVersionOverride = {
-    "CMSSW_7_4_2" : "CMSSW_7_4_7_patch2",
-    "CMSSW_7_4_3" : "CMSSW_7_4_7_patch2",
-    "CMSSW_7_4_4" : "CMSSW_7_4_7_patch2",
-    "CMSSW_7_4_5" : "CMSSW_7_4_7_patch2",
-    "CMSSW_7_4_6" : "CMSSW_7_4_7_patch2",
-    "CMSSW_7_4_7" : "CMSSW_7_4_7_patch2",
+    "CMSSW_7_4_2" : "CMSSW_7_4_8_patch1",
+    "CMSSW_7_4_3" : "CMSSW_7_4_8_patch1",
+    "CMSSW_7_4_4" : "CMSSW_7_4_8_patch1",
+    "CMSSW_7_4_5" : "CMSSW_7_4_8_patch1",
+    "CMSSW_7_4_6" : "CMSSW_7_4_8_patch1",
+    "CMSSW_7_4_7" : "CMSSW_7_4_8_patch1",
+    "CMSSW_7_4_8" : "CMSSW_7_4_8_patch1",
     }
 
 #set default repack settings for bulk streams
@@ -158,6 +160,8 @@ addDataset(tier0Config, "Default",
            tape_node = "T1_US_FNAL_MSS",
            disk_node = "T1_US_FNAL_Disk",
            blockCloseDelay = 24 * 3600,
+           timePerEvent = 5,
+           sizePerEvent = 1500,
            scenario = ppScenario)
 
 ###############################
@@ -168,11 +172,16 @@ addDataset(tier0Config, "Cosmics",
            do_reco = True,
            write_reco = True, write_aod = True, write_miniaod = False, write_dqm = True,
            alca_producers = [ "TkAlCosmics0T", "MuAlGlobalCosmics", "HcalCalHOCosmics", "DtCalibCosmics" ],
+           timePerEvent = 0.5,
+           sizePerEvent = 155,
            scenario = cosmicsScenario)
 
 addDataset(tier0Config, "Commissioning",
            do_reco = True,
            alca_producers = [ "TkAlMinBias", "SiStripCalMinBias" ],
+           dqm_sequences = [ "@common", "@hcal" ],
+           timePerEvent = 12,
+           sizePerEvent = 4000,
            scenario = ppScenario)
 
 datasets = [ "NoBPTX" ]
@@ -211,6 +220,8 @@ for dataset in datasets:
 addDataset(tier0Config, "HcalNZS",
            do_reco = True,
            alca_producers = [ "HcalCalMinBias" ],
+           timePerEvent = 4.2,
+           sizePerEvent = 1900,
            scenario = hcalnzsScenario)
 
 ###########################
@@ -223,6 +234,8 @@ addDataset(tier0Config,"AlCaLumiPixels",
            reco_split = alcarawSplitting,
            proc_version = alcarawProcVersion,
            alca_producers = [ "LumiPixels" ],
+           timePerEvent = 0.02,
+           sizePerEvent = 38,
            scenario = "AlCaLumiPixels")
 
 ########################################################
@@ -237,6 +250,9 @@ for dataset in datasets:
     addDataset(tier0Config, dataset,
                do_reco = True,
                alca_producers = [ "SiStripCalZeroBias", "TkAlMinBias", "LumiPixelsMinBias" ],
+               dqm_sequences = [ "@commonSiStripZeroBias", "@ecal", "@hcal", "@muon" ],
+               timePerEvent = 3.5,
+               sizePerEvent = 1500,
                scenario = ppScenario)
 
 ########################################################
@@ -283,12 +299,51 @@ for dataset in datasets:
 ### 50 ns Physics Menu       ###
 ################################
 
-datasets = [ "BTagCSV", "BTagMu", "DisplacedJet", "DoubleMuonLowMass",
-             "HTMHT", "MuonEG", "Tau" ]
+datasets = [ "BTagCSV", "DisplacedJet" ]
 
 for dataset in datasets:
     addDataset(tier0Config, dataset,
                do_reco = True,
+               tape_node = "T1_ES_PIC_MSS",
+               disk_node = "T1_ES_PIC_Disk",
+               scenario = ppScenario)
+
+datasets = [ "DoubleMuonLowMass", "MuonEG" ]
+
+for dataset in datasets:
+    addDataset(tier0Config, dataset,
+               do_reco = True,
+               tape_node = "T1_FR_IN2P3_MSS",
+               disk_node = "T1_FR_IN2P3_Disk",
+               scenario = ppScenario)
+
+datasets = [ "HTMHT" ]
+
+for dataset in datasets:
+    addDataset(tier0Config, dataset,
+               do_reco = True,
+               tape_node = "T1_UK_RAL_MSS",
+               disk_node = "T1_UK_RAL_Disk",
+               timePerEvent = 9.4,
+               sizePerEvent = 2000,
+               scenario = ppScenario)
+
+datasets = [ "Tau" ]
+
+for dataset in datasets:
+    addDataset(tier0Config, dataset,
+               do_reco = True,
+               tape_node = "T1_US_FNAL_MSS",
+               disk_node = "T1_US_FNAL_Disk",
+               scenario = ppScenario)
+
+datasets = [ "BTagMu" ]
+
+for dataset in datasets:
+    addDataset(tier0Config, dataset,
+               do_reco = True,
+               tape_node = "T1_IT_CNAF_MSS",
+               disk_node = "T1_IT_CNAF_Disk",
                scenario = ppScenario)
 
 datasets = [ "Charmonium" ]
@@ -296,6 +351,8 @@ datasets = [ "Charmonium" ]
 for dataset in datasets:
     addDataset(tier0Config, dataset,
                do_reco = True,
+               tape_node = "T1_DE_KIT_MSS",
+               disk_node = "T1_DE_KIT_Disk",
                alca_producers = [ "TkAlJpsiMuMu" ],
                scenario = ppScenario)
 
@@ -304,7 +361,10 @@ datasets = [ "DoubleEG" ]
 for dataset in datasets:
     addDataset(tier0Config, dataset,
                do_reco = True,
+               tape_node = "T1_US_FNAL_MSS",
+               disk_node = "T1_US_FNAL_Disk",
                alca_producers = [ "EcalCalZElectron", "EcalUncalZElectron", "HcalCalIterativePhiSym" ],
+               dqm_sequences = [ "@common", "@ecal", "@egamma" ],
                scenario = ppScenario)
 
 datasets = [ "SingleMu" ]
@@ -320,7 +380,10 @@ datasets = [ "SingleMuon" ]
 for dataset in datasets:
     addDataset(tier0Config, dataset,
                do_reco = True,
+               tape_node = "T1_US_FNAL_MSS",
+               disk_node = "T1_US_FNAL_Disk",
                alca_producers = [ "TkAlMuonIsolated", "HcalCalIterativePhiSym", "DtCalib", "MuAlCalIsolatedMu", "MuAlOverlaps", "MuAlZMuMu" ],
+               dqm_sequences = [ "@common", "@muon" ],
                scenario = ppScenario)
 
 datasets = [ "DoubleMu" ]
@@ -336,7 +399,10 @@ datasets = [ "DoubleMuon" ]
 for dataset in datasets:
     addDataset(tier0Config, dataset,
                do_reco = True,
+               tape_node = "T1_ES_PIC_MSS",
+               disk_node = "T1_ES_PIC_Disk",
                alca_producers = [ "TkAlZMuMu", "MuAlCalIsolatedMu", "MuAlOverlaps", "MuAlZMuMu", "DtCalib" ],
+               dqm_sequences = [ "@common", "@muon" ],
                scenario = ppScenario)
 
 datasets = [ "JetHT" ]
@@ -344,7 +410,12 @@ datasets = [ "JetHT" ]
 for dataset in datasets:
     addDataset(tier0Config, dataset,
                do_reco = True,
+               tape_node = "T1_IT_CNAF_MSS",
+               disk_node = "T1_IT_CNAF_Disk",
                alca_producers = [ "HcalCalDijets" ],
+               dqm_sequences = [ "@common", "@jetmet", "@hcal" ],
+               timePerEvent = 5.7,
+               sizePerEvent = 2250,
                scenario = ppScenario)
 
 datasets = [ "MET" ]
@@ -352,7 +423,10 @@ datasets = [ "MET" ]
 for dataset in datasets:
     addDataset(tier0Config, dataset,
                do_reco = True,
+               tape_node = "T1_FR_IN2P3_MSS",
+               disk_node = "T1_FR_IN2P3_Disk",
                alca_producers = [ "HcalCalNoise" ],
+               dqm_sequences = [ "@common", "@jetmet", "@hcal" ],
                scenario = ppScenario)
 
 datasets = [ "MuOnia" ]
@@ -360,7 +434,10 @@ datasets = [ "MuOnia" ]
 for dataset in datasets:
     addDataset(tier0Config, dataset,
                do_reco = True,
+               tape_node = "T1_UK_RAL_MSS",
+               disk_node = "T1_UK_RAL_Disk",
                alca_producers = [ "TkAlUpsilonMuMu" ],
+               dqm_sequences = [ "@common", "@muon" ],
                scenario = ppScenario)
 
 datasets = [ "SingleElectron" ]
@@ -368,15 +445,10 @@ datasets = [ "SingleElectron" ]
 for dataset in datasets:
     addDataset(tier0Config, dataset,
                do_reco = True,
+               tape_node = "T1_US_FNAL_MSS",
+               disk_node = "T1_US_FNAL_Disk",
                alca_producers = [ "EcalCalWElectron", "EcalUncalWElectron", "EcalCalZElectron", "EcalUncalZElectron", "HcalCalIterativePhiSym" ],
-               scenario = ppScenario)
-
-datasets = [ "MuOnia" ]
-
-for dataset in datasets:
-    addDataset(tier0Config, dataset,
-               do_reco = True,
-               alca_producers = [ "HcalCalGammaJet" ],
+               dqm_sequences = [ "@common", "@ecal", "@egamma" ],
                scenario = ppScenario)
 
 datasets = [ "TestEnablesEcalHcal" ]
@@ -392,7 +464,18 @@ datasets = [ "SinglePhoton" ]
 for dataset in datasets:
     addDataset(tier0Config, dataset,
                do_reco = True,
+               tape_node = "T1_DE_KIT_MSS",
+               disk_node = "T1_DE_KIT_Disk",
                alca_producers = [ "HcalCalGammaJet" ],
+               dqm_sequences = [ "@common", "@ecal", "@egamma" ],
+               scenario = ppScenario)
+
+datasets = [ "DoublePhoton" ]
+
+for dataset in datasets:
+    addDataset(tier0Config, dataset,
+               do_reco = True,
+               dqm_sequences = [ "@common", "@ecal", "@egamma" ],
                scenario = ppScenario)
 
 datasets = [ "HINPFJet100", "HINCaloJet100", "HighMultiplicity" ]
@@ -435,6 +518,8 @@ addExpressConfig(tier0Config, "Express",
                  maxLatency = 15 * 23,
                  periodicHarvestInterval = 20 * 60,
                  blockCloseDelay = 1200,
+                 timePerEvent = 4,
+                 sizePerEvent = 1700,
                  versionOverride = expressVersionOverride)
 
 addExpressConfig(tier0Config, "ExpressCosmics",
@@ -454,6 +539,29 @@ addExpressConfig(tier0Config, "ExpressCosmics",
                  maxLatency = 15 * 23,
                  periodicHarvestInterval = 20 * 60,
                  blockCloseDelay = 1200,
+                 timePerEvent = 4, #I have to get some stats to set this properly
+                 sizePerEvent = 1700, #I have to get some stats to set this properly
+                 versionOverride = expressVersionOverride)
+
+addExpressConfig(tier0Config, "HLTMonitor",
+                 scenario = ppScenario,
+                 data_tiers = [ "FEVTHLTALL" ],
+                 write_dqm = True,
+                 alca_producers = [],
+                 dqm_sequences = [ "@HLTMon" ],
+                 reco_version = defaultCMSSWVersion,
+                 global_tag_connect = globalTagConnect,
+                 global_tag = expressGlobalTag,
+                 proc_ver = expressProcVersion,
+                 maxInputRate = 23 * 1000,
+                 maxInputEvents = 400,
+                 maxInputSize = 2 * 1024 * 1024 * 1024,
+                 maxInputFiles = 15,
+                 maxLatency = 15 * 23,
+                 periodicHarvestInterval = 20 * 60,
+                 blockCloseDelay = 1200,
+                 timePerEvent = 4, #I have to get some stats to set this properly
+                 sizePerEvent = 1700, #I have to get some stats to set this properly
                  versionOverride = expressVersionOverride)
 
 #######################

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -77,7 +77,7 @@ setPromptCalibrationConfig(tier0Config,
                            validationMode = True)
 
 # Defaults for CMSSW version
-defaultCMSSWVersion = "CMSSW_7_4_7_patch2"
+defaultCMSSWVersion = "CMSSW_7_4_8_patch1"
 
 # Configure ScramArch
 setDefaultScramArch(tier0Config, "slc6_amd64_gcc491")
@@ -85,7 +85,7 @@ setScramArch(tier0Config, "CMSSW_5_3_20", "slc6_amd64_gcc472")
 
 # Configure scenarios
 #ppScenario = "ppRun2"
-ppScenario = "ppRun2B0T"
+ppScenario = "ppRun2"
 cosmicsScenario = "cosmicsRun2"
 hcalnzsScenario = "hcalnzsRun2"
 
@@ -96,7 +96,7 @@ expressProcVersion = 1
 alcarawProcVersion = 1
 
 # Defaults for GlobalTag
-expressGlobalTag = "74X_dataRun2_Express_v0"
+expressGlobalTag = "74X_dataRun2_Express_v1"
 promptrecoGlobalTag = "74X_dataRun2_Prompt_v1"
 alcap0GlobalTag = "74X_dataRun2_Prompt_v1"
 
@@ -115,20 +115,22 @@ alcarawSplitting = 20000 * numberOfCores
 # Setup repack and express mappings
 #
 repackVersionOverride = {
-    "CMSSW_7_4_2" : "CMSSW_7_4_7_patch2",
-    "CMSSW_7_4_3" : "CMSSW_7_4_7_patch2",
-    "CMSSW_7_4_4" : "CMSSW_7_4_7_patch2",
-    "CMSSW_7_4_5" : "CMSSW_7_4_7_patch2",
-    "CMSSW_7_4_6" : "CMSSW_7_4_7_patch2",
-    "CMSSW_7_4_7" : "CMSSW_7_4_7_patch2",
+    "CMSSW_7_4_2" : "CMSSW_7_4_8_patch1",
+    "CMSSW_7_4_3" : "CMSSW_7_4_8_patch1",
+    "CMSSW_7_4_4" : "CMSSW_7_4_8_patch1",
+    "CMSSW_7_4_5" : "CMSSW_7_4_8_patch1",
+    "CMSSW_7_4_6" : "CMSSW_7_4_8_patch1",
+    "CMSSW_7_4_7" : "CMSSW_7_4_8_patch1",
+    "CMSSW_7_4_8" : "CMSSW_7_4_8_patch1",
     }
 expressVersionOverride = {
-    "CMSSW_7_4_2" : "CMSSW_7_4_7_patch2",
-    "CMSSW_7_4_3" : "CMSSW_7_4_7_patch2",
-    "CMSSW_7_4_4" : "CMSSW_7_4_7_patch2",
-    "CMSSW_7_4_5" : "CMSSW_7_4_7_patch2",
-    "CMSSW_7_4_6" : "CMSSW_7_4_7_patch2",
-    "CMSSW_7_4_7" : "CMSSW_7_4_7_patch2",
+    "CMSSW_7_4_2" : "CMSSW_7_4_8_patch1",
+    "CMSSW_7_4_3" : "CMSSW_7_4_8_patch1",
+    "CMSSW_7_4_4" : "CMSSW_7_4_8_patch1",
+    "CMSSW_7_4_5" : "CMSSW_7_4_8_patch1",
+    "CMSSW_7_4_6" : "CMSSW_7_4_8_patch1",
+    "CMSSW_7_4_7" : "CMSSW_7_4_8_patch1",
+    "CMSSW_7_4_8" : "CMSSW_7_4_8_patch1",
     }
 
 #set default repack settings for bulk streams
@@ -160,6 +162,8 @@ addDataset(tier0Config, "Default",
 #           tape_node = "T1_US_FNAL_MSS",
 #           disk_node = "T1_CH_FNAL_Disk",
            blockCloseDelay = 1200,
+           timePerEvent = 5,
+           sizePerEvent = 1500,
            scenario = ppScenario)
 
 
@@ -171,11 +175,16 @@ addDataset(tier0Config, "Cosmics",
            do_reco = True,
            write_reco = True, write_aod = True, write_miniaod = False, write_dqm = True,
            alca_producers = [ "TkAlCosmics0T", "MuAlGlobalCosmics", "HcalCalHOCosmics", "DtCalibCosmics" ],
+           timePerEvent = 0.5,
+           sizePerEvent = 155,
            scenario = cosmicsScenario)
 
 addDataset(tier0Config, "Commissioning",
            do_reco = True,
            alca_producers = [ "TkAlMinBias", "SiStripCalMinBias" ],
+           dqm_sequences = [ "@common", "@hcal" ],
+           timePerEvent = 12,
+           sizePerEvent = 4000,
            scenario = ppScenario)
 
 datasets = [ "NoBPTX" ]
@@ -214,6 +223,8 @@ for dataset in datasets:
 addDataset(tier0Config, "HcalNZS",
            do_reco = True,
            alca_producers = [ "HcalCalMinBias" ],
+           timePerEvent = 4.2,
+           sizePerEvent = 1900,
            scenario = hcalnzsScenario)
 
 ###########################
@@ -226,6 +237,8 @@ addDataset(tier0Config,"AlCaLumiPixels",
            reco_split = alcarawSplitting,
            proc_version = alcarawProcVersion,
            alca_producers = [ "LumiPixels" ],
+           timePerEvent = 0.02,
+           sizePerEvent = 38,
            scenario = "AlCaLumiPixels")
 
 ########################################################
@@ -240,6 +253,9 @@ for dataset in datasets:
     addDataset(tier0Config, dataset,
                do_reco = True,
                alca_producers = [ "SiStripCalZeroBias", "TkAlMinBias", "LumiPixelsMinBias" ],
+               dqm_sequences = [ "@commonSiStripZeroBias", "@ecal", "@hcal", "@muon" ],
+               timePerEvent = 3.5,
+               sizePerEvent = 1500,
                scenario = ppScenario)
 
 ########################################################
@@ -286,8 +302,37 @@ for dataset in datasets:
 ### 50 ns Physics Menu       ###
 ################################
 
-datasets = [ "BTagCSV", "BTagMu", "DisplacedJet", "DoubleMuonLowMass",
-             "HTMHT", "MuonEG", "Tau" ]
+datasets = [ "BTagCSV", "DisplacedJet" ]
+
+for dataset in datasets:
+    addDataset(tier0Config, dataset,
+               do_reco = True,
+               scenario = ppScenario)
+
+datasets = [ "DoubleMuonLowMass", "MuonEG" ]
+
+for dataset in datasets:
+    addDataset(tier0Config, dataset,
+               do_reco = True,
+               scenario = ppScenario)
+
+datasets = [ "HTMHT" ]
+
+for dataset in datasets:
+    addDataset(tier0Config, dataset,
+               do_reco = True,
+               timePerEvent = 9.4,
+               sizePerEvent = 2000,
+               scenario = ppScenario)
+
+datasets = [ "Tau" ]
+
+for dataset in datasets:
+    addDataset(tier0Config, dataset,
+               do_reco = True,
+               scenario = ppScenario)
+
+datasets = [ "BTagMu" ]
 
 for dataset in datasets:
     addDataset(tier0Config, dataset,
@@ -308,6 +353,7 @@ for dataset in datasets:
     addDataset(tier0Config, dataset,
                do_reco = True,
                alca_producers = [ "EcalCalZElectron", "EcalUncalZElectron", "HcalCalIterativePhiSym" ],
+               dqm_sequences = [ "@common", "@ecal", "@egamma" ],
                scenario = ppScenario)
 
 datasets = [ "SingleMu" ]
@@ -324,6 +370,7 @@ for dataset in datasets:
     addDataset(tier0Config, dataset,
                do_reco = True,
                alca_producers = [ "TkAlMuonIsolated", "HcalCalIterativePhiSym", "DtCalib", "MuAlCalIsolatedMu", "MuAlOverlaps", "MuAlZMuMu" ],
+               dqm_sequences = [ "@common", "@muon" ],
                scenario = ppScenario)
 
 datasets = [ "DoubleMu" ]
@@ -340,6 +387,7 @@ for dataset in datasets:
     addDataset(tier0Config, dataset,
                do_reco = True,
                alca_producers = [ "TkAlZMuMu", "MuAlCalIsolatedMu", "MuAlOverlaps", "MuAlZMuMu", "DtCalib" ],
+               dqm_sequences = [ "@common", "@muon" ],
                scenario = ppScenario)
 
 datasets = [ "JetHT" ]
@@ -348,6 +396,9 @@ for dataset in datasets:
     addDataset(tier0Config, dataset,
                do_reco = True,
                alca_producers = [ "HcalCalDijets" ],
+               dqm_sequences = [ "@common", "@jetmet", "@hcal" ],
+               timePerEvent = 5.7,
+               sizePerEvent = 2250,
                scenario = ppScenario)
 
 datasets = [ "MET" ]
@@ -356,6 +407,7 @@ for dataset in datasets:
     addDataset(tier0Config, dataset,
                do_reco = True,
                alca_producers = [ "HcalCalNoise" ],
+               dqm_sequences = [ "@common", "@jetmet", "@hcal" ],
                scenario = ppScenario)
 
 datasets = [ "MuOnia" ]
@@ -364,6 +416,7 @@ for dataset in datasets:
     addDataset(tier0Config, dataset,
                do_reco = True,
                alca_producers = [ "TkAlUpsilonMuMu" ],
+               dqm_sequences = [ "@common", "@muon" ],
                scenario = ppScenario)
 
 datasets = [ "SingleElectron" ]
@@ -372,14 +425,7 @@ for dataset in datasets:
     addDataset(tier0Config, dataset,
                do_reco = True,
                alca_producers = [ "EcalCalWElectron", "EcalUncalWElectron", "EcalCalZElectron", "EcalUncalZElectron", "HcalCalIterativePhiSym" ],
-               scenario = ppScenario)
-
-datasets = [ "MuOnia" ]
-
-for dataset in datasets:
-    addDataset(tier0Config, dataset,
-               do_reco = True,
-               alca_producers = [ "HcalCalGammaJet" ],
+               dqm_sequences = [ "@common", "@ecal", "@egamma" ],
                scenario = ppScenario)
 
 datasets = [ "TestEnablesEcalHcal" ]
@@ -396,6 +442,15 @@ for dataset in datasets:
     addDataset(tier0Config, dataset,
                do_reco = True,
                alca_producers = [ "HcalCalGammaJet" ],
+               dqm_sequences = [ "@common", "@ecal", "@egamma" ],
+               scenario = ppScenario)
+
+datasets = [ "DoublePhoton" ]
+
+for dataset in datasets:
+    addDataset(tier0Config, dataset,
+               do_reco = True,
+               dqm_sequences = [ "@common", "@ecal", "@egamma" ],
                scenario = ppScenario)
 
 datasets = [ "HINPFJet100", "HINCaloJet100", "HighMultiplicity" ]
@@ -438,6 +493,8 @@ addExpressConfig(tier0Config, "Express",
                  maxLatency = 15 * 23,
                  periodicHarvestInterval = 20 * 60,
                  blockCloseDelay = 1200,
+                 timePerEvent = 4,
+                 sizePerEvent = 1700,
                  versionOverride = expressVersionOverride)
 
 addExpressConfig(tier0Config, "ExpressCosmics",
@@ -457,6 +514,29 @@ addExpressConfig(tier0Config, "ExpressCosmics",
                  maxLatency = 15 * 23,
                  periodicHarvestInterval = 20 * 60,
                  blockCloseDelay = 1200,
+                 timePerEvent = 4, #I have to get some stats to set this properly
+                 sizePerEvent = 1700, #I have to get some stats to set this properly
+                 versionOverride = expressVersionOverride)
+
+addExpressConfig(tier0Config, "HLTMonitor",
+                 scenario = ppScenario,
+                 data_tiers = [ "FEVTHLTALL" ],
+                 write_dqm = True,
+                 alca_producers = [],
+                 dqm_sequences = [ "@HLTMon" ],
+                 reco_version = defaultCMSSWVersion,
+                 global_tag_connect = globalTagConnect,
+                 global_tag = expressGlobalTag,
+                 proc_ver = expressProcVersion,
+                 maxInputRate = 23 * 1000,
+                 maxInputEvents = 400,
+                 maxInputSize = 2 * 1024 * 1024 * 1024,
+                 maxInputFiles = 15,
+                 maxLatency = 15 * 23,
+                 periodicHarvestInterval = 20 * 60,
+                 blockCloseDelay = 1200,
+                 timePerEvent = 4, #I have to get some stats to set this properly
+                 sizePerEvent = 1700, #I have to get some stats to set this properly
                  versionOverride = expressVersionOverride)
 
 #######################

--- a/etc/ReplayOfflineConfigurationRun1.py
+++ b/etc/ReplayOfflineConfigurationRun1.py
@@ -77,7 +77,7 @@ setPromptCalibrationConfig(tier0Config,
                            validationMode = True)
 
 # Defaults for CMSSW version
-defaultCMSSWVersion = "CMSSW_7_4_7_patch2"
+defaultCMSSWVersion = "CMSSW_7_4_8_patch1"
 
 # Configure ScramArch
 setDefaultScramArch(tier0Config, "slc6_amd64_gcc491")
@@ -94,7 +94,7 @@ expressProcVersion = 1
 alcarawProcVersion = 1
 
 # Defaults for GlobalTag
-expressGlobalTag = "74X_dataRun2_Express_v0"
+expressGlobalTag = "74X_dataRun2_Express_v1"
 promptrecoGlobalTag = "74X_dataRun2_Prompt_v1"
 alcap0GlobalTag = "74X_dataRun2_Prompt_v1"
 
@@ -158,6 +158,8 @@ addDataset(tier0Config, "Default",
 #           tape_node = "T1_US_FNAL_MSS",
 #           disk_node = "T1_CH_FNAL_Disk",
            blockCloseDelay = 1200,
+           timePerEvent = 5,
+           sizePerEvent = 1500,
            scenario = ppScenario)
 
 ###############################
@@ -177,6 +179,8 @@ addDataset(tier0Config, "Cosmics",
 #           tape_node = "T1_US_FNAL_MSS",
 #           disk_node = "T1_US_FNAL_Disk",
 #           siteWhitelist = [ "T1_US_FNAL_Disk" ],
+           timePerEvent = 0.5,
+           sizePerEvent = 155,
            scenario = cosmicsScenario)
 addDataset(tier0Config, "JetHT",
            do_reco = True,
@@ -273,6 +277,8 @@ addDataset(tier0Config,"AlCaLumiPixels",
            write_reco = False, write_aod = False, write_miniaod = False, write_dqm = True,
            reco_split = alcarawSplitting,
            proc_version = alcarawProcVersion,
+           timePerEvent = 0.02,
+           sizePerEvent = 38,
            scenario = "AlCaLumiPixels")
 
 
@@ -441,6 +447,8 @@ addExpressConfig(tier0Config, "HIExpress",
                  maxLatency = 15 * 23,
                  periodicHarvestInterval = 20 * 60,
                  blockCloseDelay = 1200,
+                 timePerEvent = 4,
+                 sizePerEvent = 1700,
                  versionOverride = expressVersionOverride)
 
 addExpressConfig(tier0Config, "Express",
@@ -459,6 +467,8 @@ addExpressConfig(tier0Config, "Express",
                  maxLatency = 15 * 23,
                  periodicHarvestInterval = 20 * 60,
                  blockCloseDelay = 1200,
+                 timePerEvent = 4,
+                 sizePerEvent = 1700,
                  versionOverride = expressVersionOverride)
 
 addExpressConfig(tier0Config, "ExpressCosmics",
@@ -477,6 +487,8 @@ addExpressConfig(tier0Config, "ExpressCosmics",
                  maxLatency = 15 * 23,
                  periodicHarvestInterval = 20 * 60,
                  blockCloseDelay = 1200,
+                 timePerEvent = 4,
+                 sizePerEvent = 1700,
                  versionOverride = expressVersionOverride)
 
 #addExpressConfig(tier0Config, "HLTMON",


### PR DESCRIPTION
- CMSSW_7_4_8_patch1
- New Express GT 74X_dataRun2_Express_v1
- DQM sequences updated
- HLTMonitor dataset added
- Time and Size per event estimates
- Add T1 subsciptions
- Use T2_CH_CERN_AI resources
- AcqEra to Run2015C
- Ignore HLTMonitor stream