### PR TITLE
Adding the up-to-date versions of deploy and software scripts.

### DIFF
--- a/bin/00_deploy_prod.sh
+++ b/bin/00_deploy_prod.sh
@@ -1,0 +1,258 @@
+#!/bin/bash
+
+BASE_DIR=/data/tier0
+DEPLOY_DIR=$BASE_DIR/srv/wmagent
+SPEC_DIR=$BASE_DIR/admin/Specs
+
+TIER0_VERSION=2.1.4
+TIER0_ARCH=slc7_amd64_gcc630
+
+function echo_header {
+	echo ''
+	echo " *** $1 *** "
+}
+
+# A simple confirmation check:
+AGENTNAME=$(hostname)
+while true; do
+    read -p "Are you sure you want to re-deploy the $AGENTNAME (y/n)? " yn
+    case $yn in
+      [Y/y]* ) DATA1=true; break;;
+      [N/n]* ) DATA1=false; break;;
+      * ) echo "Please answer yes or no.";;
+    esac
+done
+if [ "$DATA1" == false ]; then
+    echo "Exiting the deploy script. "
+    exit 1;
+else
+    echo "Starting the deploy script. "
+fi
+
+echo_header "Removing deploy dir \"$DEPLOY_DIR\""
+rm -rfv $DEPLOY_DIR
+mkdir -p $DEPLOY_DIR
+
+echo_header "Removing specs dir \"$SPEC_DIR\""
+rm -rfv $SPEC_DIR
+mkdir -p $SPEC_DIR
+
+cd $BASE_DIR
+echo_header "deleting deployment dir \"deployment\""
+rm -rfv deployment
+git clone https://github.com/dmwm/deployment.git
+
+cd deployment
+
+echo_header 'Deploying Tier0 WMAgent'
+#Dirk's private repo deployment
+#./Deploy -s prep -r comp=comp.hufnagel -A $TIER0_ARCH -t $TIER0_VERSION -R tier0@$TIER0_VERSION $DEPLOY_DIR tier0@$TIER0_VERSION
+#./Deploy -s sw -r comp=comp.hufnagel -A $TIER0_ARCH -t $TIER0_VERSION -R tier0@$TIER0_VERSION $DEPLOY_DIR tier0@$TIER0_VERSION
+#./Deploy -s post -r comp=comp.hufnagel -A $TIER0_ARCH -t $TIER0_VERSION -R tier0@$TIER0_VERSION $DEPLOY_DIR tier0@$TIER0_VERSION
+
+#Usual deployment
+./Deploy -s prep -r comp=comp -A $TIER0_ARCH -t $TIER0_VERSION -R tier0@$TIER0_VERSION $DEPLOY_DIR tier0@$TIER0_VERSION
+./Deploy -s sw -r comp=comp -A $TIER0_ARCH -t $TIER0_VERSION -R tier0@$TIER0_VERSION $DEPLOY_DIR tier0@$TIER0_VERSION
+./Deploy -s post -r comp=comp -A $TIER0_ARCH -t $TIER0_VERSION -R tier0@$TIER0_VERSION $DEPLOY_DIR tier0@$TIER0_VERSION
+
+## global patch override
+echo_header 'Applying general patches and cleaning t0ast'
+$BASE_DIR/00_patches.sh 2>&1 > /dev/null
+
+## clean database
+$BASE_DIR/00_wipe_t0ast.sh 2>&1 > /dev/null
+if [ $? -ne 0 ]; then # If: last exit code is non-zero
+    echo "Not wiping t0ast. Exiting the script."
+    exit 1
+fi
+
+# needs secret file location and user certs
+source $BASE_DIR/admin/env.sh
+
+cd $DEPLOY_DIR/current
+
+echo_header 'Initializing services / agent'
+./config/tier0/manage activate-tier0
+./config/tier0/manage start-services
+./config/tier0/manage init-tier0
+sleep 5
+
+#
+# mandatory configuration tweaks
+#
+sed -i 's+TIER0_CONFIG_FILE+/data/tier0/admin/ProdOfflineConfiguration.py+' ./config/tier0/config.py
+#sed -i 's+TIER0_CONFIG_FILE+/data/tier0/admin/ReplayOfflineConfiguration.py+' ./config/tier0/config.py
+sed -i 's+TIER0_SPEC_DIR+/data/tier0/admin/Specs+' ./config/tier0/config.py
+
+# Real information for WMStats
+sed -i "s+config.Agent.teamName = 'REPLACE_TEAM_NAME'+config.Agent.teamName = 'Tier0Production'+" ./config/tier0/config.py
+sed -i "s+config.Agent.contact = 'cms-comp-ops-workflow-team@cern.ch'+config.Agent.contact = 'cms-tier0-operations@cern.ch'+" ./config/tier0/config.py
+#sed -i "s+OP EMAIL+Dirk.Hufnagel@cern.ch+g" ./config/tier0/config.py
+#sed -i "s+wmagentalerts@gmail.com+Dirk.Hufnagel@cern.ch+g" ./config/tier0/config.py
+
+#
+# Use this team and not the default 
+#
+sed -i "s+'team1,team2,cmsdataops'+'tier0production'+g" ./config/tier0/config.py
+#sed -i "s+'team1,team2,cmsdataops'+'tier0replay'+g" ./config/tier0/config.py
+
+#
+# configure retry settings
+#
+echo "config.RetryManager.PauseAlgo.default.coolOffTime = {'create': 10, 'job': 10, 'submit': 10}" >> ./config/tier0/config.py
+#sed -i "s+ErrorHandler.pollInterval = 240+ErrorHandler.pollInterval = 30+g" ./config/tier0/config.py
+#sed -i "s+RetryManager.pollInterval = 240+RetryManager.pollInterval = 30+g" ./config/tier0/config.py
+
+#
+# switch to ProcessingAlgo
+#
+#sed -i "s+config.RetryManager.plugins = {'default': 'PauseAlgo', 'Cleanup': 'SquaredAlgo', 'LogCollect': 'SquaredAlgo'}+config.RetryManager.plugins = {'default': 'ProcessingAlgo'}+g" ./config/tier0/config.py
+#echo "config.RetryManager.section_('ProcessingAlgo')" >> ./config/tier0/config.py
+#echo "config.RetryManager.ProcessingAlgo.section_('default')" >> ./config/tier0/config.py
+#echo "config.RetryManager.ProcessingAlgo.default.coolOffTime = {'create': 10, 'job': 10, 'submit': 10}" >> ./config/tier0/config.py
+#echo "config.RetryManager.ProcessingAlgo.default.closeoutPercentage = 95" >> ./config/tier0/config.py
+#echo "config.RetryManager.ProcessingAlgo.default.guaranteedRetries = 4" >> ./config/tier0/config.py
+#echo "config.RetryManager.ProcessingAlgo.default.minRetryTime = 1" >> ./config/tier0/config.py
+#echo "config.RetryManager.ProcessingAlgo.default.maxRetryTime = 2" >> ./config/tier0/config.py
+
+#
+# configure DEBUG output
+#
+#sed -i "s+config.ErrorHandler.logLevel = 'INFO'+config.ErrorHandler.logLevel = 'DEBUG'+g" ./config/tier0/config.py
+#sed -i "s+config.RetryManager.logLevel = 'INFO'+config.RetryManager.logLevel = 'DEBUG'+g" ./config/tier0/config.py
+#sed -i "s+config.PhEDExInjector.logLevel = 'INFO'+config.PhEDExInjector.logLevel = 'DEBUG'+g" ./config/tier0/config.py
+#sed -i "s+config.JobCreator.logLevel = 'INFO'+config.JobCreator.logLevel = 'DEBUG'+g" ./config/tier0/config.py
+
+#
+# configure shorter polling cyles
+#
+#echo 'config.ErrorHandler.pollInterval = 30' >> ./config/tier0/config.py
+#echo 'config.RetryManager.pollInterval = 30' >> ./config/tier0/config.py
+#echo 'config.DBS3Upload.pollInterval = 30' >> ./config/tier0/config.py
+#echo 'config.PhEDExInjector.pollInterval = 30' >> ./config/tier0/config.py
+
+#
+# configure Tier0-Mode for PhEDEx
+#
+echo 'config.PhEDExInjector.tier0Mode = False' >> ./config/tier0/config.py
+echo 'config.PhEDExInjector.autoDelete = False' >> ./config/tier0/config.py
+sed -i "s+config.PhEDExInjector.subscribeInterval = 43200+config.PhEDExInjector.subscribeInterval = 30+g" ./config/tier0/config.py
+
+#
+# Set output datasets status to VALID in DBS
+#
+echo "config.DBS3Upload.datasetType = 'VALID'" >> ./config/tier0/config.py
+
+#
+# needed for LSF DQM uploads
+#
+#echo 'config.Tier0Feeder.dqmUploadProxy = "/afs/cern.ch/user/h/hufnagel/private/Certificates/dqmcert.pem"' >> ./config/tier0/config.py
+
+#
+# needed for conditions upload
+#
+echo "config.Tier0Feeder.serviceProxy = '/data/certs/serviceproxy-vocms001.pem'" >> ./config/tier0/config.py
+
+#
+# password for dropbox upload
+#
+
+HOME="/data/tier0/admin/"
+
+if [ "x$WMAGENT_SECRETS_LOCATION" == "x" ]; then
+    WMAGENT_SECRETS_LOCATION=$HOME/WMAgent.secrets;
+fi
+if [ ! -e $WMAGENT_SECRETS_LOCATION ]; then
+    echo "Password file: $WMAGENT_SECRETS_LOCATION does not exist"
+    echo "Either set WMAGENT_SECRETS_LOCATION to a valid file or check that $HOME/WMAgent.secrets exists"
+    exit 1;
+fi
+
+DROPBOX_USER=`cat $WMAGENT_SECRETS_LOCATION | grep DROPBOX_USER | sed s/DROPBOX_USER=//`
+DROPBOX_PASS=`cat $WMAGENT_SECRETS_LOCATION | grep DROPBOX_PASS | sed s/DROPBOX_PASS=//`
+
+if [ "x$DROPBOX_USER" == "x" ] || [ "x$DROPBOX_PASS" == "x" ]; then
+    echo "Secrets file doesn't contain DROPBOX_USER or DROPBOX_PASS";
+    exit 1
+fi
+
+echo 'config.Tier0Feeder.dropboxuser = "'$DROPBOX_USER'"' >> ./config/tier0/config.py
+echo 'config.Tier0Feeder.dropboxpass = "'$DROPBOX_PASS'"' >> ./config/tier0/config.py
+
+#
+# needed for passing notifications back to StorageManager
+#
+#echo 'config.Tier0Feeder.transferSystemBaseDir = "/data/tier0/sminject"' >> ./config/tier0/config.py
+
+#
+# upload PromptReco performance data
+#
+echo 'config.TaskArchiver.dashBoardUrl = "http://dashb-luminosity.cern.ch/dashboard/request.py/putluminositydata"' >> ./config/tier0/config.py
+echo 'config.TaskArchiver.logLevel = "DEBUG"' >> ./config/tier0/config.py
+
+#
+# Workflow archive delay
+#
+echo 'config.TaskArchiver.archiveDelayHours = 168' >> ./config/tier0/config.py
+
+#
+# Do not use WorkQueue
+#
+echo 'config.TaskArchiver.useWorkQueue = False' >> ./config/tier0/config.py
+
+#
+# Enable AgentStatusWatcher - site status automatic updated
+#
+echo "config.AgentStatusWatcher.enabled = False" >> ./config/tier0/config.py
+echo "config.AgentStatusWatcher.onlySSB = False" >> ./config/tier0/config.py
+
+#
+# Increase ErrorHandler maxFailTime
+#
+echo "config.ErrorHandler.maxFailTime = 604800" >> ./config/tier0/config.py
+
+#
+# JobAccountant Repack Error Dataset settings
+#
+echo 'config.JobAccountant.maxAllowedRepackOutputSize = 24 * 1024 * 1024 * 1024' >> ./config/tier0/config.py
+
+#
+# Use SimpleCondorPlugin by default
+#
+echo 'config.BossAir.pluginNames = ["SimpleCondorPlugin"]' >> ./config/tier0/config.py
+
+#
+# Setting up sites
+#
+
+#./config/tier0/manage execute-agent wmagent-resource-control --site-name=T0_CH_CERN --cms-name=T0_CH_CERN --pnn=T0_CH_CERN_Disk --ce-name=T0_CH_CERN --pending-slots=1600 --running-slots=9000 --plugin=SimpleCondorPlugin
+#./config/tier0/manage execute-agent wmagent-resource-control --site-name=T0_CH_CERN --task-type=Processing --pending-slots=800 --running-slots=9000
+#./config/tier0/manage execute-agent wmagent-resource-control --site-name=T0_CH_CERN --task-type=Merge --pending-slots=200 --running-slots=1000
+#./config/tier0/manage execute-agent wmagent-resource-control --site-name=T0_CH_CERN --task-type=Cleanup --pending-slots=80 --running-slots=160
+#./config/tier0/manage execute-agent wmagent-resource-control --site-name=T0_CH_CERN --task-type=LogCollect --pending-slots=40 --running-slots=80
+#./config/tier0/manage execute-agent wmagent-resource-control --site-name=T0_CH_CERN --task-type=Skim --pending-slots=1 --running-slots=1
+#./config/tier0/manage execute-agent wmagent-resource-control --site-name=T0_CH_CERN --task-type=Production --pending-slots=1 --running-slots=1
+#./config/tier0/manage execute-agent wmagent-resource-control --site-name=T0_CH_CERN --task-type=Harvesting --pending-slots=40 --running-slots=80
+#./config/tier0/manage execute-agent wmagent-resource-control --site-name=T0_CH_CERN --task-type=Express --pending-slots=800 --running-slots=9000
+#./config/tier0/manage execute-agent wmagent-resource-control --site-name=T0_CH_CERN --task-type=Repack --pending-slots=500 --running-slots=2500
+
+./config/tier0/manage execute-agent wmagent-resource-control --site-name=T2_CH_CERN --cms-name=T2_CH_CERN --pnn=T2_CH_CERN --ce-name=T2_CH_CERN --pending-slots=20000 --running-slots=20000 --plugin=SimpleCondorPlugin
+./config/tier0/manage execute-agent wmagent-resource-control --site-name=T2_CH_CERN --task-type=Processing --pending-slots=10000 --running-slots=10000
+./config/tier0/manage execute-agent wmagent-resource-control --site-name=T2_CH_CERN --task-type=Merge --pending-slots=1000 --running-slots=1000
+./config/tier0/manage execute-agent wmagent-resource-control --site-name=T2_CH_CERN --task-type=Cleanup --pending-slots=1000 --running-slots=1000
+./config/tier0/manage execute-agent wmagent-resource-control --site-name=T2_CH_CERN --task-type=LogCollect --pending-slots=1000 --running-slots=1000
+./config/tier0/manage execute-agent wmagent-resource-control --site-name=T2_CH_CERN --task-type=Skim --pending-slots=1 --running-slots=1
+./config/tier0/manage execute-agent wmagent-resource-control --site-name=T2_CH_CERN --task-type=Production --pending-slots=1 --running-slots=1
+./config/tier0/manage execute-agent wmagent-resource-control --site-name=T2_CH_CERN --task-type=Harvesting --pending-slots=1000 --running-slots=1000
+./config/tier0/manage execute-agent wmagent-resource-control --site-name=T2_CH_CERN --task-type=Express --pending-slots=3000 --running-slots=3000
+./config/tier0/manage execute-agent wmagent-resource-control --site-name=T2_CH_CERN --task-type=Repack --pending-slots=5000 --running-slots=5000
+
+# Thresholds configurations
+echo "config.AgentStatusWatcher.t1SitesCores = 12.5"  >> ./config/tier0/config.py
+
+echo "config.AgentStatusWatcher.pendingSlotsTaskPercent = 30" >> ./config/tier0/config.py
+echo "config.AgentStatusWatcher.pendingSlotsSitePercent = 40" >> ./config/tier0/config.py
+
+echo "config.AgentStatusWatcher.runningExpressPercent = 25" >> ./config/tier0/config.py
+echo "config.AgentStatusWatcher.runningRepackPercent = 10" >> ./config/tier0/config.py
+

