### PR TITLE
make Express more flexible, allow to configure it almost like Bulk

### DIFF
--- a/etc/HIProdOfflineConfiguration.py
+++ b/etc/HIProdOfflineConfiguration.py
@@ -14,7 +14,6 @@ from T0.RunConfig.Tier0Config import setBaseRequestPriority
 from T0.RunConfig.Tier0Config import setBackfill
 from T0.RunConfig.Tier0Config import setBulkDataType
 from T0.RunConfig.Tier0Config import setProcessingSite
-from T0.RunConfig.Tier0Config import setExpressSubscribeNode
 from T0.RunConfig.Tier0Config import setDQMDataTier
 from T0.RunConfig.Tier0Config import setDQMUploadUrl
 from T0.RunConfig.Tier0Config import setPromptCalibrationConfig
@@ -46,7 +45,6 @@ setBaseRequestPriority(tier0Config, 250000)
 setBackfill(tier0Config, None)
 setBulkDataType(tier0Config, "hidata")
 setProcessingSite(tier0Config, processingSite)
-setExpressSubscribeNode(tier0Config, "T2_CH_CERN")
 
 # Override for DQM data tier
 setDQMDataTier(tier0Config, "DQMIO")
@@ -1581,6 +1579,7 @@ addExpressConfig(tier0Config, "Express",
                  blockCloseDelay = 1200,
                  timePerEvent = 4,
                  sizePerEvent = 1700,
+                 diskNode = "T2_CH_CERN"
                  versionOverride = expressVersionOverride)
 
 addExpressConfig(tier0Config, "Express0T",
@@ -1605,6 +1604,7 @@ addExpressConfig(tier0Config, "Express0T",
                  blockCloseDelay = 1200,
                  timePerEvent = 4,
                  sizePerEvent = 1700,
+                 diskNode = "T2_CH_CERN",
                  versionOverride = expressVersionOverride)
 
 addExpressConfig(tier0Config, "ExpressCosmics",
@@ -1627,6 +1627,7 @@ addExpressConfig(tier0Config, "ExpressCosmics",
                  blockCloseDelay = 1200,
                  timePerEvent = 4, #I have to get some stats to set this properly
                  sizePerEvent = 1700, #I have to get some stats to set this properly
+                 diskNode = "T2_CH_CERN",
                  versionOverride = expressVersionOverride)
 
 addExpressConfig(tier0Config, "HLTMonitor",
@@ -1649,6 +1650,7 @@ addExpressConfig(tier0Config, "HLTMonitor",
                  blockCloseDelay = 1200,
                  timePerEvent = 4, #I have to get some stats to set this properly
                  sizePerEvent = 1700, #I have to get some stats to set this properly
+                 diskNode = "T2_CH_CERN",
                  versionOverride = expressVersionOverride)
 
 ###############################
@@ -1677,6 +1679,7 @@ addExpressConfig(tier0Config, "ExpressPA",
                  blockCloseDelay = 1200,
                  timePerEvent = 4,
                  sizePerEvent = 1700,
+                 diskNode = "T2_CH_CERN",
                  versionOverride = expressVersionOverride)
 
 addExpressConfig(tier0Config, "HLTMonitorPA",
@@ -1699,6 +1702,7 @@ addExpressConfig(tier0Config, "HLTMonitorPA",
                  blockCloseDelay = 1200,
                  timePerEvent = 4, #I have to get some stats to set this properly
                  sizePerEvent = 1700, #I have to get some stats to set this properly
+                 diskNode = "T2_CH_CERN",
                  versionOverride = expressVersionOverride)
 
 #######################

--- a/etc/HIReplayOfflineConfiguration.py
+++ b/etc/HIReplayOfflineConfiguration.py
@@ -14,7 +14,6 @@ from T0.RunConfig.Tier0Config import setBaseRequestPriority
 from T0.RunConfig.Tier0Config import setBackfill
 from T0.RunConfig.Tier0Config import setBulkDataType
 from T0.RunConfig.Tier0Config import setProcessingSite
-from T0.RunConfig.Tier0Config import setExpressSubscribeNode
 from T0.RunConfig.Tier0Config import setDQMDataTier
 from T0.RunConfig.Tier0Config import setDQMUploadUrl
 from T0.RunConfig.Tier0Config import setPromptCalibrationConfig
@@ -46,7 +45,6 @@ setBaseRequestPriority(tier0Config, 300000)
 setBackfill(tier0Config, 1)
 setBulkDataType(tier0Config, "hidata")
 setProcessingSite(tier0Config, processingSite)
-setExpressSubscribeNode(tier0Config, None)
 
 # Override for DQM data tier
 setDQMDataTier(tier0Config, "DQMIO")

--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -14,7 +14,6 @@ from T0.RunConfig.Tier0Config import setBaseRequestPriority
 from T0.RunConfig.Tier0Config import setBackfill
 from T0.RunConfig.Tier0Config import setBulkDataType
 from T0.RunConfig.Tier0Config import setProcessingSite
-from T0.RunConfig.Tier0Config import setExpressSubscribeNode
 from T0.RunConfig.Tier0Config import setDQMDataTier
 from T0.RunConfig.Tier0Config import setDQMUploadUrl
 from T0.RunConfig.Tier0Config import setPromptCalibrationConfig
@@ -46,7 +45,6 @@ setBaseRequestPriority(tier0Config, 250000)
 setBackfill(tier0Config, None)
 setBulkDataType(tier0Config, "data")
 setProcessingSite(tier0Config, processingSite)
-setExpressSubscribeNode(tier0Config, "T2_CH_CERN")
 
 # Override for DQM data tier
 setDQMDataTier(tier0Config, "DQMIO")
@@ -1453,6 +1451,7 @@ addExpressConfig(tier0Config, "Express",
                  blockCloseDelay = 1200,
                  timePerEvent = 4,
                  sizePerEvent = 1700,
+                 diskNode = "T2_CH_CERN",
                  versionOverride = expressVersionOverride)
 
 addExpressConfig(tier0Config, "Express0T",
@@ -1477,6 +1476,7 @@ addExpressConfig(tier0Config, "Express0T",
                  blockCloseDelay = 1200,
                  timePerEvent = 4,
                  sizePerEvent = 1700,
+                 diskNode = "T2_CH_CERN",
                  versionOverride = expressVersionOverride)
 
 addExpressConfig(tier0Config, "ExpressCosmics",
@@ -1499,6 +1499,7 @@ addExpressConfig(tier0Config, "ExpressCosmics",
                  blockCloseDelay = 1200,
                  timePerEvent = 4, #I have to get some stats to set this properly
                  sizePerEvent = 1700, #I have to get some stats to set this properly
+                 diskNode = "T2_CH_CERN",
                  versionOverride = expressVersionOverride)
 
 addExpressConfig(tier0Config, "HLTMonitor",
@@ -1521,6 +1522,7 @@ addExpressConfig(tier0Config, "HLTMonitor",
                  blockCloseDelay = 1200,
                  timePerEvent = 4, #I have to get some stats to set this properly
                  sizePerEvent = 1700, #I have to get some stats to set this properly
+                 diskNode = "T2_CH_CERN",
                  versionOverride = expressVersionOverride)
 
 #######################

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -14,7 +14,6 @@ from T0.RunConfig.Tier0Config import setBaseRequestPriority
 from T0.RunConfig.Tier0Config import setBackfill
 from T0.RunConfig.Tier0Config import setBulkDataType
 from T0.RunConfig.Tier0Config import setProcessingSite
-from T0.RunConfig.Tier0Config import setExpressSubscribeNode
 from T0.RunConfig.Tier0Config import setDQMDataTier
 from T0.RunConfig.Tier0Config import setDQMUploadUrl
 from T0.RunConfig.Tier0Config import setPromptCalibrationConfig
@@ -46,7 +45,6 @@ setBaseRequestPriority(tier0Config, 300000)
 setBackfill(tier0Config, 1)
 setBulkDataType(tier0Config, "data")
 setProcessingSite(tier0Config, processingSite)
-setExpressSubscribeNode(tier0Config, None)
 
 # Override for DQM data tier
 setDQMDataTier(tier0Config, "DQMIO")

--- a/etc/ReplayOfflineConfigurationRun1.py
+++ b/etc/ReplayOfflineConfigurationRun1.py
@@ -14,7 +14,6 @@ from T0.RunConfig.Tier0Config import setBaseRequestPriority
 from T0.RunConfig.Tier0Config import setBackfill
 from T0.RunConfig.Tier0Config import setBulkDataType
 from T0.RunConfig.Tier0Config import setProcessingSite
-from T0.RunConfig.Tier0Config import setExpressSubscribeNode
 from T0.RunConfig.Tier0Config import setDQMDataTier
 from T0.RunConfig.Tier0Config import setDQMUploadUrl
 from T0.RunConfig.Tier0Config import setPromptCalibrationConfig
@@ -46,7 +45,6 @@ setBaseRequestPriority(tier0Config, 300000)
 setBackfill(tier0Config, 1)
 setBulkDataType(tier0Config, "data")
 setProcessingSite(tier0Config, processingSite)
-setExpressSubscribeNode(tier0Config, None)
 
 # Override for DQM data tier
 setDQMDataTier(tier0Config, "DQMIO")

--- a/src/python/T0/RunConfig/RunConfigAPI.py
+++ b/src/python/T0/RunConfig/RunConfigAPI.py
@@ -60,7 +60,6 @@ def configureRun(tier0Config, run, hltConfig, referenceHltConfig = None):
                             dbinterface = myThread.dbi)
 
     # dao to update global run settings
-    insertStorageNodeDAO = daoFactory(classname = "RunConfig.InsertStorageNode")
     updateRunDAO = daoFactory(classname = "RunConfig.UpdateRun")
 
     # workaround to make unit test work without HLTConfDatabase
@@ -77,16 +76,11 @@ def configureRun(tier0Config, run, hltConfig, referenceHltConfig = None):
         insertTriggerDAO = daoFactory(classname = "RunConfig.InsertTrigger")
         insertDatasetTriggerDAO = daoFactory(classname = "RunConfig.InsertDatasetTrigger")
 
-        bindsStorageNode = []
-        if tier0Config.Global.ExpressSubscribeNode:
-            bindsStorageNode.append( { 'NODE' : tier0Config.Global.ExpressSubscribeNode } )
-
         bindsUpdateRun = { 'RUN' : run,
                            'PROCESS' : hltConfig['process'],
                            'ACQERA' : tier0Config.Global.AcquisitionEra,
                            'BACKFILL' : tier0Config.Global.Backfill,
                            'BULKDATATYPE' : tier0Config.Global.BulkDataType,
-                           'EXPRESS_SUBSCRIBE' : tier0Config.Global.ExpressSubscribeNode,
                            'DQMUPLOADURL' : tier0Config.Global.DQMUploadUrl,
                            'AHTIMEOUT' : tier0Config.Global.AlcaHarvestTimeout,
                            'AHDIR' : tier0Config.Global.AlcaHarvestDir,
@@ -124,8 +118,6 @@ def configureRun(tier0Config, run, hltConfig, referenceHltConfig = None):
 
         try:
             myThread.transaction.begin()
-            if len(bindsStorageNode) > 0:
-                insertStorageNodeDAO.execute(bindsStorageNode, conn = myThread.transaction.conn, transaction = True)
             updateRunDAO.execute(bindsUpdateRun, conn = myThread.transaction.conn, transaction = True)
             insertStreamDAO.execute(bindsStream, conn = myThread.transaction.conn, transaction = True)
             insertDatasetDAO.execute(bindsDataset, conn = myThread.transaction.conn, transaction = True)
@@ -309,21 +301,40 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
                                               'eventContent' : tier0Config.Global.DQMDataTier,
                                               'primaryDataset' : specialDataset } )
 
-            if runInfo['express_subscribe']:
+            if streamConfig.Express.ArchivalNode or streamConfig.Express.TapeNode or streamConfig.Express.DiskNode:
 
                 bindsPhEDExConfig.append( { 'RUN' : run,
                                             'PRIMDS' : specialDataset,
-                                            'ARCHIVAL_NODE' : None,
-                                            'TAPE_NODE' : None,
-                                            'DISK_NODE' :  runInfo['express_subscribe']} )
+                                            'ARCHIVAL_NODE' : streamConfig.Express.ArchivalNode,
+                                            'TAPE_NODE' : streamConfig.Express.TapeNode,
+                                            'DISK_NODE' :  streamConfig.Express.DiskNode } )
 
-                subscriptions.append( { 'nonCustodialSites' : [ runInfo['express_subscribe'] ],
-                                        'nonCustodialSubType' : "Replica",
-                                        'nonCustodialGroup' : "express",
-                                        'autoApproveSites' : [ runInfo['express_subscribe'] ],
-                                        'priority' : "high",
-                                        'primaryDataset' : specialDataset,
-                                        'deleteFromSource' : bool(runInfo['express_subscribe']) } )
+                custodialSites = []
+                nonCustodialSites = []
+                autoApproveSites = []
+                if streamConfig.Express.ArchivalNode:
+                    bindsStorageNode.append( { 'NODE' : streamConfig.Express.ArchivalNode } )
+                    custodialSites.append(streamConfig.Express.ArchivalNode)
+                    autoApproveSites.append(streamConfig.Express.ArchivalNode)
+                if streamConfig.Express.TapeNode:
+                    bindsStorageNode.append( { 'NODE' : streamConfig.Express.TapeNode } )
+                    custodialSites.append(streamConfig.Express.TapeNode)
+                if streamConfig.Express.DiskNode:
+                    bindsStorageNode.append( { 'NODE' : streamConfig.Express.DiskNode } )
+                    nonCustodialSites.append(streamConfig.Express.DiskNode)
+                    autoApproveSites.append(streamConfig.Express.DiskNode)
+
+                if len(custodialSites) > 0 or len(nonCustodialSites) > 0:
+                    subscriptions.append( { 'custodialSites' : custodialSites,
+                                            'custodialSubType' : "Replica",
+                                            'custodialGroup' : "DataOps",
+                                            'nonCustodialSites' : nonCustodialSites,
+                                            'nonCustodialSubType' : "Replica",
+                                            'nonCustodialGroup' : streamConfig.Express.PhEDExGroup,
+                                            'autoApproveSites' : autoApproveSites,
+                                            'priority' : "high",
+                                            'primaryDataset' : specialDataset,
+                                            'deleteFromSource' : True } )
 
             alcaSkim = None
             if len(streamConfig.Express.AlcaSkims) > 0:
@@ -385,6 +396,7 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
                                    'SCRAM_ARCH' : streamConfig.Express.ScramArch,
                                    'RECO_CMSSW' : streamConfig.Express.RecoCMSSWVersion,
                                    'RECO_SCRAM_ARCH' : streamConfig.Express.RecoScramArch,
+                                   'DATA_TYPE' : streamConfig.Express.DataType,
                                    'MULTICORE' : streamConfig.Express.Multicore,
                                    'ALCA_SKIM' : alcaSkim,
                                    'DQM_SEQ' : dqmSeq }
@@ -477,21 +489,37 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
                                                       'selectEvents' : selectEvents,
                                                       'primaryDataset' : dataset } )
 
