### PR TITLE
fix schema init order for unittests

### DIFF
--- a/test/python/T0Component_t/Tier0Feeder_t/Tier0Feeder_t.py
+++ b/test/python/T0Component_t/Tier0Feeder_t/Tier0Feeder_t.py
@@ -39,7 +39,7 @@ class Tier0FeederTest(unittest.TestCase):
         self.testInit.setLogging()
         self.testInit.setDatabaseConnection()
 
-        self.testInit.setSchema(customModules = ["T0.WMBS", "WMComponent.DBS3Buffer"])
+        self.testInit.setSchema(customModules=["WMComponent.DBS3Buffer", "T0.WMBS"])
 
         self.testDir  = self.testInit.generateWorkDir()
 

--- a/test/python/T0_t/WMBS_t/RunConfig_t/RunConfig_t.py
+++ b/test/python/T0_t/WMBS_t/RunConfig_t/RunConfig_t.py
@@ -38,7 +38,7 @@ class RunConfigTest(unittest.TestCase):
         self.testInit.setLogging()
         self.testInit.setDatabaseConnection()
 
-        self.testInit.setSchema(customModules = ["T0.WMBS", "WMComponent.DBS3Buffer"])
+        self.testInit.setSchema(customModules=["WMComponent.DBS3Buffer", "T0.WMBS"])
 
         self.testDir  = self.testInit.generateWorkDir()
 


### PR DESCRIPTION
The T0 schema depends on the DBS3Buffer schema, so the latter needs to be initialized first.