### PR TITLE
don't forward unconfigured runs to Tier0 Data Service

### DIFF
--- a/src/python/T0/WMBS/Oracle/T0DataSvc/GetNewRun.py
+++ b/src/python/T0/WMBS/Oracle/T0DataSvc/GetNewRun.py
@@ -19,6 +19,7 @@ class GetNewRun(DBFormatter):
                         run.acq_era AS acq_era
                  FROM run
                  WHERE checkForZeroState(run.in_datasvc) = 0
+                 AND run.acq_era IS NOT NULL
                  """
 
         results = self.dbi.processData(sql, binds = {}, conn = conn,


### PR DESCRIPTION
Only consider configured runs for forwarding run information to the Tier0 Data Service.