--- a/bin/00_deploy_replay.sh
+++ b/bin/00_deploy_replay.sh
@@ -1,0 +1,228 @@
+#!/bin/bash
+
+BASE_DIR=/data/tier0
+DEPLOY_DIR=$BASE_DIR/srv/wmagent
+SPEC_DIR=$BASE_DIR/admin/Specs
+
+TIER0_VERSION=2.1.4
+TIER0_ARCH=slc7_amd64_gcc630
+
+function echo_header {
+    echo ''
+    echo " *** $1 *** "
+}
+
+echo_header "Removing deploy dir \"$DEPLOY_DIR\""
+rm -rf $DEPLOY_DIR
+mkdir -p $DEPLOY_DIR
+
+echo_header "Removing specs dir \"$SPEC_DIR\""
+rm -rf $SPEC_DIR
+mkdir -p $SPEC_DIR
+
+cd $BASE_DIR
+echo_header "deleting deployment dir \"deployment\""
+rm -rf deployment
+git clone https://github.com/dmwm/deployment.git
+cd deployment
+
+echo_header 'Deploying Tier0 WMAgent'
+#Dirk's private repo deployment
+#./Deploy -s prep -r comp=comp.hufnagel -A $TIER0_ARCH -t $TIER0_VERSION -R tier0@$TIER0_VERSION $DEPLOY_DIR tier0@$TIER0_VERSION
+#./Deploy -s sw -r comp=comp.hufnagel -A $TIER0_ARCH -t $TIER0_VERSION -R tier0@$TIER0_VERSION $DEPLOY_DIR tier0@$TIER0_VERSION
+#./Deploy -s post -r comp=comp.hufnagel -A $TIER0_ARCH -t $TIER0_VERSION -R tier0@$TIER0_VERSION $DEPLOY_DIR tier0@$TIER0_VERSION
+
+#Usual deployment
+./Deploy -s prep -r comp=comp -A $TIER0_ARCH -t $TIER0_VERSION -R tier0@$TIER0_VERSION $DEPLOY_DIR tier0@$TIER0_VERSION
+./Deploy -s sw -r comp=comp -A $TIER0_ARCH -t $TIER0_VERSION -R tier0@$TIER0_VERSION $DEPLOY_DIR tier0@$TIER0_VERSION
+./Deploy -s post -r comp=comp -A $TIER0_ARCH -t $TIER0_VERSION -R tier0@$TIER0_VERSION $DEPLOY_DIR tier0@$TIER0_VERSION
+
+## global patch override
+echo_header 'Applying general patches and cleaning t0ast'
+$BASE_DIR/00_patches.sh 2>&1 > /dev/null
+
+## clean database
+$BASE_DIR/00_wipe_t0ast.sh 2>&1 > /dev/null
+
+# needs secret file location and user certs
+source $BASE_DIR/admin/env.sh
+
+cd $DEPLOY_DIR/current
+
+echo_header 'Initializing services / agent'
+./config/tier0/manage activate-tier0
+./config/tier0/manage start-services
+./config/tier0/manage init-tier0
+sleep 5
+
+#
+# mandatory configuration tweaks
+#
+#sed -i 's+TIER0_CONFIG_FILE+/data/tier0/admin/ProdOfflineConfiguration.py+' ./config/tier0/config.py
+sed -i 's+TIER0_CONFIG_FILE+/data/tier0/admin/ReplayOfflineConfiguration.py+' ./config/tier0/config.py
+sed -i 's+TIER0_SPEC_DIR+/data/tier0/admin/Specs+' ./config/tier0/config.py
+
+# Real information for WMStats
+sed -i "s+config.Agent.teamName = 'REPLACE_TEAM_NAME'+config.Agent.teamName = 'Tier0Replay'+" ./config/tier0/config.py
+sed -i "s+config.Agent.contact = 'cms-comp-ops-workflow-team@cern.ch'+config.Agent.contact = 'cms-tier0-operations@cern.ch'+" ./config/tier0/config.py
+#sed -i "s+OP EMAIL+Dirk.Hufnagel@cern.ch+g" ./config/tier0/config.py
+#sed -i "s+wmagentalerts@gmail.com+Dirk.Hufnagel@cern.ch+g" ./config/tier0/config.py
+
+#
+# Use this team and not the default 
+#
+#sed -i "s+'team1,team2,cmsdataops'+'tier0production'+g" ./config/tier0/config.py
+sed -i "s+'team1,team2,cmsdataops'+'tier0replay'+g" ./config/tier0/config.py
+
+#
+# configure retry settings
+#
+echo "config.RetryManager.PauseAlgo.default.coolOffTime = {'create': 10, 'job': 10, 'submit': 10}" >> ./config/tier0/config.py
+#sed -i "s+ErrorHandler.pollInterval = 240+ErrorHandler.pollInterval = 30+g" ./config/tier0/config.py
+#sed -i "s+RetryManager.pollInterval = 240+RetryManager.pollInterval = 30+g" ./config/tier0/config.py
+
+#
+# switch to ProcessingAlgo
+#
+#sed -i "s+config.RetryManager.plugins = {'default': 'PauseAlgo', 'Cleanup': 'SquaredAlgo', 'LogCollect': 'SquaredAlgo'}+config.RetryManager.plugins = {'default': 'ProcessingAlgo'}+g" ./config/tier0/config.py
+#echo "config.RetryManager.section_('ProcessingAlgo')" >> ./config/tier0/config.py
+#echo "config.RetryManager.ProcessingAlgo.section_('default')" >> ./config/tier0/config.py
+#echo "config.RetryManager.ProcessingAlgo.default.coolOffTime = {'create': 10, 'job': 10, 'submit': 10}" >> ./config/tier0/config.py
+#echo "config.RetryManager.ProcessingAlgo.default.closeoutPercentage = 95" >> ./config/tier0/config.py
+#echo "config.RetryManager.ProcessingAlgo.default.guaranteedRetries = 4" >> ./config/tier0/config.py
+#echo "config.RetryManager.ProcessingAlgo.default.minRetryTime = 1" >> ./config/tier0/config.py
+#echo "config.RetryManager.ProcessingAlgo.default.maxRetryTime = 2" >> ./config/tier0/config.py
+
+#
+# configure DEBUG output
+#
+#sed -i "s+config.ErrorHandler.logLevel = 'INFO'+config.ErrorHandler.logLevel = 'DEBUG'+g" ./config/tier0/config.py
+#sed -i "s+config.RetryManager.logLevel = 'INFO'+config.RetryManager.logLevel = 'DEBUG'+g" ./config/tier0/config.py
+#sed -i "s+config.PhEDExInjector.logLevel = 'INFO'+config.PhEDExInjector.logLevel = 'DEBUG'+g" ./config/tier0/config.py
+#sed -i "s+config.JobCreator.logLevel = 'INFO'+config.JobCreator.logLevel = 'DEBUG'+g" ./config/tier0/config.py
+
+#
+# configure shorter polling cyles
+#
+#echo 'config.ErrorHandler.pollInterval = 30' >> ./config/tier0/config.py
+#echo 'config.RetryManager.pollInterval = 30' >> ./config/tier0/config.py
+#echo 'config.DBS3Upload.pollInterval = 30' >> ./config/tier0/config.py
+#echo 'config.PhEDExInjector.pollInterval = 30' >> ./config/tier0/config.py
+
+#
+# configure Tier0-Mode for PhEDEx
+#
+echo 'config.PhEDExInjector.tier0Mode = False' >> ./config/tier0/config.py
+echo 'config.PhEDExInjector.autoDelete = False' >> ./config/tier0/config.py
+sed -i "s+config.PhEDExInjector.subscribeInterval = 43200+config.PhEDExInjector.subscribeInterval = 30+g" ./config/tier0/config.py
+
+#
+# Set output datasets status to VALID in DBS
+#
+echo "config.DBS3Upload.datasetType = 'VALID'" >> ./config/tier0/config.py
+
+#
+# needed for LSF DQM uploads
+#
+#echo 'config.Tier0Feeder.dqmUploadProxy = "/afs/cern.ch/user/h/hufnagel/private/Certificates/dqmcert.pem"' >> ./config/tier0/config.py
+
+#
+# needed for conditions upload
+#
+echo "config.Tier0Feeder.serviceProxy = '/data/certs/serviceproxy-vocms001.pem'" >> ./config/tier0/config.py
+
+#
+# password for dropbox upload
+#
+
+HOME="/data/tier0/admin/"
+
+if [ "x$WMAGENT_SECRETS_LOCATION" == "x" ]; then
+    WMAGENT_SECRETS_LOCATION=$HOME/WMAgent.secrets;
+fi
+if [ -f $WMAGENT_SECRETS_LOCATION\.replay ]; then
+    ln -s -f $WMAGENT_SECRETS_LOCATION\.replay $WMAGENT_SECRETS_LOCATION
+fi
+if [ ! -e $WMAGENT_SECRETS_LOCATION ]; then
+    echo "Password file: $WMAGENT_SECRETS_LOCATION does not exist"
+    echo "Either set WMAGENT_SECRETS_LOCATION to a valid file or check that $HOME/WMAgent.secrets exists"
+    exit 1;
+fi
+
+DROPBOX_USER=`cat $WMAGENT_SECRETS_LOCATION | grep DROPBOX_USER | sed s/DROPBOX_USER=//`
+DROPBOX_PASS=`cat $WMAGENT_SECRETS_LOCATION | grep DROPBOX_PASS | sed s/DROPBOX_PASS=//`
+
+if [ "x$DROPBOX_USER" == "x" ] || [ "x$DROPBOX_PASS" == "x" ]; then
+    echo "Secrets file doesn't contain DROPBOX_USER or DROPBOX_PASS";
+    exit 1
+fi
+
+echo 'config.Tier0Feeder.dropboxuser = "'$DROPBOX_USER'"' >> ./config/tier0/config.py
+echo 'config.Tier0Feeder.dropboxpass = "'$DROPBOX_PASS'"' >> ./config/tier0/config.py
+
+#
+# needed for passing notifications back to StorageManager
+#
+#echo 'config.Tier0Feeder.transferSystemBaseDir = "/data/tier0/sminject"' >> ./config/tier0/config.py
+
+#
+# upload PromptReco performance data
+#
+echo 'config.TaskArchiver.dashBoardUrl = "http://dashb-luminosity.cern.ch/dashboard/request.py/putluminositydata"' >> ./config/tier0/config.py
+echo 'config.TaskArchiver.logLevel = "DEBUG"' >> ./config/tier0/config.py
+
+#
+# Workflow archive delay
+#
+#echo 'config.TaskArchiver.archiveDelayHours = 1' >> ./config/tier0/config.py
+sed -i "s+config.TaskArchiver.archiveDelayHours = 24+config.TaskArchiver.archiveDelayHours = 1+" ./config/tier0/config.py
+
+#
+# Do not use WorkQueue
+#
+echo 'config.TaskArchiver.useWorkQueue = False' >> ./config/tier0/config.py
+
+#
+# Enable AgentStatusWatcher - site status automatic updated
+#
+echo "config.AgentStatusWatcher.enabled = False" >> ./config/tier0/config.py
+echo "config.AgentStatusWatcher.onlySSB = False" >> ./config/tier0/config.py
+
+#
+# Increase ErrorHandler maxFailTime
+#
+echo "config.ErrorHandler.maxFailTime = 604800" >> ./config/tier0/config.py
+
+#
+# JobAccountant Repack Error Dataset settings
+#
+echo 'config.JobAccountant.maxAllowedRepackOutputSize = 24 * 1024 * 1024 * 1024' >> ./config/tier0/config.py
+
+#
+# Use SimpleCondorPlugin by default
+#
+echo 'config.BossAir.pluginNames = ["SimpleCondorPlugin"]' >> ./config/tier0/config.py
+
+#
+# Setting up sites
+#
+
+./config/tier0/manage execute-agent wmagent-resource-control --site-name=T2_CH_CERN --cms-name=T2_CH_CERN --pnn=T2_CH_CERN --ce-name=T2_CH_CERN --pending-slots=20000 --running-slots=20000 --plugin=SimpleCondorPlugin
+./config/tier0/manage execute-agent wmagent-resource-control --site-name=T2_CH_CERN --task-type=Processing --pending-slots=10000 --running-slots=10000
+./config/tier0/manage execute-agent wmagent-resource-control --site-name=T2_CH_CERN --task-type=Merge --pending-slots=1000 --running-slots=1000
+./config/tier0/manage execute-agent wmagent-resource-control --site-name=T2_CH_CERN --task-type=Cleanup --pending-slots=1000 --running-slots=1000
+./config/tier0/manage execute-agent wmagent-resource-control --site-name=T2_CH_CERN --task-type=LogCollect --pending-slots=1000 --running-slots=1000
+./config/tier0/manage execute-agent wmagent-resource-control --site-name=T2_CH_CERN --task-type=Skim --pending-slots=1 --running-slots=1
+./config/tier0/manage execute-agent wmagent-resource-control --site-name=T2_CH_CERN --task-type=Production --pending-slots=1 --running-slots=1
+./config/tier0/manage execute-agent wmagent-resource-control --site-name=T2_CH_CERN --task-type=Harvesting --pending-slots=1000 --running-slots=1000
+./config/tier0/manage execute-agent wmagent-resource-control --site-name=T2_CH_CERN --task-type=Express --pending-slots=3000 --running-slots=3000
+./config/tier0/manage execute-agent wmagent-resource-control --site-name=T2_CH_CERN --task-type=Repack --pending-slots=5000 --running-slots=5000
+
+# Thresholds configurations
+echo "config.AgentStatusWatcher.t1SitesCores = 12.5"  >> ./config/tier0/config.py
+
+echo "config.AgentStatusWatcher.pendingSlotsTaskPercent = 30" >> ./config/tier0/config.py
+echo "config.AgentStatusWatcher.pendingSlotsSitePercent = 40" >> ./config/tier0/config.py
+
+echo "config.AgentStatusWatcher.runningExpressPercent = 25" >> ./config/tier0/config.py
+echo "config.AgentStatusWatcher.runningRepackPercent = 10" >> ./config/tier0/config.py

