### PR TITLE
Adding a global EnableUniqueWorkflowName configuration parameter to b…

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -25,6 +25,7 @@ from T0.RunConfig.Tier0Config import addRegistrationConfig
 from T0.RunConfig.Tier0Config import addConversionConfig
 from T0.RunConfig.Tier0Config import setInjectRuns
 from T0.RunConfig.Tier0Config import setStreamerPNN
+from T0.RunConfig.Tier0Config import setEnableUniqueWorkflowName
 
 # Create the Tier0 configuration object
 tier0Config = createTier0Config()
@@ -33,7 +34,7 @@ tier0Config = createTier0Config()
 setConfigVersion(tier0Config, "replace with real version")
 
 # Set run number to replay
-setInjectRuns(tier0Config, [ 322602 ])
+setInjectRuns(tier0Config, [ 322057 ])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"
@@ -55,6 +56,11 @@ setStreamerPNN(tier0Config, streamerPNN)
 
 # Override for DQM data tier
 setDQMDataTier(tier0Config, "DQMIO")
+
+# Set unique replay workflow names
+# Uses era name, Repack, Express, PromptReco processing versions, date/time, e.g.:
+# PromptReco_Run322057_Charmonium_Tier0_REPLAY_vocms047_v274_190221_121
+setEnableUniqueWorkflowName(tier0Config)
 
 # Define the two default timeouts for reco release
 # First timeout is used directly for reco release
@@ -101,9 +107,9 @@ alcaLumiPixelsScenario = "AlCaLumiPixels"
 hiTestppScenario = "ppEra_Run2_2018_pp_on_AA"
 
 # Defaults for processing version
-defaultProcVersion = 258
-expressProcVersion = 258
-alcarawProcVersion = 258
+defaultProcVersion = 274
+expressProcVersion = 274
+alcarawProcVersion = 274
 
 # Defaults for GlobalTag
 expressGlobalTag = "102X_dataRun2_Express_v4"
@@ -693,7 +699,8 @@ for dataset in datasets:
     addDataset(tier0Config, dataset,
                do_reco = True,
                write_dqm = True,
-               alca_producers = [ "EcalUncalZElectron", "EcalUncalWElectron", "HcalCalIterativePhiSym", "HcalCalIsoTrkFilter", "EcalESAlign" ],
+               alca_producers = [ "EcalUncalZElectron", "EcalUncalWElectron", "HcalCalIterativePhiSym",
+                "HcalCalIsoTrkFilter", "EcalESAlign" ],
                dqm_sequences = [ "@common", "@ecal", "@egamma", "@L1TEgamma" ],
                physics_skims = [ "EXOMONOPOLE", "ZElectron", "LogError", "LogErrorMonitor" ],
                scenario = ppScenario)

--- a/src/python/T0/RunConfig/RunConfigAPI.py
+++ b/src/python/T0/RunConfig/RunConfigAPI.py
@@ -551,7 +551,13 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
         if streamConfig.ProcessingStyle == "Bulk":
 
             taskName = "Repack"
-            workflowName = "Repack_Run%d_Stream%s" % (run, stream)
+
+            if tier0Config.Global.EnableUniqueWorkflowName:
+                workflowName = "Repack_Run%d_Stream%s_%s_v%s_%s" % (run, stream, 
+                    tier0Config.Global.AcquisitionEra, streamConfig.Repack.ProcessingVersion, 
+                    time.strftime('%y%m%d_%H%M', time.localtime(time.time())))
+            else:
+                workflowName = "Repack_Run%d_Stream%s" % (run, stream)
 
             specArguments = {}
 
@@ -600,7 +606,13 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
         elif streamConfig.ProcessingStyle == "Express":
 
             taskName = "Express"
-            workflowName = "Express_Run%d_Stream%s" % (run, stream)
+
+            if tier0Config.Global.EnableUniqueWorkflowName:
+                workflowName = "Express_Run%d_Stream%s_%s_v%s_%s" % (run, stream, 
+                    tier0Config.Global.AcquisitionEra, streamConfig.Express.ProcessingVersion,
+                    time.strftime('%y%m%d_%H%M', time.localtime(time.time())))
+            else:
+                workflowName = "Express_Run%d_Stream%s" % (run, stream)
 
             specArguments = {}
 
@@ -1020,7 +1032,13 @@ def releasePromptReco(tier0Config, specDirectory, dqmUploadProxy):
                 # create WMSpec
                 #
                 taskName = "Reco"
-                workflowName = "PromptReco_Run%d_%s" % (run, dataset)
+
+                if tier0Config.Global.EnableUniqueWorkflowName:
+                    workflowName = "PromptReco_Run%d_%s_%s_v%s_%s" % (run, dataset,
+                        tier0Config.Global.AcquisitionEra, datasetConfig.ProcessingVersion,
+                        time.strftime('%y%m%d_%H%M', time.localtime(time.time())))
+                else:
+                    workflowName = "PromptReco_Run%d_%s" % (run, dataset)
 
                 specArguments = {}
 

--- a/src/python/T0/RunConfig/Tier0Config.py
+++ b/src/python/T0/RunConfig/Tier0Config.py
@@ -257,6 +257,8 @@ def createTier0Config():
 
     tier0Config.Global.BaseRequestPriority = 150000
 
+    tier0Config.Global.EnableUniqueWorkflowName = False
+
     return tier0Config
 
 def retrieveStreamConfig(config, streamName):
@@ -661,6 +663,17 @@ def setInjectMaxRun(config, injectMaxRun):
     Set the highest run to be injected into the Tier0.
     """
     config.Global.InjectMaxRun = injectMaxRun
+    return
+
+def setEnableUniqueWorkflowName(config):
+    """
+    _setEnableUniqueWorkflowName_
+
+    Enables using unique workflow names in Tier0 replays.
+    Uses era name, Repack, Express, PromptReco processing versions, date/time, e.g.:
+    PromptReco_Run322057_Charmonium_Tier0_REPLAY_vocms047_v274_190221_121
+    """
+    config.Global.EnableUniqueWorkflowName = True
     return
 
 def ignoreStream(config, streamName):


### PR DESCRIPTION
…e used in replays. If enabled, the replay workflows would be formed adding the era name, processing version number and date (YYMMDD) + time (hhmm):
PromptReco_Run322057_Charmonium_Tier0_REPLAY_vocms047_v274_190221_1210