### PR TITLE
complete express and reco config, also in t0wmadatasvc

### DIFF
--- a/src/python/T0/RunConfig/RunConfigAPI.py
+++ b/src/python/T0/RunConfig/RunConfigAPI.py
@@ -725,6 +725,10 @@ def releasePromptReco(tier0Config, specDirectory, dqmUploadProxy):
             if len(datasetConfig.AlcaSkims) > 0:
                 alcaSkim = ",".join(datasetConfig.AlcaSkims)
 
+            physicsSkim = None
+            if len(datasetConfig.PhysicsSkims) > 0:
+                physicsSkim = ",".join(datasetConfig.PhysicsSkims)
+
             dqmSeq = None
             if len(datasetConfig.DqmSequences) > 0:
                 dqmSeq = ",".join(datasetConfig.DqmSequences)
@@ -742,6 +746,7 @@ def releasePromptReco(tier0Config, specDirectory, dqmUploadProxy):
                                       'WRITE_MINIAOD' : int(datasetConfig.WriteMINIAOD),
                                       'PROC_VER' : datasetConfig.ProcessingVersion,
                                       'ALCA_SKIM' : alcaSkim,
+                                      'PHYSICS_SKIM' : physicsSkim,
                                       'DQM_SEQ' : dqmSeq,
                                       'BLOCK_DELAY' : datasetConfig.BlockCloseDelay,
                                       'CMSSW' : datasetConfig.CMSSWVersion,
@@ -786,6 +791,24 @@ def releasePromptReco(tier0Config, specDirectory, dqmUploadProxy):
                                                 'primaryDataset' : dataset,
                                                 'deleteFromSource' : True,
                                                 'dataTier' : "ALCARECO" } )
+
+                    if len(datasetConfig.PhysicsSkims) > 0:
+                        subscriptions.append( { 'custodialSites' : [phedexConfig['tape_node']],
+                                                'custodialSubType' : "Replica",
+                                                'nonCustodialSites' : [phedexConfig['disk_node']],
+                                                'autoApproveSites' : [phedexConfig['disk_node']],
+                                                'priority' : "high",
+                                                'primaryDataset' : dataset,
+                                                'deleteFromSource' : True,
+                                                'dataTier' : "RAW-RECO" } )
+                        subscriptions.append( { 'custodialSites' : [phedexConfig['tape_node']],
+                                                'custodialSubType' : "Replica",
+                                                'nonCustodialSites' : [phedexConfig['disk_node']],
+                                                'autoApproveSites' : [phedexConfig['disk_node']],
+                                                'priority' : "high",
+                                                'primaryDataset' : dataset,
+                                                'deleteFromSource' : True,
+                                                'dataTier' : "USER" } )
 
                     if datasetConfig.WriteDQM:
                         subscriptions.append( { 'custodialSites' : [phedexConfig['tape_node']],
@@ -837,6 +860,24 @@ def releasePromptReco(tier0Config, specDirectory, dqmUploadProxy):
                                                 'primaryDataset' : dataset,
                                                 'deleteFromSource' : True,
                                                 'dataTier' : "ALCARECO" } )