-                if runInfo['express_subscribe']:
+                if streamConfig.Express.ArchivalNode or streamConfig.Express.TapeNode or streamConfig.Express.DiskNode:
 
                     bindsPhEDExConfig.append( { 'RUN' : run,
                                                 'PRIMDS' : dataset,
-                                                'ARCHIVAL_NODE' : None,
-                                                'TAPE_NODE' : None,
-                                                'DISK_NODE' : runInfo['express_subscribe'] } )
+                                                'ARCHIVAL_NODE' : streamConfig.Express.ArchivalNode,
+                                                'TAPE_NODE' : streamConfig.Express.TapeNode,
+                                                'DISK_NODE' : streamConfig.Express.DiskNode } )
 
-                    subscriptions.append( { 'nonCustodialSites' : [ runInfo['express_subscribe'] ],
-                                            'nonCustodialSubType' : "Replica",
-                                            'nonCustodialGroup' : "express",
-                                            'autoApproveSites' : [ runInfo['express_subscribe'] ],
-                                            'priority' : "high",
-                                            'primaryDataset' : dataset,
-                                            'deleteFromSource' : bool(runInfo['express_subscribe']) } )
+                    custodialSites = []
+                    nonCustodialSites = []
+                    autoApproveSites = []
+                    if streamConfig.Express.ArchivalNode:
+                        custodialSites.append(streamConfig.Express.ArchivalNode)
+                        autoApproveSites.append(streamConfig.Express.ArchivalNode)
+                    if streamConfig.Express.TapeNode:
+                        custodialSites.append(streamConfig.Express.TapeNode)
+                    if streamConfig.Express.DiskNode:
+                        nonCustodialSites.append(streamConfig.Express.DiskNode)
+                        autoApproveSites.append(streamConfig.Express.DiskNode)
+
+                    if len(custodialSites) > 0 or len(nonCustodialSites) > 0:
+                        subscriptions.append( { 'custodialSites' : custodialSites,
+                                                'custodialSubType' : "Replica",
+                                                'custodialGroup' : streamConfig.Express.PhEDExGroup,
+                                                'nonCustodialSites' : nonCustodialSites,
+                                                'nonCustodialSubType' : "Replica",
+                                                'nonCustodialGroup' : streamConfig.Express.PhEDExGroup,
+                                                'autoApproveSites' : autoApproveSites,
+                                                'priority' : "high",
+                                                'primaryDataset' : dataset,
+                                                'deleteFromSource' : True } )
 
         #
         # finally create WMSpec
