### PR TITLE
mark run/stream as done quicker

### DIFF
--- a/src/python/T0/WMBS/Oracle/T0DataSvc/GetRunStreamDone.py
+++ b/src/python/T0/WMBS/Oracle/T0DataSvc/GetRunStreamDone.py
@@ -13,6 +13,8 @@ class GetRunStreamDone(DBFormatter):
 
     def execute(self, conn = None, transaction = False):
 
+        returnList = []
+
         sql = """SELECT run_stream_done.run_id AS run,
                         stream.name AS stream
                  FROM run_stream_done
@@ -26,6 +28,39 @@ class GetRunStreamDone(DBFormatter):
                  """
 
         results = self.dbi.processData(sql, binds = {}, conn = conn,
-                                       transaction = transaction)
+                                       transaction = transaction)[0].fetchall()
 
-        return self.formatDict(results)
+        for result in results:
+            returnList.append( { 'run': result[0],
+                                 'stream': result[1] } )
+
+        sql = """SELECT run_stream_done.run_id AS run,
+                        stream.name AS stream
+                 FROM run_stream_done
+                 INNER JOIN stream ON
+                   stream.id = run_stream_done.stream_id
+                 INNER JOIN run_stream_fileset_assoc ON
+                   run_stream_fileset_assoc.run_id = run_stream_done.run_id AND
+                   run_stream_fileset_assoc.stream_id = run_stream_done.stream_id
+                 INNER JOIN wmbs_subscription ON
+                   wmbs_subscription.fileset = run_stream_fileset_assoc.fileset
+                 INNER JOIN wmbs_workflow ON
+                   wmbs_workflow.id = wmbs_subscription.workflow
+                 INNER JOIN wmbs_workflow runstream_workflow ON
+                   runstream_workflow.name = wmbs_workflow.name
+                 INNER JOIN wmbs_subscription runstream_subscription ON
+                   runstream_subscription.workflow = runstream_workflow.id
+                 WHERE checkForZeroState(run_stream_done.in_datasvc) = 0
+                 GROUP BY run_stream_done.run_id,
+                          stream.name
+                 HAVING SUM(runstream_subscription.finished) = COUNT(*)
+                 """
+
+        results = self.dbi.processData(sql, binds = {}, conn = conn,
+                                       transaction = transaction)[0].fetchall()
+
+        for result in results:
+            returnList.append( { 'run': result[0],
+                                 'stream': result[1] } )
+
+        return returnList


### PR DESCRIPTION
Currently run/stream is marked done when a run/stream workflow is archived and cleaned up. Due to WMStats retention policy this takes a week, which is a bit long. Change this to mark a run/stream as done if all subscriptions for this run/stream are marked as finished.