--- a/bin/00_software.sh
+++ b/bin/00_software.sh
@@ -1,40 +1,75 @@
 #!/bin/bash
 
 BASE_DIR=/data/tier0
+WMCORE_VERSION=1.1.20.patch4
+T0_VERSION=2.1.4
 
+function echo_header {
+	echo ''
+	echo " *** $1 *** "
+}
+
+echo_header 'Cloning WMCore'
 rm -rf $BASE_DIR/WMCore
 cd $BASE_DIR
-git clone https://github.com/dmwm/WMCore.git 
+git clone https://github.com/dmwm/WMCore.git
 
 cd $BASE_DIR/WMCore
 
-git checkout tags/1.0.7.pre6
+echo_header "Switching to tag $WMCORE_VERSION"
+git checkout tags/$WMCORE_VERSION
 
-# enable lazydownload
-# (wait for pull request to be merged)
-git fetch https://github.com/hufnagel/WMCore enable-lazydownload && git cherry-pick FETCH_HEAD
+########################################
+# Mandatory WMCore patches
+########################################
+
+echo_header 'Applying WMCore mandatory patches'
+
+#Skip WorkQueue MonIT statistics for T0 agent
+git fetch https://github.com/amaltaro/WMCore fix-9056 && git cherry-pick FETCH_HEAD
+
+#Use `tier0_wmagent` producer for T0 agent uploading data to MonIT
+git fetch https://github.com/amaltaro/WMCore tier0-producer && git cherry-pick FETCH_HEAD
+
+#Change default AMQ host and ports:
+git fetch https://github.com/vytjan/WMCore default-amq-hostname && git cherry-pick FETCH_HEAD
+########################################
+# Additional (Optional) WMCore patches
+########################################
+
+echo_header 'Applying WMCore optional patches'
+
+# Allow not failing job creation in JobSplitting/ EventAwareLumiBased if specified in WMAgent config
+git fetch https://github.com/khurtado/WMCore jobsplitnewat && git cherry-pick FETCH_HEAD
 
 # enable xrootd debug output
 # (for testing only)
