### PR TITLE
Change the UUID module name

### DIFF
--- a/src/python/T0/JobSplitting/AlcaHarvest.py
+++ b/src/python/T0/JobSplitting/AlcaHarvest.py
@@ -11,7 +11,7 @@ from WMCore.WMBS.File import File
 
 from WMCore.JobSplitting.JobFactory import JobFactory
 from WMCore.DAOFactory import DAOFactory
-from WMCore.Services.UUID import makeUUID
+from WMCore.Services.UUIDLib import makeUUID
 
 class AlcaHarvest(JobFactory):
     """

--- a/src/python/T0/JobSplitting/Express.py
+++ b/src/python/T0/JobSplitting/Express.py
@@ -11,7 +11,7 @@ from WMCore.WMBS.File import File
 
 from WMCore.JobSplitting.JobFactory import JobFactory
 from WMCore.DAOFactory import DAOFactory
-from WMCore.Services.UUID import makeUUID
+from WMCore.Services.UUIDLib import makeUUID
 
 
 class Express(JobFactory):

--- a/src/python/T0/JobSplitting/ExpressMerge.py
+++ b/src/python/T0/JobSplitting/ExpressMerge.py
@@ -12,7 +12,7 @@ from WMCore.WMBS.File import File
 
 from WMCore.JobSplitting.JobFactory import JobFactory
 from WMCore.DAOFactory import DAOFactory
-from WMCore.Services.UUID import makeUUID
+from WMCore.Services.UUIDLib import makeUUID
 
 
 class ExpressMerge(JobFactory):

--- a/src/python/T0/JobSplitting/Repack.py
+++ b/src/python/T0/JobSplitting/Repack.py
@@ -12,7 +12,7 @@ from WMCore.WMBS.File import File
 
 from WMCore.JobSplitting.JobFactory import JobFactory
 from WMCore.DAOFactory import DAOFactory
-from WMCore.Services.UUID import makeUUID
+from WMCore.Services.UUIDLib import makeUUID
 
 
 class Repack(JobFactory):

--- a/src/python/T0/JobSplitting/RepackMerge.py
+++ b/src/python/T0/JobSplitting/RepackMerge.py
@@ -12,7 +12,7 @@ from WMCore.WMBS.File import File
 
 from WMCore.JobSplitting.JobFactory import JobFactory
 from WMCore.DAOFactory import DAOFactory
-from WMCore.Services.UUID import makeUUID
+from WMCore.Services.UUIDLib import makeUUID
 
 
 class RepackMerge(JobFactory):

--- a/test/python/T0Component_t/Tier0Feeder_t/Tier0Feeder_t.py
+++ b/test/python/T0Component_t/Tier0Feeder_t/Tier0Feeder_t.py
@@ -16,7 +16,7 @@ from WMQuality.TestInit import TestInit
 from WMCore.DAOFactory import DAOFactory
 from WMCore.Database.DBFactory import DBFactory
 from WMCore.Configuration import loadConfigurationFile
-from WMCore.Services.UUID import makeUUID
+from WMCore.Services.UUIDLib import makeUUID
 from WMCore.Services.RequestDB.RequestDBWriter import RequestDBWriter
 
 from T0.RunConfig import RunConfigAPI

--- a/test/python/T0_t/WMBS_t/JobSplitting_t/ExpressMerge_t.py
+++ b/test/python/T0_t/WMBS_t/JobSplitting_t/ExpressMerge_t.py
@@ -19,7 +19,7 @@ from WMCore.DataStructs.Run import Run
 
 from WMCore.DAOFactory import DAOFactory
 from WMCore.JobSplitting.SplitterFactory import SplitterFactory
-from WMCore.Services.UUID import makeUUID
+from WMCore.Services.UUIDLib import makeUUID
 from WMQuality.TestInit import TestInit
 
 

--- a/test/python/T0_t/WMBS_t/JobSplitting_t/Express_t.py
+++ b/test/python/T0_t/WMBS_t/JobSplitting_t/Express_t.py
@@ -19,7 +19,7 @@ from WMCore.DataStructs.Run import Run
 
 from WMCore.DAOFactory import DAOFactory
 from WMCore.JobSplitting.SplitterFactory import SplitterFactory
-from WMCore.Services.UUID import makeUUID
+from WMCore.Services.UUIDLib import makeUUID
 from WMQuality.TestInit import TestInit
 
 

--- a/test/python/T0_t/WMBS_t/JobSplitting_t/RepackMerge_t.py
+++ b/test/python/T0_t/WMBS_t/JobSplitting_t/RepackMerge_t.py
@@ -19,7 +19,7 @@ from WMCore.DataStructs.Run import Run
 
 from WMCore.DAOFactory import DAOFactory
 from WMCore.JobSplitting.SplitterFactory import SplitterFactory
-from WMCore.Services.UUID import makeUUID
+from WMCore.Services.UUIDLib import makeUUID
 from WMQuality.TestInit import TestInit
 
 

--- a/test/python/T0_t/WMBS_t/JobSplitting_t/Repack_t.py
+++ b/test/python/T0_t/WMBS_t/JobSplitting_t/Repack_t.py
@@ -19,7 +19,7 @@ from WMCore.DataStructs.Run import Run
 
 from WMCore.DAOFactory import DAOFactory
 from WMCore.JobSplitting.SplitterFactory import SplitterFactory
-from WMCore.Services.UUID import makeUUID
+from WMCore.Services.UUIDLib import makeUUID
 from WMQuality.TestInit import TestInit
 
 


### PR DESCRIPTION
related to https://github.com/dmwm/WMCore/pull/7606

If you are using WMCore 1.1.1.pre2 and above (tag is not yet created), this patch will be needed.

@hufnagel, Dirk please review.