### PR TITLE
remove TFC override

### DIFF
--- a/src/python/T0/RunConfig/RunConfigAPI.py
+++ b/src/python/T0/RunConfig/RunConfigAPI.py
@@ -567,7 +567,6 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
             specArguments['RunNumber'] = run
             specArguments['AcquisitionEra'] = tier0Config.Global.AcquisitionEra
             specArguments['Outputs'] = outputModuleDetails
-            specArguments['OverrideCatalog'] = "trivialcatalog_file:/cvmfs/cms.cern.ch/SITECONF/T2_CH_CERN/Tier0/override_catalog.xml?protocol=override"
             specArguments['ValidStatus'] = "VALID"
 
             specArguments['SiteWhitelist'] = [ "T2_CH_CERN_T0" ]


### PR DESCRIPTION
We currently include T2_CH_CERN/Tier0/override_catalog.xml to make sure we read streamer files from castor. Remove this, streamer will be read from EOS now.