### PR TITLE
remove ArchiveReporter compoent

### DIFF
--- a/bin/tier0-mod-config
+++ b/bin/tier0-mod-config
@@ -79,6 +79,10 @@ def modifyConfiguration(config, **args):
     # don't use workqueue
     if hasattr(config, "WorkQueueManager"):
         delattr(config, "WorkQueueManager")
+        
+    # don't use wmarchive data reporter
+    if hasattr(config, "ArchiveDataReporter"):
+        delattr(config, "ArchiveDataReporter")
     
     config.TaskArchiver.useWorkQueue = False
     


### PR DESCRIPTION
Tie0 doesn' use it now. But maybe consider using it later. (Basically archiver collect all the fwjr and provide analytics for it.

https://cmsweb-testbed.cern.ch/wmarchive/web/performance?metrics[]=jobstate&axes[]=host&axes[]=jobstate&axes[]=time&axes[]=site&start_date=20160825&end_date=20160827

@hufnagel, Dirk please review