-git fetch https://github.com/hufnagel/WMCore xrootd-debug && git cherry-pick FETCH_HEAD
+# git fetch https://github.com/hufnagel/WMCore xrootd-debug && git cherry-pick FETCH_HEAD
 
-# overcommit multicore pilots
-git fetch https://github.com/hufnagel/WMCore overcommit-pilot && git cherry-pick FETCH_HEAD
+########################################
 
-# fix for phedex recovery
-git fetch https://github.com/hufnagel/WMCore phedex-recovery-limits && git cherry-pick FETCH_HEAD
-
+echo_header 'Cloning T0'
 rm -rf $BASE_DIR/T0
 cd $BASE_DIR
 git clone https://github.com/dmwm/T0.git
 
 cd $BASE_DIR/T0
 
-git checkout tags/1.9.94
+echo_header "Switching to tag $T0_VERSION"
+git checkout tags/$T0_VERSION
 
-# map out known corrupt Run2012 replay streamer
-git fetch https://github.com/hufnagel/T0 zeroevents && git cherry-pick FETCH_HEAD
+########################################
+# Mandatory T0 patches
+########################################
 
-# remove TFC override, read streamer from EOS
-git fetch https://github.com/hufnagel/T0 remove-tfc-override && git cherry-pick FETCH_HEAD
+echo_header 'Applying T0 mandatory patches'
 
+#Move SMNOTIFYDB_URL to secrets file
+git fetch https://github.com/vytjan/T0 smnotifydb-to-secrets && git cherry-pick FETCH_HEAD
+########################################
+# Additional (Optional) T0 patches
+########################################
+
+echo_header 'Applying T0 optional patches'
+
+########################################


### PR DESCRIPTION
@hufnagel Dirk, as discussed some time ago, I am adding the most recent deploy and software script versions to the repository.
Even though all the following are mostly operational concerns, I would like to know your opinion on the following:
1. 00_deploy_prod.sh and 00_deploy_replay.sh are different since we are using them for different cases (production and replay deployment). It is easier to manage them here on GH than on every T0 VM separately anyway.
2. 00_software.sh should be updated as well with all mandatory patches from T0 release notes ( https://twiki.cern.ch/twiki/bin/view/CMS/T0AST ). Every time there is a fix patch or a new T0 release - the script should be updated respectively. The same applies for both deployment scripts.

Also, not sure if we want to keep the old 00_deploy.sh script. Maybe we could simply merge it with 00_deploy_prod.sh or vice versa.