@@ -587,12 +615,12 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
             specArguments['StreamName'] = stream
             specArguments['SpecialDataset'] = specialDataset
 
-            specArguments['UnmergedLFNBase'] = "/store/unmerged/express"
-            specArguments['MergedLFNBase'] = "/store/express"
+            specArguments['UnmergedLFNBase'] = "/store/unmerged/%s" % streamConfig.Express.DataType
             if runInfo['backfill']:
-                specArguments['MergedLFNBase'] = "/store/backfill/%s/express" % runInfo['backfill']
+                specArguments['MergedLFNBase'] = "/store/backfill/%s/%s" % (runInfo['backfill'],
+                                                                            streamConfig.Express.DataType)
             else:
-                specArguments['MergedLFNBase'] = "/store/express"
+                specArguments['MergedLFNBase'] = "/store/%s" % streamConfig.Express.DataType
 
             specArguments['PeriodicHarvestInterval'] = streamConfig.Express.PeriodicHarvestInterval
 

--- a/src/python/T0/RunConfig/Tier0Config.py
+++ b/src/python/T0/RunConfig/Tier0Config.py
@@ -20,8 +20,6 @@ Tier0Configuration - Global configuration object
 | |       |
 | |       |--> ProcessingSite - Main (CERN) site where processing is done.
 | |       |
