### PR TITLE
implemet stageout to merged for repack

### DIFF
--- a/src/python/T0/JobSplitting/Repack.py
+++ b/src/python/T0/JobSplitting/Repack.py
@@ -61,7 +61,12 @@ class Repack(JobFactory):
 
         # data discovery for already used lumis
         getUsedLumisDAO = daoFactory(classname = "Subscriptions.GetUsedLumis")
-        usedLumis = getUsedLumisDAO.execute(self.subscription["id"])
+        usedLumis = getUsedLumisDAO.execute(self.subscription["id"], False)
+
+        # empty lumis (as declared by StorageManager) are treated the
+        # same way as used lumis, ie. we process around them
+        getEmptyLumisDAO = daoFactory(classname = "Subscriptions.GetLumiHolesForRepack")
+        usedLumis |= getEmptyLumisDAO.execute(self.subscription["id"])
 
         # sort available files by lumi
         availableFileLumiDict = {}

--- a/src/python/T0/JobSplitting/RepackMerge.py
+++ b/src/python/T0/JobSplitting/RepackMerge.py
@@ -60,7 +60,12 @@ class RepackMerge(JobFactory):
 
         # data discovery for already used lumis
         getUsedLumisDAO = daoFactory(classname = "Subscriptions.GetUsedLumis")
-        usedLumis = getUsedLumisDAO.execute(self.subscription["id"])
+        usedLumis = getUsedLumisDAO.execute(self.subscription["id"], True)
+
+        # empty lumis (as declared by StorageManager) are treated the
+        # same way as used lumis, ie. we process around them
+        getEmptyLumisDAO = daoFactory(classname = "Subscriptions.GetLumiHolesForRepackMerge")
+        usedLumis |= getEmptyLumisDAO.execute(self.subscription["id"])
 
         # sort available files by lumi
         availableFileLumiDict = {}

--- a/src/python/T0/RunConfig/RunConfigAPI.py
+++ b/src/python/T0/RunConfig/RunConfigAPI.py
@@ -495,6 +495,10 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
             specArguments['MaxInputFiles'] = streamConfig.Repack.MaxInputFiles
             specArguments['MaxLatency'] = streamConfig.Repack.MaxLatency
 
