### PR TITLE
do not subscribe express data anywhere by default

### DIFF
--- a/src/python/T0/RunConfig/Tier0Config.py
+++ b/src/python/T0/RunConfig/Tier0Config.py
@@ -224,12 +224,12 @@ def createTier0Config():
     tier0Config.Global.ScramArches = {}
     tier0Config.Global.Backfill = None
 
-    tier0Config.Global.ProcessingSite = "T2_CH_CERN_T0"
+    tier0Config.Global.ProcessingSite = "T2_CH_CERN_AI"
 
-    tier0Config.Global.BulkInjectNode = "T2_CH_CERN"
-    tier0Config.Global.ExpressInjectNode = "T2_CH_CERN"
+    tier0Config.Global.BulkInjectNode = "T0_CH_CERN_Disk"
+    tier0Config.Global.ExpressInjectNode = "T0_CH_CERN_Disk"
 
-    tier0Config.Global.ExpressSubscribeNode = "T2_CH_CERN"
+    tier0Config.Global.ExpressSubscribeNode = None
 
     tier0Config.Global.DQMDataTier = "DQMIO"
 

--- a/src/python/T0/WMBS/Oracle/RunConfig/GetRunInfo.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/GetRunInfo.py
@@ -33,7 +33,7 @@ class GetRunInfo(DBFormatter):
                    bulk_inject.id = run.bulk_inject
                  INNER JOIN storage_node express_inject ON
                    express_inject.id = run.express_inject
-                 INNER JOIN storage_node express_subscribe ON
+                 LEFT OUTER JOIN storage_node express_subscribe ON
                    express_subscribe.id = run.express_subscribe
                  WHERE run.run_id = :RUN
                  """


### PR DESCRIPTION
For replays we want to keep all data on the production buffer T0_CH_CERN_Disk and not subscribed anywhere.