### PR TITLE
Do not allow T0 to use WorkQueue in any case.

### DIFF
--- a/bin/00_patches.sh
+++ b/bin/00_patches.sh
@@ -6,5 +6,5 @@
 BASE_DIR=/data/tier0
 DEPLOY_DIR=$BASE_DIR/srv/wmagent
 
-# LogCollect job fix - https://github.com/dmwm/WMCore/pull/9295
-# curl https://patch-diff.githubusercontent.com/raw/dmwm/WMCore/pull/9295.patch | patch -d $DEPLOY_DIR/current/apps/t0/lib/python2.7/site-packages/ -p3
+# Do not allow T0 to use WorkQueue in any case: https://github.com/dmwm/WMCore/pull/9314
+curl https://patch-diff.githubusercontent.com/raw/dmwm/WMCore/pull/9314.patch | patch -d $DEPLOY_DIR/current/apps/t0/lib/python2.7/site-packages/ -p3


### PR DESCRIPTION
A mandatory patch for T0 2.1.5 release.