### PR TITLE
add priority transition needed for WMAgent 1.1.15 and up (backward compatible)

### DIFF
--- a/src/python/T0/RunConfig/RunConfigAPI.py
+++ b/src/python/T0/RunConfig/RunConfigAPI.py
@@ -552,6 +552,7 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
             specArguments['RequestTransition'] = []
             specArguments['RequestStatus'] = REQUEST_START_STATE
             specArguments['RequestPriority'] = tier0Config.Global.BaseRequestPriority + 5000
+            specArguments['PriorityTransition'] = []
 
             specArguments['CMSSWVersion'] = streamConfig.Repack.CMSSWVersion
             specArguments['ScramArch'] = streamConfig.Repack.ScramArch
@@ -611,6 +612,7 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
             specArguments['RequestTransition'] = []
             specArguments['RequestStatus'] = REQUEST_START_STATE
             specArguments['RequestPriority'] = tier0Config.Global.BaseRequestPriority + 10000
+            specArguments['PriorityTransition'] = []
 
             specArguments['ProcessingString'] = "Express"
             specArguments['ProcessingVersion'] = streamConfig.Express.ProcessingVersion
@@ -1022,6 +1024,7 @@ def releasePromptReco(tier0Config, specDirectory, dqmUploadProxy):
                 specArguments['RequestTransition'] = []
                 specArguments['RequestStatus'] = REQUEST_START_STATE
                 specArguments['RequestPriority'] = tier0Config.Global.BaseRequestPriority
+                specArguments['PriorityTransition'] = []
 
                 specArguments['AcquisitionEra'] = runInfo['acq_era']
                 specArguments['CMSSWVersion'] = datasetConfig.CMSSWVersion


### PR DESCRIPTION
This is needed if Tier0 uses WMAgent 1.1.15 and up but also backward compatible so it can be merged even if uses lower version of WMAgent)