### PR TITLE
10_1_8 release and increment of RECO processing version.

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -90,7 +90,7 @@ setPromptCalibrationConfig(tier0Config,
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
        'acqEra': {'Commissioning2018': 'CMSSW_10_1_2_patch2'},
-       'default': "CMSSW_10_1_7"
+       'default': "CMSSW_10_1_8"
      }
 
 # Configure ScramArch
@@ -111,12 +111,12 @@ defaultProcVersionRAW = 1
 
 alcarawProcVersion = {
        'acqEra': {'Commissioning2018': '1', 'Run2018A': '2', 'Run2018B': '2'},
-       'default': "1"
+       'default': "2"
      }
 
 defaultProcVersionReco = {
        'acqEra': {'Commissioning2018': '1', 'Run2018A': '2', 'Run2018B': '2'},
-       'default': "1"
+       'default': "2"
      }
 
 expressProcVersion = {
@@ -144,35 +144,37 @@ alcarawSplitting = 20000 * numberOfCores
 # Setup repack and express mappings
 #
 repackVersionOverride = {
-    "CMSSW_10_0_0" : "CMSSW_10_1_7",
-    "CMSSW_10_0_1" : "CMSSW_10_1_7",
-    "CMSSW_10_0_2" : "CMSSW_10_1_7",
-    "CMSSW_10_0_3" : "CMSSW_10_1_7",
-    "CMSSW_10_0_4" : "CMSSW_10_1_7",
-    "CMSSW_10_0_5" : "CMSSW_10_1_7",
-    "CMSSW_10_1_0" : "CMSSW_10_1_7",
-    "CMSSW_10_1_1" : "CMSSW_10_1_7",
-    "CMSSW_10_1_2" : "CMSSW_10_1_7",
-    "CMSSW_10_1_3" : "CMSSW_10_1_7",
-    "CMSSW_10_1_4" : "CMSSW_10_1_7",
-    "CMSSW_10_1_5" : "CMSSW_10_1_7",
-    "CMSSW_10_1_6" : "CMSSW_10_1_7"
+    "CMSSW_10_0_0" : "CMSSW_10_1_8",
+    "CMSSW_10_0_1" : "CMSSW_10_1_8",
+    "CMSSW_10_0_2" : "CMSSW_10_1_8",
+    "CMSSW_10_0_3" : "CMSSW_10_1_8",
+    "CMSSW_10_0_4" : "CMSSW_10_1_8",
+    "CMSSW_10_0_5" : "CMSSW_10_1_8",
+    "CMSSW_10_1_0" : "CMSSW_10_1_8",
+    "CMSSW_10_1_1" : "CMSSW_10_1_8",
+    "CMSSW_10_1_2" : "CMSSW_10_1_8",
+    "CMSSW_10_1_3" : "CMSSW_10_1_8",
+    "CMSSW_10_1_4" : "CMSSW_10_1_8",
+    "CMSSW_10_1_5" : "CMSSW_10_1_8",
+    "CMSSW_10_1_6" : "CMSSW_10_1_8",
+    "CMSSW_10_1_7" : "CMSSW_10_1_8"
     }
 
 expressVersionOverride = {
-    "CMSSW_10_0_0" : "CMSSW_10_1_7",
-    "CMSSW_10_0_1" : "CMSSW_10_1_7",
-    "CMSSW_10_0_2" : "CMSSW_10_1_7",
-    "CMSSW_10_0_3" : "CMSSW_10_1_7",
-    "CMSSW_10_0_4" : "CMSSW_10_1_7",
-    "CMSSW_10_0_5" : "CMSSW_10_1_7",
-    "CMSSW_10_1_0" : "CMSSW_10_1_7",
-    "CMSSW_10_1_1" : "CMSSW_10_1_7",
-    "CMSSW_10_1_2" : "CMSSW_10_1_7",
-    "CMSSW_10_1_3" : "CMSSW_10_1_7",
-    "CMSSW_10_1_4" : "CMSSW_10_1_7",
-    "CMSSW_10_1_5" : "CMSSW_10_1_7",
-    "CMSSW_10_1_6" : "CMSSW_10_1_7"
+    "CMSSW_10_0_0" : "CMSSW_10_1_8",
+    "CMSSW_10_0_1" : "CMSSW_10_1_8",
+    "CMSSW_10_0_2" : "CMSSW_10_1_8",
+    "CMSSW_10_0_3" : "CMSSW_10_1_8",
+    "CMSSW_10_0_4" : "CMSSW_10_1_8",
+    "CMSSW_10_0_5" : "CMSSW_10_1_8",
+    "CMSSW_10_1_0" : "CMSSW_10_1_8",
+    "CMSSW_10_1_1" : "CMSSW_10_1_8",
+    "CMSSW_10_1_2" : "CMSSW_10_1_8",
+    "CMSSW_10_1_3" : "CMSSW_10_1_8",
+    "CMSSW_10_1_4" : "CMSSW_10_1_8",
+    "CMSSW_10_1_5" : "CMSSW_10_1_8",
+    "CMSSW_10_1_6" : "CMSSW_10_1_8",
+    "CMSSW_10_1_7" : "CMSSW_10_1_8"
     }
 
 #set default repack settings for bulk streams

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -83,7 +83,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-       'default': "CMSSW_10_1_7"
+       'default': "CMSSW_10_1_8"
      }
 
 # Configure ScramArch
