### PR TITLE
forward run/stream processing completion into t0wmadatasvc

### DIFF
--- a/src/python/T0/RunConfig/RunConfigAPI.py
+++ b/src/python/T0/RunConfig/RunConfigAPI.py
@@ -189,6 +189,8 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
             if len(datasets) == 0:
                 raise RuntimeError("Stream is not defined in HLT menu or has no datasets !")
 
+        # write run/stream processing completion record
+        insertRunStreamDoneDAO = daoFactory(classname = "RunConfig.InsertRunStreamDone")
 
         # write stream/dataset mapping (for special express and error datasets)
         insertDatasetDAO = daoFactory(classname = "RunConfig.InsertPrimaryDataset")
@@ -208,6 +210,8 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
         insertStorageNodeDAO = daoFactory(classname = "RunConfig.InsertStorageNode")
         insertPhEDExConfigDAO = daoFactory(classname = "RunConfig.InsertPhEDExConfig")
 
+        bindsRunStreamDone = {'RUN' : run,
+                              'STREAM' : stream}
         bindsCMSSWVersion = []
         bindsDataset = []
         bindsStreamDataset = []
@@ -625,6 +629,7 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
                 insertStorageNodeDAO.execute(bindsStorageNode, conn = myThread.transaction.conn, transaction = True)
             if len(bindsPhEDExConfig) > 0:
                 insertPhEDExConfigDAO.execute(bindsPhEDExConfig, conn = myThread.transaction.conn, transaction = True)
+            insertRunStreamDoneDAO.execute(bindsRunStreamDone, conn = myThread.transaction.conn, transaction = True)
             insertStreamStyleDAO.execute(bindsStreamStyle, conn = myThread.transaction.conn, transaction = True)
             if streamConfig.ProcessingStyle in [ 'Bulk', 'Express' ]:
                 insertStreamFilesetDAO.execute(run, stream, filesetName, conn = myThread.transaction.conn, transaction = True)

