### PR TITLE
disable robbust (ie. flaky) merge

### DIFF
--- a/src/python/T0/RunConfig/RunConfigAPI.py
+++ b/src/python/T0/RunConfig/RunConfigAPI.py
@@ -961,6 +961,8 @@ def releasePromptReco(tier0Config, specDirectory, dqmUploadProxy):
                 specArguments['SplittingAlgo'] = "EventAwareLumiBased"
                 specArguments['EventsPerJob'] = datasetConfig.RecoSplit
 
+                specArguments['RobustMerge'] = False
+
                 specArguments['ProcessingString'] = "PromptReco"
                 specArguments['ProcessingVersion'] = datasetConfig.ProcessingVersion
                 specArguments['Scenario'] = datasetConfig.Scenario


### PR DESCRIPTION
Tier0 doesn't do ACDC, therefore fail merge jobs that can't open any of their input files