### PR TITLE
Switched to new GTs.

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -123,9 +123,9 @@ expressProcVersion = {
 
 
 # Defaults for GlobalTag
-expressGlobalTag = "100X_dataRun2_Express_v1"
-promptrecoGlobalTag = "100X_dataRun2_Prompt_v1"
-alcap0GlobalTag = "100X_dataRun2_Prompt_v1"
+expressGlobalTag = "100X_dataRun2_Express_v2"
+promptrecoGlobalTag = "100X_dataRun2_Prompt_v2"
+alcap0GlobalTag = "100X_dataRun2_Prompt_v2"
 
 # Mandatory for CondDBv2
 globalTagConnect = "frontier://PromptProd/CMS_CONDITIONS"

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -104,9 +104,9 @@ expressProcVersion = 1
 alcarawProcVersion = 1
 
 # Defaults for GlobalTag
-expressGlobalTag = "100X_dataRun2_Express_forT0Replay_MWGR2"
-promptrecoGlobalTag = "100X_dataRun2_Prompt_forT0Replay_MWGR2"
-alcap0GlobalTag = "100X_dataRun2_Prompt_forT0Replay_MWGR2"
+expressGlobalTag = "100X_dataRun2_Express_v2"
+promptrecoGlobalTag = "100X_dataRun2_Prompt_v2"
+alcap0GlobalTag = "100X_dataRun2_Prompt_v2"
 
 # Mandatory for CondDBv2
 globalTagConnect = "frontier://PromptProd/CMS_CONDITIONS"


### PR DESCRIPTION
https://hypernews.cern.ch/HyperNews/CMS/get/tier0-Ops/1822/1/1/1/2.html