### PR TITLE
stop considering HLT CMSSW patch levels for override purposes

### DIFF
--- a/src/python/T0/StorageManager/StorageManagerAPI.py
+++ b/src/python/T0/StorageManager/StorageManagerAPI.py
@@ -93,6 +93,7 @@ def injectNewData(dbInterfaceStorageManager,
         (hltkey, cmssw) = getRunInfoDAO.execute(run = run, transaction = False)
         logging.debug("StorageManagerAPI: run = %d, hltkey = %s, cmssw = %s", run, hltkey, cmssw)
         if hltkey and cmssw:
+            cmssw = '_'.join(cmssw.split('_')[0:4]) # only consider base release
             cmsswVersions.add(cmssw)
             bindRunHltKey.append( { 'RUN': run,
                                     'HLTKEY': hltkey } )


### PR DESCRIPTION
The Repack and Express CMSSW version override currently takes into account the full patch level of the HLT CMSSW. This was mistakenly introduced during the migration to the new transfersystem. Change it back so only he CMSSW version without patches is used for override purposes.