+
+                    if len(datasetConfig.PhysicsSkims) > 0:
+                        subscriptions.append( { 'custodialSites' : [phedexConfig['archival_node']],
+                                                'custodialSubType' : "Replica",
+                                                'nonCustodialSites' : [],
+                                                'autoApproveSites' : [phedexConfig['archival_node']],
+                                                'priority' : "high",
+                                                'primaryDataset' : dataset,
+                                                'deleteFromSource' : True,
+                                                'dataTier' : "RAW-RECO" } )
+                        subscriptions.append( { 'custodialSites' : [phedexConfig['archival_node']],
+                                                'custodialSubType' : "Replica",
+                                                'nonCustodialSites' : [],
+                                                'autoApproveSites' : [phedexConfig['archival_node']],
+                                                'priority' : "high",
+                                                'primaryDataset' : dataset,
+                                                'deleteFromSource' : True,
+                                                'dataTier' : "USER" } )
 
                     if datasetConfig.WriteDQM:
                         subscriptions.append( { 'custodialSites' : [phedexConfig['archival_node']],

--- a/src/python/T0/WMBS/Oracle/Create.py
+++ b/src/python/T0/WMBS/Oracle/Create.py
@@ -279,8 +279,8 @@ class Create(DBCreator):
                  reco_cmssw_id   int,
                  multicore       int,
                  reco_scram_arch varchar2(50),
-                 alca_skim       varchar2(1000),
-                 dqm_seq         varchar2(1000),
+                 alca_skim       varchar2(700),
+                 dqm_seq         varchar2(700),
                  primary key (run_id, stream_id)
                ) ORGANIZATION INDEX"""
 
@@ -319,8 +319,9 @@ class Create(DBCreator):
                  scram_arch     varchar2(50)   not null,
                  global_tag     varchar2(255)  not null,
                  multicore      int,
-                 alca_skim      varchar2(1000),
-                 dqm_seq        varchar2(1000),
+                 alca_skim      varchar2(700),
+                 physics_skim   varchar2(700),
+                 dqm_seq        varchar2(700),
                  primary key (run_id, primds_id)
                ) ORGANIZATION INDEX"""
 

--- a/src/python/T0/WMBS/Oracle/RunConfig/InsertRecoConfig.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/InsertRecoConfig.py
@@ -13,8 +13,8 @@ class InsertRecoConfig(DBFormatter):
 
         sql = """INSERT INTO reco_config
                  (RUN_ID, PRIMDS_ID, DO_RECO, RECO_SPLIT, WRITE_RECO, WRITE_DQM,
-                  WRITE_AOD, WRITE_MINIAOD, PROC_VERSION, ALCA_SKIM, DQM_SEQ,
-                  BLOCK_DELAY, CMSSW_ID, MULTICORE, SCRAM_ARCH, GLOBAL_TAG)
+                  WRITE_AOD, WRITE_MINIAOD, PROC_VERSION, ALCA_SKIM, PHYSICS_SKIM,
+                  DQM_SEQ, BLOCK_DELAY, CMSSW_ID, MULTICORE, SCRAM_ARCH, GLOBAL_TAG)
                  VALUES (:RUN,
                          (SELECT id FROM primary_dataset WHERE name = :PRIMDS),
                          :DO_RECO,
@@ -25,6 +25,7 @@ class InsertRecoConfig(DBFormatter):
                          :WRITE_MINIAOD,
                          :PROC_VER,
                          :ALCA_SKIM,
+                         :PHYSICS_SKIM,
                          :DQM_SEQ,
                          :BLOCK_DELAY,
                          (SELECT id FROM cmssw_version WHERE name = :CMSSW),

--- a/src/python/T0/WMBS/Oracle/T0DataSvc/GetExpressConfigs.py
+++ b/src/python/T0/WMBS/Oracle/T0DataSvc/GetExpressConfigs.py
@@ -19,6 +19,8 @@ class GetExpressConfigs(DBFormatter):
                         express_config.scram_arch AS scram_arch,
                         reco_version.name AS reco_cmssw,
                         express_config.reco_scram_arch AS reco_scram_arch,
+                        express_config.alca_skim AS alca_skim,
+                        express_config.dqm_seq AS dqm_seq,
                         express_config.global_tag AS global_tag,
                         event_scenario.name AS scenario
                  FROM express_config

--- a/src/python/T0/WMBS/Oracle/T0DataSvc/GetRecoConfigs.py
+++ b/src/python/T0/WMBS/Oracle/T0DataSvc/GetRecoConfigs.py
@@ -17,6 +17,9 @@ class GetRecoConfigs(DBFormatter):
                         primary_dataset.name AS primds,
                         cmssw_version.name AS cmssw,
                         reco_config.scram_arch AS scram_arch,
+                        reco_config.alca_skim AS alca_skim,
+                        reco_config.physics_skim AS physics_skim,
+                        reco_config.dqm_seq AS dqm_seq,
                         reco_config.global_tag AS global_tag,
                         event_scenario.name AS scenario
                  FROM reco_config

--- a/src/python/T0/WMBS/Oracle/T0DataSvc/InsertExpressConfigs.py
+++ b/src/python/T0/WMBS/Oracle/T0DataSvc/InsertExpressConfigs.py
@@ -20,12 +20,15 @@ class InsertExpressConfigs(DBFormatter):
                               scram_arch = :SCRAM_ARCH,
                               reco_cmssw = :RECO_CMSSW,
                               reco_scram_arch = :RECO_SCRAM_ARCH,
+                              alca_skim = :ALCA_SKIM,
+                              dqm_seq = :DQM_SEQ,
+                              global_tag = :GLOBAL_TAG,
                               scenario = :SCENARIO
                  WHEN NOT MATCHED THEN
-                   INSERT (run, stream, cmssw, scram_arch, reco_cmssw,
-                           reco_scram_arch, global_tag, scenario)
-                   VALUES (:RUN, :STREAM, :CMSSW, :SCRAM_ARCH, :RECO_CMSSW,
-                           :RECO_SCRAM_ARCH, :GLOBAL_TAG, :SCENARIO)
+                   INSERT (run, stream, cmssw, scram_arch, reco_cmssw, reco_scram_arch,
+                           alca_skim, dqm_seq, global_tag, scenario)
+                   VALUES (:RUN, :STREAM, :CMSSW, :SCRAM_ARCH, :RECO_CMSSW, :RECO_SCRAM_ARCH,
+                           :ALCA_SKIM, :DQM_SEQ, :GLOBAL_TAG, :SCENARIO)
                  """
 
         self.dbi.processData(sql, binds, conn = conn,

--- a/src/python/T0/WMBS/Oracle/T0DataSvc/InsertRecoConfigs.py
+++ b/src/python/T0/WMBS/Oracle/T0DataSvc/InsertRecoConfigs.py
@@ -18,12 +18,17 @@ class InsertRecoConfigs(DBFormatter):
                  WHEN MATCHED THEN
                    UPDATE SET cmssw = :CMSSW,
                               scram_arch = :SCRAM_ARCH,
+                              alca_skim = :ALCA_SKIM,
+                              physics_skim = :PHYSICS_SKIM,
+                              dqm_seq = :DQM_SEQ,
                               global_tag = :GLOBAL_TAG,
                               scenario = :SCENARIO
                  WHEN NOT MATCHED THEN
                    INSERT (run, primds, cmssw, scram_arch,
+                           alca_skim, physics_skim, dqm_seq,
                            global_tag, scenario)
                    VALUES (:RUN, :PRIMDS, :CMSSW, :SCRAM_ARCH,
+                           :ALCA_SKIM, :PHYSICS_SKIM, :DQM_SEQ,
                            :GLOBAL_TAG, :SCENARIO)
                  """
 

--- a/src/python/T0Component/Tier0Feeder/Tier0FeederPoller.py
+++ b/src/python/T0Component/Tier0Feeder/Tier0FeederPoller.py
@@ -408,6 +408,8 @@ class Tier0FeederPoller(BaseWorkerThread):
                                       'SCRAM_ARCH' : config['scram_arch'],
                                       'RECO_CMSSW' : config['reco_cmssw'],
                                       'RECO_SCRAM_ARCH' : config['reco_scram_arch'],
+                                      'ALCA_SKIM' : config['alca_skim'],
+                                      'DQM_SEQ' : config['dqm_seq'],
                                       'GLOBAL_TAG' : config['global_tag'][:50],
                                       'SCENARIO' : config['scenario'] } )
                 bindsUpdate.append( { 'RUN' : config['run'],
@@ -442,6 +444,9 @@ class Tier0FeederPoller(BaseWorkerThread):
                                       'PRIMDS' : config['primds'],
                                       'CMSSW' : config['cmssw'],
                                       'SCRAM_ARCH' : config['scram_arch'],
+                                      'ALCA_SKIM' : config['alca_skim'],
+                                      'PHYSICS_SKIM' : config['physics_skim'],
+                                      'DQM_SEQ' : config['dqm_seq'],
                                       'GLOBAL_TAG' : config['global_tag'][:50],
                                       'SCENARIO' : config['scenario'] } )
                 bindsUpdate.append( { 'RUN' : config['run'],


### PR DESCRIPTION
Add physics_skim to the reco_config in t0ast. Add alca_skim and dqm_seq to the express_config in t0wmadatasvc. Add alca_skim, physics_skim and dqm_seq to the reco_config in t0wmadatasvc.

Also add subscriptions for RAW-RECO and USER data tiers for PromptReco output (same as for AOD, so tape and disk at T1). These are for the PhysicsSkims.