-| |       |--> ExpressSubscribeNode - Node to which Express is subscribed.
-| |       |
 | |       |--> BulkDataType - The bulk data type for the run
 | |       |
 | |       |--> DQMDataTier - The data tier used for DQM (default is DQMIO).
@@ -132,6 +130,16 @@ Tier0Configuration - Global configuration object
 |             |     |
 |             |     |--> DqmInterval - periodic DQM harvesting interval
 |             |     |
+|             |     |--> DataType - The type of data in this stream (default express)
+|             |     |
+|             |     |--> ArchivalNode - The archival PhEDEx node (default None)
+|             |     |
+|             |     |--> TapeNode - The tape PhEDEx node (default None)
+|             |     |
+|             |     |--> DiskNode - The disk PhEDEx node (default None)
+|             |     |
+|             |     |--> PhEDExGroup - The PhEDEx group for the subscriptions.
+|             |     |
 |             |     |--> BlockCloseDelay - delay to close block in WMAgent
 |             |
 |             |--> Register - Configuration section for register streams
@@ -225,8 +233,6 @@ def createTier0Config():
     tier0Config.Global.Backfill = None
 
     tier0Config.Global.ProcessingSite = "T0_CH_CERN"
-
-    tier0Config.Global.ExpressSubscribeNode = None
 
     tier0Config.Global.DQMDataTier = "DQMIO"
 
