### PR TITLE
Add ErrorHandler failure exit codes to T0 config

### DIFF
--- a/etc/Tier0Config.py
+++ b/etc/Tier0Config.py
@@ -36,4 +36,6 @@ config.DBS3Upload.primaryDatasetType = "data"
 
 config.DBSInterface.primaryDatasetType = "data"
 
+config.ErrorHandler.failureExitCodes = [8023, 8026, 50660, 50661, 50664, 71102]
+
 config.AnalyticsDataCollector.pluginName = "Tier0Plugin"


### PR DESCRIPTION
This attribute was removed from the standard WMAgent configuration in (as of 1.1.6.pre6):
https://github.com/dmwm/WMCore/pull/8050

@hufnagel I haven't added the new exit codes CompOps was asking to be added.