### PR TITLE
Changes to allow single lumi Replays

### DIFF
--- a/etc/ContainterConfig.sh
+++ b/etc/ContainterConfig.sh
@@ -19,4 +19,4 @@ REPLAY_TEST=1
 #	ppColissions2018	Proton-Proton run from 2018
 #	ThisPR				Use the replay configuration specified in this PR
 #
-RUN_TYPE=MWGR
+RUN_TYPE=ThisPR

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -25,6 +25,7 @@ from T0.RunConfig.Tier0Config import addExpressConfig
 from T0.RunConfig.Tier0Config import addRegistrationConfig
 from T0.RunConfig.Tier0Config import addConversionConfig
 from T0.RunConfig.Tier0Config import setInjectRuns
+from T0.RunConfig.Tier0Config import setLumi
 from T0.RunConfig.Tier0Config import setStreamerPNN
 from T0.RunConfig.Tier0Config import setEnableUniqueWorkflowName
 
@@ -35,7 +36,10 @@ tier0Config = createTier0Config()
 setConfigVersion(tier0Config, "replace with real version")
 
 # Set run number to replay
-setInjectRuns(tier0Config, [ 335508,336349,336436 ])
+setInjectRuns(tier0Config, [ 335508 ])
+
+# Set lumi number to replay. 
+setLumi(tier0Config, 1)
 
 # Settings up sites
 processingSite = "T2_CH_CERN"

--- a/src/python/T0/RunConfig/Tier0Config.py
+++ b/src/python/T0/RunConfig/Tier0Config.py
@@ -245,6 +245,7 @@ def createTier0Config():
     tier0Config.Global.InjectRuns = None
     tier0Config.Global.InjectMinRun = None
     tier0Config.Global.InjectMaxRun = None
+    tier0Config.Global.Lumi = None
 
     tier0Config.Global.ScramArches = {}
     tier0Config.Global.Backfill = None
@@ -663,6 +664,15 @@ def setInjectMaxRun(config, injectMaxRun):
     Set the highest run to be injected into the Tier0.
     """
     config.Global.InjectMaxRun = injectMaxRun
+    return
+
+def setLumi(config, lumi = 1 ):
+    """
+    _setLumi_
+
+    Set the lumi to be injected into the Tier0.
+    """
+    config.Global.Lumi = lumi
     return
 
 def setEnableUniqueWorkflowName(config):

--- a/src/python/T0/StorageManager/StorageManagerAPI.py
+++ b/src/python/T0/StorageManager/StorageManagerAPI.py
@@ -18,7 +18,8 @@ def injectNewData(dbInterfaceStorageManager,
                   streamerPNN,
                   minRun = None,
                   maxRun = None,
-                  injectRun = None):
+                  injectRun = None,
+                  lumi = None):
     """
     _injectNewData_
 
@@ -64,7 +65,8 @@ def injectNewData(dbInterfaceStorageManager,
 
     newData = getNewDataDAO.execute(minRun = minRun,
                                     maxRun = maxRun,
-                                    injectRun = injectRun, 
+                                    injectRun = injectRun,
+                                    lumi = lumi,
                                     transaction = False)
 
     # remove already processed files

--- a/src/python/T0/WMBS/Oracle/StorageManager/GetNewData.py
+++ b/src/python/T0/WMBS/Oracle/StorageManager/GetNewData.py
@@ -11,7 +11,7 @@ from WMCore.Database.DBFormatter import DBFormatter
 
 class GetNewData(DBFormatter):
 
-    def execute(self, minRun = None, maxRun = None, injectRun = None, conn = None, transaction = False):
+    def execute(self, minRun = None, maxRun = None, injectRun = None, lumi = None, conn = None, transaction = False):
 
         if injectRun:
             binds = { 'RUN': injectRun }
@@ -20,6 +20,10 @@ class GetNewData(DBFormatter):
                           AND CMS_STOMGR.FILE_TRANSFER_STATUS.BAD_CHECKSUM = 0
                           AND CMS_STOMGR.FILE_TRANSFER_STATUS.RUNNUMBER = :RUN
                           """
+            if lumi:
+                binds['LUMI'] = lumi
+                whereSql += """AND CMS_STOMGR.FILE_TRANSFER_STATUS.LS = :LUMI
+                            """
         else:
             binds = {}
             whereSql = """WHERE CMS_STOMGR.T0_NEEDS_TO_INJECT(CMS_STOMGR.FILE_TRANSFER_STATUS.STATUS_FLAG,

--- a/src/python/T0Component/Tier0Feeder/Tier0FeederPoller.py
+++ b/src/python/T0Component/Tier0Feeder/Tier0FeederPoller.py
@@ -57,6 +57,7 @@ class Tier0FeederPoller(BaseWorkerThread):
                                                    couchapp = config.AnalyticsDataCollector.RequestCouchApp)
 
         self.injectedRuns = set()
+        self.lumis = set()
 
         hltConfConnectUrl = config.HLTConfDatabase.connectUrl
         dbFactoryHltConf = DBFactory(logging, dburl = hltConfConnectUrl, options = {})
@@ -144,6 +145,9 @@ class Tier0FeederPoller(BaseWorkerThread):
                                                     maxRun = tier0Config.Global.InjectMaxRun)
                 else:
                     injectRuns = set()
+                    lumi = None
+                    if tier0Config.Global.Lumi:
+                        lumi = tier0Config.Global.Lumi
                     for injectRun in tier0Config.Global.InjectRuns:
                         if injectRun not in self.injectedRuns:
                             injectRuns.add(injectRun)
@@ -152,7 +156,8 @@ class Tier0FeederPoller(BaseWorkerThread):
                                                         self.dbInterfaceHltConf,
                                                         self.dbInterfaceSMNotify,
                                                         streamerPNN = tier0Config.Global.StreamerPNN,
-                                                        injectRun = injectRun)
+                                                        injectRun = injectRun,
+                                                        lumi = lumi)
                         self.injectedRuns.add(injectRun)
             except:
                 # shouldn't happen, just a catch all insurance


### PR DESCRIPTION
Add `lumi` to global configuration. If set to an integer, Tier0Feeder will only get data from the specified lumi section. The variable can be set in ReplayOfflineConfiguration.py using `T0.RunConfig.Tier0Config.setLumi`