@@ -529,15 +535,6 @@ def setProcessingSite(config, site):
     config.Global.ProcessingSite = site
     return
 
-def setExpressSubscribeNode(config, node):
-    """
-    _setExpressSubscribeNode_
-
-    Set the node to which Express is subscribed.
-    """
-    config.Global.ExpressSubscribeNode = node
-    return
-
 def setBulkDataType(config, type):
     """
     _setBulkDataType_
@@ -757,6 +754,13 @@ def addExpressConfig(config, streamName, **options):
     streamConfig.Express.MaxLatency = options.get("maxLatency", 15 * 23)
 
     streamConfig.Express.PeriodicHarvestInterval = options.get("periodicHarvestInterval", 0)
+
+    streamConfig.Express.DataType = options.get("dataType", "express")
+
+    streamConfig.Express.ArchivalNode = options.get("archivalNode", None)
+    streamConfig.Express.TapeNode = options.get("tapeNode", None)
+    streamConfig.Express.DiskNode = options.get("diskNode", None)
+    streamConfig.Express.PhEDExGroup = options.get("phedexGroup", "express")
 
     streamConfig.Express.BlockCloseDelay = options.get("blockCloseDelay", 3600)
 

--- a/src/python/T0/WMBS/Oracle/Create.py
+++ b/src/python/T0/WMBS/Oracle/Create.py
@@ -113,8 +113,7 @@ class Create(DBCreator):
                  process            varchar2(255),
                  acq_era            varchar2(255),
                  backfill           varchar2(255),
-                 bulk_data_type     varchar2(255),
-                 express_subscribe  int,
+                 bulk_data_type     varchar2(50),
                  dqmuploadurl       varchar2(255),
                  ah_timeout         int,
                  ah_dir             varchar2(255),
@@ -282,6 +281,7 @@ class Create(DBCreator):
                  block_delay     int           not null,
                  cmssw_id        int           not null,
                  scram_arch      varchar2(50)  not null,
+                 data_type       varchar2(50)  not null,
                  reco_cmssw_id   int,
                  multicore       int,
                  reco_scram_arch varchar2(50),
@@ -488,12 +488,6 @@ class Create(DBCreator):
                  ADD CONSTRAINT run_sta_fk
                  FOREIGN KEY (status)
                  REFERENCES run_status(id)"""
