### PR TITLE
Initial replay configuration for MWGR4 2020

### DIFF
--- a/etc/ContainterConfig.sh
+++ b/etc/ContainterConfig.sh
@@ -19,4 +19,4 @@ REPLAY_TEST=1
 #	ppColissions2018	Proton-Proton run from 2018
 #	ThisPR				Use the replay configuration specified in this PR
 #
-RUN_TYPE=MWGR
+RUN_TYPE=ThisPR

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -35,7 +35,7 @@ tier0Config = createTier0Config()
 setConfigVersion(tier0Config, "replace with real version")
 
 # Set run number to replay
-setInjectRuns(tier0Config, [ 335508,336349,336436 ])
+setInjectRuns(tier0Config, [337240, 337234])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"
@@ -90,7 +90,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-       'default': "CMSSW_11_1_3"
+       'default': "CMSSW_11_1_4"
      }
 
 # Configure ScramArch
@@ -133,65 +133,67 @@ alcarawSplitting = 20000 * numberOfCores
 # Setup repack and express mappings
 #
 repackVersionOverride = {
-    "CMSSW_10_0_0" : "CMSSW_11_1_3",
-    "CMSSW_10_0_1" : "CMSSW_11_1_3",
-    "CMSSW_10_0_2" : "CMSSW_11_1_3",
-    "CMSSW_10_0_3" : "CMSSW_11_1_3",
-    "CMSSW_10_0_4" : "CMSSW_11_1_3",
-    "CMSSW_10_0_5" : "CMSSW_11_1_3",
-    "CMSSW_10_1_0" : "CMSSW_11_1_3",
-    "CMSSW_10_1_1" : "CMSSW_11_1_3",
-    "CMSSW_10_1_2" : "CMSSW_11_1_3",
-    "CMSSW_10_1_3" : "CMSSW_11_1_3",
-    "CMSSW_10_1_4" : "CMSSW_11_1_3",
-    "CMSSW_10_1_5" : "CMSSW_11_1_3",
-    "CMSSW_10_1_6" : "CMSSW_11_1_3",
-    "CMSSW_10_1_7" : "CMSSW_11_1_3",
-    "CMSSW_10_1_8" : "CMSSW_11_1_3",
-    "CMSSW_10_1_9" : "CMSSW_11_1_3",
-    "CMSSW_10_1_10" : "CMSSW_11_1_3",
-    "CMSSW_10_2_0" : "CMSSW_11_1_3",
-    "CMSSW_10_2_1" : "CMSSW_11_1_3",
-    "CMSSW_10_2_5" : "CMSSW_11_1_3",
-    "CMSSW_10_3_0" : "CMSSW_11_1_3",
-    "CMSSW_10_3_1" : "CMSSW_11_1_3",
-    "CMSSW_10_3_3" : "CMSSW_11_1_3",
-    "CMSSW_10_6_1" : "CMSSW_11_1_3",
-    "CMSSW_10_6_3" : "CMSSW_11_1_3",
-    "CMSSW_10_6_8" : "CMSSW_11_1_3",
-    "CMSSW_11_0_1" : "CMSSW_11_1_3",
-    "CMSSW_11_0_2" : "CMSSW_11_1_3"
+    "CMSSW_10_0_0" : "CMSSW_11_1_4",
+    "CMSSW_10_0_1" : "CMSSW_11_1_4",
+    "CMSSW_10_0_2" : "CMSSW_11_1_4",
+    "CMSSW_10_0_3" : "CMSSW_11_1_4",
+    "CMSSW_10_0_4" : "CMSSW_11_1_4",
+    "CMSSW_10_0_5" : "CMSSW_11_1_4",
+    "CMSSW_10_1_0" : "CMSSW_11_1_4",
+    "CMSSW_10_1_1" : "CMSSW_11_1_4",
+    "CMSSW_10_1_2" : "CMSSW_11_1_4",
+    "CMSSW_10_1_3" : "CMSSW_11_1_4",
+    "CMSSW_10_1_4" : "CMSSW_11_1_4",
+    "CMSSW_10_1_5" : "CMSSW_11_1_4",
+    "CMSSW_10_1_6" : "CMSSW_11_1_4",
+    "CMSSW_10_1_7" : "CMSSW_11_1_4",
+    "CMSSW_10_1_8" : "CMSSW_11_1_4",
+    "CMSSW_10_1_9" : "CMSSW_11_1_4",
+    "CMSSW_10_1_10" : "CMSSW_11_1_4",
+    "CMSSW_10_2_0" : "CMSSW_11_1_4",
+    "CMSSW_10_2_1" : "CMSSW_11_1_4",
+    "CMSSW_10_2_5" : "CMSSW_11_1_4",
+    "CMSSW_10_3_0" : "CMSSW_11_1_4",
+    "CMSSW_10_3_1" : "CMSSW_11_1_4",
+    "CMSSW_10_3_3" : "CMSSW_11_1_4",
+    "CMSSW_10_6_1" : "CMSSW_11_1_4",
+    "CMSSW_10_6_3" : "CMSSW_11_1_4",
+    "CMSSW_10_6_8" : "CMSSW_11_1_4",
+    "CMSSW_11_0_1" : "CMSSW_11_1_4",
+    "CMSSW_11_0_2" : "CMSSW_11_1_4",
+    "CMSSW_11_1_3" : "CMSSW_11_1_4"
     }
 
 expressVersionOverride = {
-    "CMSSW_10_0_0" : "CMSSW_11_1_3",
-    "CMSSW_10_0_1" : "CMSSW_11_1_3",
-    "CMSSW_10_0_2" : "CMSSW_11_1_3",
-    "CMSSW_10_0_3" : "CMSSW_11_1_3",
-    "CMSSW_10_0_4" : "CMSSW_11_1_3",
-    "CMSSW_10_0_5" : "CMSSW_11_1_3",
-    "CMSSW_10_1_0" : "CMSSW_11_1_3",
-    "CMSSW_10_1_1" : "CMSSW_11_1_3",
-    "CMSSW_10_1_2" : "CMSSW_11_1_3",
-    "CMSSW_10_1_3" : "CMSSW_11_1_3",
-    "CMSSW_10_1_4" : "CMSSW_11_1_3",
-    "CMSSW_10_1_5" : "CMSSW_11_1_3",
-    "CMSSW_10_1_6" : "CMSSW_11_1_3",
-    "CMSSW_10_1_7" : "CMSSW_11_1_3",
-    "CMSSW_10_1_8" : "CMSSW_11_1_3",
-    "CMSSW_10_1_9" : "CMSSW_11_1_3",
-    "CMSSW_10_1_10" : "CMSSW_11_1_3",
-    "CMSSW_10_2_0" : "CMSSW_11_1_3",
-    "CMSSW_10_2_1" : "CMSSW_11_1_3",
-    "CMSSW_10_2_5" : "CMSSW_11_1_3",
-    "CMSSW_10_3_0" : "CMSSW_11_1_3",
-    "CMSSW_10_3_1" : "CMSSW_11_1_3",
-    "CMSSW_10_3_3" : "CMSSW_11_1_3",
-    "CMSSW_10_6_1" : "CMSSW_11_1_3",
-    "CMSSW_10_6_3" : "CMSSW_11_1_3",
-    "CMSSW_10_6_8" : "CMSSW_11_1_3",
-    "CMSSW_11_0_1" : "CMSSW_11_1_3",
-    "CMSSW_11_0_2" : "CMSSW_11_1_3"
+    "CMSSW_10_0_0" : "CMSSW_11_1_4",
+    "CMSSW_10_0_1" : "CMSSW_11_1_4",
+    "CMSSW_10_0_2" : "CMSSW_11_1_4",
+    "CMSSW_10_0_3" : "CMSSW_11_1_4",
+    "CMSSW_10_0_4" : "CMSSW_11_1_4",
+    "CMSSW_10_0_5" : "CMSSW_11_1_4",
+    "CMSSW_10_1_0" : "CMSSW_11_1_4",
+    "CMSSW_10_1_1" : "CMSSW_11_1_4",
+    "CMSSW_10_1_2" : "CMSSW_11_1_4",
+    "CMSSW_10_1_3" : "CMSSW_11_1_4",
+    "CMSSW_10_1_4" : "CMSSW_11_1_4",
+    "CMSSW_10_1_5" : "CMSSW_11_1_4",
+    "CMSSW_10_1_6" : "CMSSW_11_1_4",
+    "CMSSW_10_1_7" : "CMSSW_11_1_4",
+    "CMSSW_10_1_8" : "CMSSW_11_1_4",
+    "CMSSW_10_1_9" : "CMSSW_11_1_4",
+    "CMSSW_10_1_10" : "CMSSW_11_1_4",
+    "CMSSW_10_2_0" : "CMSSW_11_1_4",
+    "CMSSW_10_2_1" : "CMSSW_11_1_4",
+    "CMSSW_10_2_5" : "CMSSW_11_1_4",
+    "CMSSW_10_3_0" : "CMSSW_11_1_4",
+    "CMSSW_10_3_1" : "CMSSW_11_1_4",
+    "CMSSW_10_3_3" : "CMSSW_11_1_4",
+    "CMSSW_10_6_1" : "CMSSW_11_1_4",
+    "CMSSW_10_6_3" : "CMSSW_11_1_4",
+    "CMSSW_10_6_8" : "CMSSW_11_1_4",
+    "CMSSW_11_0_1" : "CMSSW_11_1_4",
+    "CMSSW_11_0_2" : "CMSSW_11_1_4",
+    "CMSSW_11_1_3" : "CMSSW_11_1_4"
 
     }
 


### PR DESCRIPTION
First configuration test for MWGR#4:

Release: CMSSW_11_1_4
RUNS: 337240 and 337234
GT (**):
  + HLT: 111X_dataRun3_HLT_v2
  + Express: 111X_dataRun3_Express_v2
  + Prompt: 111X_dataRun3_Prompt_v2