--- a/src/python/T0/WMBS/Oracle/Create.py
+++ b/src/python/T0/WMBS/Oracle/Create.py
@@ -179,6 +179,14 @@ class Create(DBCreator):
                )"""
 
         self.create[len(self.create)] = \
+            """CREATE TABLE run_stream_done (
+                 run_id      int not null,
+                 stream_id   int not null,
+                 in_datasvc  int default 0 not null,
+                 primary key(run_id, stream_id)
+               )"""
+
+        self.create[len(self.create)] = \
             """CREATE TABLE reco_release_config (
                  run_id         int not null,
                  primds_id      int not null,
@@ -428,6 +436,9 @@ class Create(DBCreator):
             """CREATE INDEX idx_run_primds_stream_1 ON run_primds_stream_assoc (run_id, stream_id)"""
 
         self.indexes[len(self.indexes)] = \
+            """CREATE INDEX idx_run_stream_done_1 ON run_stream_done (checkForZeroOneState(in_datasvc))"""
+
+        self.indexes[len(self.indexes)] = \
             """CREATE INDEX idx_reco_release_config_2 ON reco_release_config (checkForZeroOneState(in_datasvc))"""
 
         self.indexes[len(self.indexes)] = \
@@ -600,6 +611,18 @@ class Create(DBCreator):
                  FOREIGN KEY (fileset)
                  REFERENCES wmbs_fileset(id)
                  ON DELETE CASCADE"""
+
+        self.constraints[len(self.constraints)] = \
+            """ALTER TABLE run_stream_done
+                 ADD CONSTRAINT run_str_don_run_id_fk
+                 FOREIGN KEY (run_id)
+                 REFERENCES run(run_id)"""
+
+        self.constraints[len(self.constraints)] = \
+            """ALTER TABLE run_stream_done
+                 ADD CONSTRAINT run_str_don_str_id_fk
+                 FOREIGN KEY (stream_id)
+                 REFERENCES stream(id)"""
 
         self.constraints[len(self.constraints)] = \
             """ALTER TABLE reco_release_config

--- a/src/python/T0/WMBS/Oracle/RunConfig/InsertRunStreamDone.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/InsertRunStreamDone.py
@@ -1,0 +1,25 @@
+"""
+_InsertRunStreamDone_
+
+Oracle implementation of InsertRunStreamDone
+
+Insert RunStreamDone record
+
+"""
+
+from WMCore.Database.DBFormatter import DBFormatter
+
+class InsertRunStreamDone(DBFormatter):
+
+    def execute(self, binds, conn = None, transaction = False):
+
+        sql = """INSERT INTO run_stream_done
+                 (run_id, stream_id)
+                 VALUES (:RUN,
+                         (SELECT id FROM stream WHERE name = :STREAM))
+                 """
+
+        self.dbi.processData(sql, binds, conn = conn,
+                             transaction = transaction)
+
+        return

--- a/src/python/T0/WMBS/Oracle/T0DataSvc/GetRunStreamDone.py
+++ b/src/python/T0/WMBS/Oracle/T0DataSvc/GetRunStreamDone.py
@@ -1,0 +1,31 @@
+"""
+_GetRunStreamDone_
+
+Oracle implementation of GetRunStreamDone
+
+Returns run/stream combinations that are fully processed
+
+"""
+
+from WMCore.Database.DBFormatter import DBFormatter
+
+class GetRunStreamDone(DBFormatter):
+
+    def execute(self, conn = None, transaction = False):
+
+        sql = """SELECT run_stream_done.run_id AS run,
+                        stream.name AS stream
+                 FROM run_stream_done
+                 INNER JOIN stream ON
+                   stream.id = run_stream_done.stream_id
+                 LEFT OUTER JOIN run_stream_fileset_assoc ON
+                   run_stream_fileset_assoc.run_id = run_stream_done.run_id AND
+                   run_stream_fileset_assoc.stream_id = run_stream_done.stream_id
+                 WHERE checkForZeroState(run_stream_done.in_datasvc) = 0
+                 AND run_stream_fileset_assoc.run_id IS NULL
+                 """
+
+        results = self.dbi.processData(sql, binds = {}, conn = conn,
+                                       transaction = transaction)
+
+        return self.formatDict(results)

--- a/src/python/T0/WMBS/Oracle/T0DataSvc/InsertRunStreamDone.py
+++ b/src/python/T0/WMBS/Oracle/T0DataSvc/InsertRunStreamDone.py
@@ -1,0 +1,26 @@
+"""
+_InsertRunStreamDone_
+
+Oracle implementation of InsertRunStreamDone
+
+Insert RunStreamDone record into Tier0 Data Service
+
+"""
+
+from WMCore.Database.DBFormatter import DBFormatter
+
+class InsertRunStreamDone(DBFormatter):
+
+    def execute(self, binds, conn = None, transaction = False):
+
+        sql = """MERGE INTO run_stream_done
+                 USING DUAL ON ( run = :RUN AND stream = :STREAM )
+                 WHEN NOT MATCHED THEN
+                   INSERT (run, stream)
+                   VALUES (:RUN, :STREAM)
+                 """
+
+        self.dbi.processData(sql, binds, conn = conn,
+                             transaction = transaction)
+
+        return

--- a/src/python/T0/WMBS/Oracle/T0DataSvc/UpdateRunStreamDone.py
+++ b/src/python/T0/WMBS/Oracle/T0DataSvc/UpdateRunStreamDone.py
@@ -1,0 +1,25 @@
+"""
+_UpdateRunStreamDone_
+
+Oracle implementation of UpdateRunStreamDone
+
+Mark run/stream processing finished status as present in in Tier0 Data Service
+
+"""
+
+from WMCore.Database.DBFormatter import DBFormatter
+
+class UpdateRunStreamDone(DBFormatter):
+
+    def execute(self, binds, conn = None, transaction = False):
+
+        sql = """UPDATE run_stream_done
+                 SET in_datasvc = 1
+                 WHERE run_id = :RUN
+                 AND stream_id = (SELECT id FROM stream WHERE name = :STREAM)
+                 """
+
+        self.dbi.processData(sql, binds, conn = conn,
+                             transaction = transaction)
+
+        return


### PR DESCRIPTION
The streamer deletion script is supposed to check for each run/stream it deletes if that run/stream is already fully processed by the Tier0. Implement publication of this information into the Tier0 Data Service so it can be easily queried there.