-
-        self.constraints[len(self.constraints)] = \
-            """ALTER TABLE run
-                 ADD CONSTRAINT run_exp_sub
-                 FOREIGN KEY (express_subscribe)
-                 REFERENCES storage_node(id)"""
 
         self.constraints[len(self.constraints)] = \
             """ALTER TABLE run_trig_primds_assoc

--- a/src/python/T0/WMBS/Oracle/RunConfig/GetExpressConfig.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/GetExpressConfig.py
@@ -28,6 +28,7 @@ class GetExpressConfig(DBFormatter):
                         express_config.scram_arch AS scram_arch,
                         reco_version.name AS reco_cmssw,
                         express_config.reco_scram_arch AS reco_scram_arch,
+                        express_config.data_type AS data_type,
                         express_config.multicore AS multicore,
                         express_config.alca_skim AS alca_skim,
                         express_config.dqm_seq AS dqm_seq,

--- a/src/python/T0/WMBS/Oracle/RunConfig/GetRunInfo.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/GetRunInfo.py
@@ -19,7 +19,6 @@ class GetRunInfo(DBFormatter):
                         run.acq_era AS acq_era,
                         run.backfill AS backfill,
                         run.bulk_data_type AS bulk_data_type,
-                        express_subscribe.name AS express_subscribe,
                         run.dqmuploadurl AS dqmuploadurl,
                         run.ah_timeout AS ah_timeout,
                         run.ah_dir AS ah_dir,
@@ -27,8 +26,6 @@ class GetRunInfo(DBFormatter):
                         run.db_host AS db_host,
                         run.valid_mode AS valid_mode
                  FROM run
-                 LEFT OUTER JOIN storage_node express_subscribe ON
-                   express_subscribe.id = run.express_subscribe
                  WHERE run.run_id = :RUN
                  """
 

