### PR TITLE
fix bug in disk node configuration

### DIFF
--- a/src/python/T0/RunConfig/RunConfigAPI.py
+++ b/src/python/T0/RunConfig/RunConfigAPI.py
@@ -467,10 +467,11 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
                         custodialSites.append(datasetConfig.RAWTapeNode)
                     else:
                         custodialSites.append(datasetConfig.TapeNode)
-                if datasetConfig.DiskNode and datasetConfig.RAWtoDisk:
+                if datasetConfig.DiskNode:
                     bindsStorageNode.append( { 'NODE' : datasetConfig.DiskNode } )
-                    nonCustodialSites.append(datasetConfig.DiskNode)
-                    autoApproveSites.append(datasetConfig.DiskNode)
+                    if datasetConfig.RAWtoDisk:
+                        nonCustodialSites.append(datasetConfig.DiskNode)
+                        autoApproveSites.append(datasetConfig.DiskNode)
                 if datasetConfig.DiskNodeReco:
                     bindsStorageNode.append( { 'NODE' : datasetConfig.DiskNodeReco } )
 


### PR DESCRIPTION
If a disk node was configured, but no dataset had RAW subscribed to that disk node, a critical code path was skipped that added the disk node to the list of defined nodes, leading to no disk subscriptions being made, not even for non-RAW data tiers.