### PR TITLE
special handling for SiPixelAli PCL

### DIFF
--- a/src/python/T0/JobSplitting/AlcaHarvest.py
+++ b/src/python/T0/JobSplitting/AlcaHarvest.py
@@ -32,6 +32,7 @@ class AlcaHarvest(JobFactory):
         """
         self.jobNamePrefix = kwargs.get('jobNamePrefix', "AlcaHarvest")
         run = kwargs['runNumber']
+        alcapromptdataset = kwargs['alcapromptdataset']
         timeout = kwargs['timeout']
 
         myThread = threading.currentThread()
@@ -57,7 +58,7 @@ class AlcaHarvest(JobFactory):
 
                     if stopTime + timeout < time.time():
 
-                        self.createJob(self.getInputFilesForJob())
+                        self.createJob(self.getInputFilesForJob(), alcapromptdataset)
 
         else:
 
@@ -66,7 +67,7 @@ class AlcaHarvest(JobFactory):
 
             if availableFile:
 
-                self.createJob(self.getInputFilesForJob())
+                self.createJob(self.getInputFilesForJob(), alcapromptdataset)
 
         return
 
@@ -81,7 +82,7 @@ class AlcaHarvest(JobFactory):
         getAllFilesDAO = self.daoFactory(classname = "Subscriptions.GetAllFiles")
         return getAllFilesDAO.execute(self.subscription["id"])
 
-    def createJob(self, fileList):
+    def createJob(self, fileList, alcapromptdataset):
         """
         _createJob_
 
@@ -91,6 +92,9 @@ class AlcaHarvest(JobFactory):
         self.newGroup()
 
         self.newJob(name = "%s-%s" % (self.jobNamePrefix, makeUUID()))
+
+        if alcapromptdataset == "PromptCalibProdSiPixelAli":
+            self.currentJob.addBaggageParameter("numberOfCores", 4)
 
         for fileInfo in fileList:
             f = File(id = fileInfo['id'],

--- a/src/python/T0/WMSpec/StdSpecs/Express.py
+++ b/src/python/T0/WMSpec/StdSpecs/Express.py
@@ -333,6 +333,7 @@ class ExpressWorkloadFactory(StdBase):
         mySplitArgs = {}
         mySplitArgs['algo_package'] = "T0.JobSplitting"
         mySplitArgs['runNumber'] = self.runNumber
+        mySplitArgs['alcapromptdataset'] = alcapromptdataset
         mySplitArgs['timeout'] = self.alcaHarvestTimeout
 
         harvestTask = parentTask.addTask("%sAlcaHarvest%s" % (parentTask.name(), parentOutputModuleName))


### PR DESCRIPTION
The SiPixelAli AlcaHarvest job needs a lot of local disk space. Assign 4 cores to it in the job splitter and then override at runtime to run single core.