--- a/src/python/T0/WMBS/Oracle/RunConfig/InsertExpressConfig.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/InsertExpressConfig.py
@@ -15,8 +15,8 @@ class InsertExpressConfig(DBFormatter):
                  (RUN_ID, STREAM_ID, PROC_VERSION, WRITE_TIERS, WRITE_DQM,
                   GLOBAL_TAG, MAX_RATE, MAX_EVENTS, MAX_SIZE, MAX_FILES,
                   MAX_LATENCY, DQM_INTERVAL, BLOCK_DELAY, CMSSW_ID,
-                  SCRAM_ARCH, RECO_CMSSW_ID, RECO_SCRAM_ARCH, MULTICORE,
-                  ALCA_SKIM, DQM_SEQ)
+                  SCRAM_ARCH, RECO_CMSSW_ID, RECO_SCRAM_ARCH, DATA_TYPE,
+                  MULTICORE, ALCA_SKIM, DQM_SEQ)
                  VALUES (:RUN,
                          (SELECT id FROM stream WHERE name = :STREAM),
                          :PROC_VER,
@@ -34,6 +34,7 @@ class InsertExpressConfig(DBFormatter):
                          :SCRAM_ARCH,
                          (SELECT id FROM cmssw_version WHERE name = :RECO_CMSSW),
                          :RECO_SCRAM_ARCH,
+                         :DATA_TYPE,
                          :MULTICORE,
                          :ALCA_SKIM,
                          :DQM_SEQ)

--- a/src/python/T0/WMBS/Oracle/RunConfig/UpdateRun.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/UpdateRun.py
@@ -16,7 +16,6 @@ class UpdateRun(DBFormatter):
                      acq_era = :ACQERA,
                      backfill = :BACKFILL,
                      bulk_data_type = :BULKDATATYPE,
-                     express_subscribe = (SELECT id FROM storage_node WHERE name = :EXPRESS_SUBSCRIBE),
                      dqmuploadurl = :DQMUPLOADURL,
                      ah_timeout = :AHTIMEOUT,
                      ah_dir = :AHDIR,

--- a/test/python/T0Component_t/Tier0Feeder_t/ExampleConfig.py
+++ b/test/python/T0Component_t/Tier0Feeder_t/ExampleConfig.py
@@ -13,7 +13,6 @@ from T0.RunConfig.Tier0Config import setDefaultScramArch
 from T0.RunConfig.Tier0Config import setBackfill
 from T0.RunConfig.Tier0Config import setBulkDataType
 from T0.RunConfig.Tier0Config import setProcessingSite
-from T0.RunConfig.Tier0Config import setExpressSubscribeNode
 from T0.RunConfig.Tier0Config import setDQMDataTier
 from T0.RunConfig.Tier0Config import setDQMUploadUrl
 from T0.RunConfig.Tier0Config import setPromptCalibrationConfig
@@ -41,7 +40,6 @@ setAcquisitionEra(tier0Config, "ExampleConfig_UnitTest")
 setBackfill(tier0Config, None)
 setBulkDataType(tier0Config, "data")
 setProcessingSite(tier0Config, processingSite)