@@ -124,35 +124,37 @@ alcarawSplitting = 20000 * numberOfCores
 # Setup repack and express mappings
 #
 repackVersionOverride = {
-    "CMSSW_10_0_0" : "CMSSW_10_1_7",
-    "CMSSW_10_0_1" : "CMSSW_10_1_7",
-    "CMSSW_10_0_2" : "CMSSW_10_1_7",
-    "CMSSW_10_0_3" : "CMSSW_10_1_7",
-    "CMSSW_10_0_4" : "CMSSW_10_1_7",
-    "CMSSW_10_0_5" : "CMSSW_10_1_7",
-    "CMSSW_10_1_0" : "CMSSW_10_1_7",
-    "CMSSW_10_1_1" : "CMSSW_10_1_7",
-    "CMSSW_10_1_2" : "CMSSW_10_1_7",
-    "CMSSW_10_1_3" : "CMSSW_10_1_7",
-    "CMSSW_10_1_4" : "CMSSW_10_1_7",
-    "CMSSW_10_1_5" : "CMSSW_10_1_7",
-    "CMSSW_10_1_6" : "CMSSW_10_1_7"
+    "CMSSW_10_0_0" : "CMSSW_10_1_8",
+    "CMSSW_10_0_1" : "CMSSW_10_1_8",
+    "CMSSW_10_0_2" : "CMSSW_10_1_8",
+    "CMSSW_10_0_3" : "CMSSW_10_1_8",
+    "CMSSW_10_0_4" : "CMSSW_10_1_8",
+    "CMSSW_10_0_5" : "CMSSW_10_1_8",
+    "CMSSW_10_1_0" : "CMSSW_10_1_8",
+    "CMSSW_10_1_1" : "CMSSW_10_1_8",
+    "CMSSW_10_1_2" : "CMSSW_10_1_8",
+    "CMSSW_10_1_3" : "CMSSW_10_1_8",
+    "CMSSW_10_1_4" : "CMSSW_10_1_8",
+    "CMSSW_10_1_5" : "CMSSW_10_1_8",
+    "CMSSW_10_1_6" : "CMSSW_10_1_8",
+    "CMSSW_10_1_7" : "CMSSW_10_1_8"
     }
 
 expressVersionOverride = {
-    "CMSSW_10_0_0" : "CMSSW_10_1_7",
-    "CMSSW_10_0_1" : "CMSSW_10_1_7",
-    "CMSSW_10_0_2" : "CMSSW_10_1_7",
-    "CMSSW_10_0_3" : "CMSSW_10_1_7",
-    "CMSSW_10_0_4" : "CMSSW_10_1_7",
-    "CMSSW_10_0_5" : "CMSSW_10_1_7",
-    "CMSSW_10_1_0" : "CMSSW_10_1_7",
-    "CMSSW_10_1_1" : "CMSSW_10_1_7",
-    "CMSSW_10_1_2" : "CMSSW_10_1_7",
-    "CMSSW_10_1_3" : "CMSSW_10_1_7",
-    "CMSSW_10_1_4" : "CMSSW_10_1_7",
-    "CMSSW_10_1_5" : "CMSSW_10_1_7",
-    "CMSSW_10_1_6" : "CMSSW_10_1_7"
+    "CMSSW_10_0_0" : "CMSSW_10_1_8",
+    "CMSSW_10_0_1" : "CMSSW_10_1_8",
+    "CMSSW_10_0_2" : "CMSSW_10_1_8",
+    "CMSSW_10_0_3" : "CMSSW_10_1_8",
+    "CMSSW_10_0_4" : "CMSSW_10_1_8",
+    "CMSSW_10_0_5" : "CMSSW_10_1_8",
+    "CMSSW_10_1_0" : "CMSSW_10_1_8",
+    "CMSSW_10_1_1" : "CMSSW_10_1_8",
+    "CMSSW_10_1_2" : "CMSSW_10_1_8",
+    "CMSSW_10_1_3" : "CMSSW_10_1_8",
+    "CMSSW_10_1_4" : "CMSSW_10_1_8",
+    "CMSSW_10_1_5" : "CMSSW_10_1_8",
+    "CMSSW_10_1_6" : "CMSSW_10_1_8",
+    "CMSSW_10_1_7" : "CMSSW_10_1_8"
     }
 
 #set default repack settings for bulk streams


### PR DESCRIPTION
https://hypernews.cern.ch/HyperNews/CMS/get/tier0-Ops/1939/1/1/1/1/1/1/1/1/1/1.html