### PR TITLE
better checks for anomalous data from SM discovery

### DIFF
--- a/src/python/T0/StorageManager/StorageManagerAPI.py
+++ b/src/python/T0/StorageManager/StorageManagerAPI.py
@@ -67,7 +67,7 @@ def injectNewData(dbInterfaceStorageManager,
     # remove already processed files
     newData[:] = [newFile for newFile in newData if newFile['p5_id'] not in knownStreamers]
 
-    logging.info("XXX found %d new files", len(newData))
+    logging.debug("StoragemanagerAPI: found %d new files", len(newData))
 
     newRuns = set()
     newRunStreams = {}
@@ -83,7 +83,7 @@ def injectNewData(dbInterfaceStorageManager,
         if stream not in newRunStreams[run]:
             newRunStreams[run].add(stream)
 
-    logging.info("XXX found %d new runs", len(newRuns))
+    logging.debug("StoragemanagerAPI: found %d new runs", len(newRuns))
 
     cmsswVersions = set()
     streams = set()
@@ -91,7 +91,7 @@ def injectNewData(dbInterfaceStorageManager,
     bindRunStreamCMSSW = []
     for run in sorted(list(newRuns)):
         (hltkey, cmssw) = getRunInfoDAO.execute(run = run, transaction = False)
-        logging.info("XXX run = %d, hltkey = %s, cmssw = %s", run, hltkey, cmssw)
+        logging.debug("StorageManagerAPI: run = %d, hltkey = %s, cmssw = %s", run, hltkey, cmssw)
         if hltkey and cmssw:
             cmsswVersions.add(cmssw)
             bindRunHltKey.append( { 'RUN': run,
@@ -167,8 +167,6 @@ def injectNewData(dbInterfaceStorageManager,
 
     for x in bindStreamer:
         knownStreamers.add(x['P5_ID'])
-
-    logging.info("XXX finished injectNewData")
 
     return
 

--- a/src/python/T0/WMBS/Oracle/StorageManager/GetNewData.py
+++ b/src/python/T0/WMBS/Oracle/StorageManager/GetNewData.py
@@ -47,6 +47,7 @@ class GetNewData(DBFormatter):
                  INNER JOIN CMS_STOMGR.FILE_QUALITY_CONTROL ON
                    CMS_STOMGR.FILE_QUALITY_CONTROL.FILENAME = CMS_STOMGR.FILE_TRANSFER_STATUS.FILENAME
                  %s
+                 AND CMS_STOMGR.FILE_TRANSFER_STATUS.PATH IS NOT NULL
                  """ % whereSql
 
         results = self.dbi.processData(sql, binds, conn = conn,

--- a/src/python/T0Component/Tier0Feeder/Tier0FeederPoller.py
+++ b/src/python/T0Component/Tier0Feeder/Tier0FeederPoller.py
@@ -130,25 +130,30 @@ class Tier0FeederPoller(BaseWorkerThread):
             # discover new data from StorageManager and inject into Tier0
             # (if the config specifies a list of runs do it only once)
             #
-            # replays inject data only once (and ignore data status)
+            # replays call data discovery only once (and ignore data status)
             #
-            if tier0Config.Global.InjectRuns == None:
-                StorageManagerAPI.injectNewData(self.dbInterfaceStorageManager,
-                                                self.dbInterfaceHltConf,
-                                                self.dbInterfaceSMNotify,
-                                                minRun = tier0Config.Global.InjectMinRun,
-                                                maxRun = tier0Config.Global.InjectMaxRun)
-            else:
-                injectRuns = set()
-                for injectRun in tier0Config.Global.InjectRuns:
-                    if injectRun not in self.injectedRuns:
-                        injectRuns.add(injectRun)
-                for injectRun in injectRuns:
+            try:
+                if tier0Config.Global.InjectRuns == None:
                     StorageManagerAPI.injectNewData(self.dbInterfaceStorageManager,
                                                     self.dbInterfaceHltConf,
                                                     self.dbInterfaceSMNotify,
-                                                    injectRun = injectRun)
-                    self.injectedRuns.add(injectRun)
+                                                    minRun = tier0Config.Global.InjectMinRun,
+                                                    maxRun = tier0Config.Global.InjectMaxRun)
+                else:
+                    injectRuns = set()
+                    for injectRun in tier0Config.Global.InjectRuns:
+                        if injectRun not in self.injectedRuns:
+                            injectRuns.add(injectRun)
+                    for injectRun in injectRuns:
+                        StorageManagerAPI.injectNewData(self.dbInterfaceStorageManager,
+                                                        self.dbInterfaceHltConf,
+                                                        self.dbInterfaceSMNotify,
+                                                        injectRun = injectRun)
+                        self.injectedRuns.add(injectRun)
+            except:
+                # shouldn't happen, just a catch all insurance
+                logging.exception("Something went wrong with data retrieval from StorageManager")
+
 
             #
             # find new runs, setup global run settings and stream/dataset/trigger mapping


### PR DESCRIPTION
Make sure the Tier0Feeder can't crash if the data inside the SM bookkeeping is anomalous.