-setExpressSubscribeNode(tier0Config, "T2_CH_CERN")
 
 # Override for DQM data tier
 setDQMDataTier(tier0Config, "DQMIO")
@@ -108,6 +106,7 @@ addExpressConfig(tier0Config, "HLTMON",
                  write_dqm = False,
                  global_tag = "GlobalTag2",
                  proc_ver = 3,
+                 data_type = 'test',
                  blockCloseDelay = 7200,
                  versionOverride = hltmonVersionOverride)
 

--- a/test/python/T0_t/WMBS_t/RunConfig_t/ExampleConfig.py
+++ b/test/python/T0_t/WMBS_t/RunConfig_t/ExampleConfig.py
@@ -13,7 +13,6 @@ from T0.RunConfig.Tier0Config import setDefaultScramArch
 from T0.RunConfig.Tier0Config import setBackfill
 from T0.RunConfig.Tier0Config import setBulkDataType
 from T0.RunConfig.Tier0Config import setProcessingSite
-from T0.RunConfig.Tier0Config import setExpressSubscribeNode
 from T0.RunConfig.Tier0Config import setDQMDataTier
 from T0.RunConfig.Tier0Config import setDQMUploadUrl
 from T0.RunConfig.Tier0Config import setPromptCalibrationConfig
@@ -41,7 +40,6 @@ setAcquisitionEra(tier0Config, "ExampleConfig_UnitTest")
 setBackfill(tier0Config, None)
 setBulkDataType(tier0Config, "data")
 setProcessingSite(tier0Config, processingSite)
-setExpressSubscribeNode(tier0Config, "T2_CH_CERN")
 
 # Override for DQM data tier
 setDQMDataTier(tier0Config, "DQMIO")
@@ -108,6 +106,7 @@ addExpressConfig(tier0Config, "HLTMON",
                  write_dqm = False,
                  global_tag = "GlobalTag2",
                  proc_ver = 3,
+                 data_type = 'test',
                  blockCloseDelay = 7200,
                  versionOverride = hltmonVersionOverride)
 

--- a/test/python/T0_t/WMBS_t/RunConfig_t/RunConfig_t.py
+++ b/test/python/T0_t/WMBS_t/RunConfig_t/RunConfig_t.py
@@ -149,7 +149,6 @@ class RunConfigTest(unittest.TestCase):
         self.referenceRunInfo = [ { 'status': 1,
                                     'backfill' : None,
                                     'bulk_data_type' : "data",
-                                    'express_subscribe' : 'T2_CH_CERN',
                                     'dqmuploadurl' : "https://cmsweb.cern.ch/dqm/dev",
                                     'process': 'HLT',
                                     'hltkey': self.hltkey,
@@ -1226,6 +1225,9 @@ class RunConfigTest(unittest.TestCase):
         self.assertEqual(expressConfig['reco_scram_arch'], "slc5_amd64_gcc472",
                          "ERROR: wrong reco ScramArch for stream Express")
 
+        self.assertEqual(expressConfig['data_type'], "express",
+                         "ERROR: wrong data type for stream Express")
+
         writeTiers = expressConfig['write_tiers'].split(',')
         self.assertEqual(set(writeTiers), set([ "FEVT" ]),
                          "ERROR: wrong data tiers for stream Express")
@@ -1292,6 +1294,9 @@ class RunConfigTest(unittest.TestCase):
 
         self.assertEqual(expressConfig['reco_scram_arch'], None,
                          "ERROR: wrong reco ScramArch for stream Express")
+
+        self.assertEqual(expressConfig['data_type'], "test",
+                         "ERROR: wrong data type for stream Express")
 
         writeTiers = expressConfig['write_tiers'].split(',')
         self.assertEqual(set(writeTiers), set([ "FEVTHLTALL" ]),


### PR DESCRIPTION
Add config options that allow Express processing to be more like Bulk in the way it handles the output (bulk LFN, configurable subscriptions etc).