+            # parameters for repack direct to merge stageout
+            specArguments['MinMergeSize'] = streamConfig.Repack.MinInputSize
+            specArguments['MaxMergeEvents'] = streamConfig.Repack.MaxInputEvents
+
             specArguments['UnmergedLFNBase'] = "/store/unmerged/%s" % runInfo['bulk_data_type']
             if runInfo['backfill']:
                 specArguments['MergedLFNBase'] = "/store/backfill/%s/%s" % (runInfo['backfill'],

--- a/src/python/T0/WMBS/Oracle/Subscriptions/GetLumiHolesForRepack.py
+++ b/src/python/T0/WMBS/Oracle/Subscriptions/GetLumiHolesForRepack.py
@@ -1,0 +1,34 @@
+"""
+_GetLumiHolesForRepack_
+
+Oracle implementation of GetLumiHolesForRepack
+
+For a given repack subscription return the empty lumis (no streamers)
+"""
+
+from WMCore.Database.DBFormatter import DBFormatter
+
+class GetLumiHolesForRepack(DBFormatter):
+
+    sql = """SELECT lumi_section_closed.lumi_id AS lumi
+             FROM wmbs_subscription
+             INNER JOIN run_stream_fileset_assoc ON
+               run_stream_fileset_assoc.fileset = wmbs_subscription.fileset
+             INNER JOIN lumi_section_closed ON
+               lumi_section_closed.run_id = run_stream_fileset_assoc.run_id AND
+               lumi_section_closed.stream_id = run_stream_fileset_assoc.stream_id AND
+               lumi_section_closed.close_time > 0 AND
+               lumi_section_closed.filecount = 0
+             WHERE wmbs_subscription.id = :subscription
+             """
+
+    def execute(self, subscription, conn = None, transaction = False):
+
+        results = self.dbi.processData(self.sql, { 'subscription' : subscription },
+                                       conn = conn, transaction = transaction)[0].fetchall()
+
+        lumiSet = set()
+        for result in results:
+            lumiSet.add(result[0])
+
+        return lumiSet

--- a/src/python/T0/WMBS/Oracle/Subscriptions/GetLumiHolesForRepackMerge.py
+++ b/src/python/T0/WMBS/Oracle/Subscriptions/GetLumiHolesForRepackMerge.py
@@ -1,0 +1,38 @@
+"""
+_GetLumiHolesForRepackMerge_
+
+Oracle implementation of GetLumiHolesForRepackMerge
+
+For a given repack merge subscription return the empty lumis (no streamers)
+"""
+
+from WMCore.Database.DBFormatter import DBFormatter
+
+class GetLumiHolesForRepackMerge(DBFormatter):
+
+    sql = """SELECT lumi_section_closed.lumi_id AS lumi
+             FROM wmbs_subscription
+             INNER JOIN wmbs_workflow_output ON
+               wmbs_workflow_output.output_fileset = wmbs_subscription.fileset
+             INNER JOIN wmbs_subscription repack_subscription ON
+               repack_subscription.workflow = wmbs_workflow_output.workflow_id
+             INNER JOIN run_stream_fileset_assoc ON
+               run_stream_fileset_assoc.fileset = repack_subscription.fileset
+             INNER JOIN lumi_section_closed ON
+               lumi_section_closed.run_id = run_stream_fileset_assoc.run_id AND
+               lumi_section_closed.stream_id = run_stream_fileset_assoc.stream_id AND
+               lumi_section_closed.close_time > 0 AND
+               lumi_section_closed.filecount = 0
+             WHERE wmbs_subscription.id = :subscription
+             """
+
+    def execute(self, subscription, conn = None, transaction = False):
+
+        results = self.dbi.processData(self.sql, { 'subscription' : subscription },
+                                       conn = conn, transaction = transaction)[0].fetchall()
+
+        lumiSet = set()
+        for result in results:
+            lumiSet.add(result[0])
+
+        return lumiSet

--- a/src/python/T0/WMBS/Oracle/Subscriptions/GetUsedLumis.py
+++ b/src/python/T0/WMBS/Oracle/Subscriptions/GetUsedLumis.py
@@ -4,13 +4,15 @@ _GetUsedLumis_
 Oracle implementation of GetUsedLumis
 
 Returns the already used lumis for a given subscription
+
+Currently only used by Repack and RepackMerge job splitters
 """
 
 from WMCore.Database.DBFormatter import DBFormatter
 
 class GetUsedLumis(DBFormatter):
 
-    def execute(self, subscription, conn = None, transaction = False):
+    def execute(self, subscription, checkStageoutToMerged, conn = None, transaction = False):
 
         # check which lumis are already in acquired, complete
         # or failed files for this subscription
@@ -55,5 +57,32 @@ class GetUsedLumis(DBFormatter):
 
         for result in self.formatDict(results):
             lumiSet.add(result['lumi'])
+
+        #
+        # optionally check for direct stageout to merged output
+        # (used when called from repackmerge)
+        #
+
+        if checkStageoutToMerged:
+
+            sql = """SELECT wmbs_file_runlumi_map.lumi AS lumi
+                     FROM wmbs_fileset_files
+                     INNER JOIN wmbs_file_runlumi_map ON
+                       wmbs_file_runlumi_map.fileid = wmbs_fileset_files.fileid
+                     WHERE wmbs_fileset_files.fileset =
+                       ( SELECT output_fileset
+                         FROM wmbs_workflow_output
+                         WHERE workflow_id =
+                           ( SELECT workflow
+                             FROM wmbs_subscription
+                             WHERE id = :subscription )
+                         AND output_identifier = 'Merged' )
+                     """
+
+            results = self.dbi.processData(sql, { 'subscription' : subscription },
+                                           conn = conn, transaction = transaction)
+
+            for result in self.formatDict(results):
+                lumiSet.add(result['lumi'])
 
         return lumiSet

--- a/src/python/T0/WMSpec/StdSpecs/Repack.py
+++ b/src/python/T0/WMSpec/StdSpecs/Repack.py
@@ -63,7 +63,6 @@ class RepackWorkloadFactory(StdBase):
                                                  splitAlgo = "Repack",
                                                  splitArgs = mySplitArgs,
                                                  stepType = cmsswStepType,
-                                                 forceUnmerged = True,
                                                  useMulticore = False)
 
         repackTask.setTaskType("Repack")


### PR DESCRIPTION
Use the minimum acceptable merge file size and the number of event threshold to trigger direct stageout to merged from repack jobs. In addition also treat lumi holes from the detector (StorageManager declaring no data for that lumi) the same way as already processed lumis, ie. process around the holes. This is a bit inefficient in creating large RAW files, but protects against data later appearing for these lumis.