### PR TITLE
send SM repack notifications quicker, fixes #4293

### DIFF
--- a/src/python/T0/WMBS/Oracle/SMNotification/GetFinishedStreamers.py
+++ b/src/python/T0/WMBS/Oracle/SMNotification/GetFinishedStreamers.py
@@ -3,9 +3,9 @@ _GetFinishedStreamers_
 
 Oracle implementation of GetFinishedStreamers
 
-Returns all streamer files that are in closed run/stream filesets
-(run is over and all run/stream files are transfered/feed to Tier0)
-and which are completely processed (file is not available or acquired).
+Returns all streamer files that are completely processed (file is complete or failed).
+
+Query works as-is since streamer files are only in a single fileset/subscription.
 
 """
 
@@ -18,21 +18,15 @@ class GetFinishedStreamers(DBFormatter):
         sql = """SELECT streamer.id,
                         wmbs_file_details.lfn
                  FROM streamer
-                 INNER JOIN run_stream_fileset_assoc ON
-                   run_stream_fileset_assoc.run_id = streamer.run_id AND
-                   run_stream_fileset_assoc.stream_id = streamer.stream_id
-                 INNER JOIN wmbs_fileset ON
-                   wmbs_fileset.id = run_stream_fileset_assoc.fileset AND
-                   wmbs_fileset.open = 0
-                 LEFT OUTER JOIN wmbs_sub_files_available ON
-                   wmbs_sub_files_available.fileid = streamer.id
-                 LEFT OUTER JOIN wmbs_sub_files_acquired ON
-                   wmbs_sub_files_acquired.fileid = streamer.id
+                 LEFT OUTER JOIN wmbs_sub_files_complete ON
+                   wmbs_sub_files_complete.fileid = streamer.id
+                 LEFT OUTER JOIN wmbs_sub_files_failed ON
+                   wmbs_sub_files_failed.fileid = streamer.id
                  INNER JOIN wmbs_file_details ON
                    wmbs_file_details.id = streamer.id
                  WHERE checkForZeroState(streamer.deleted) = 0
-                 AND wmbs_sub_files_available.fileid IS NULL
-                 AND wmbs_sub_files_acquired.fileid IS NULL
+                 AND ( wmbs_sub_files_complete.fileid IS NOT NULL
+                       OR wmbs_sub_files_failed.fileid IS NOT NULL )
                  """
 
         results = self.dbi.processData(sql, {}, conn = conn,

--- a/src/python/T0Component/Tier0Feeder/Tier0FeederPoller.py
+++ b/src/python/T0Component/Tier0Feeder/Tier0FeederPoller.py
@@ -388,8 +388,8 @@ class Tier0FeederPoller(BaseWorkerThread):
             if len(error) > 0:
                 logging.error("ERROR: Could not notify transfer system about processed streamers")
                 logging.error("ERROR: %s" % error)
-
-            markStreamersFinishedDAO.execute(streamers, transaction = False)
+            else:
+                markStreamersFinishedDAO.execute(streamers, transaction = False)
 
         return
 


### PR DESCRIPTION
Immediately send notifications when the streamer file is completed or failed. Also retry notification if it fails.