### PR TITLE
Enabled write_reco for TOTEM* datasets

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -1222,6 +1222,7 @@ datasets += [ "ZeroBiasTOTEM1", "ZeroBiasTOTEM2", "ZeroBiasTOTEM3", "ZeroBiasTOT
 for dataset in datasets:
     addDataset(tier0Config, dataset,
                do_reco = True,
+               write_reco = True,
                dqm_sequences = [ "@common" ],
                scenario = ppScenario)
 

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -1117,6 +1117,7 @@ datasets += [ "ZeroBiasTOTEM1", "ZeroBiasTOTEM2", "ZeroBiasTOTEM3", "ZeroBiasTOT
 for dataset in datasets:
     addDataset(tier0Config, dataset,
                do_reco = True,
+               write_reco = True,
                dqm_sequences = [ "@common" ],
                scenario = ppScenario)
 


### PR DESCRIPTION
Enabled `write_reco` for TOTEM* datasets due a request via [Hypernews](https://hypernews.cern.ch/HyperNews/CMS/get/tier0-Ops/1923.html)