### PR TITLE
[build] Add requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+sqlalchemy==1.3.3
+httplib2==0.18.0
+pycurl==7.43.0.3
+rucio-clients==1.23.6
+MySQL-python==1.2.4b4
+cx_Oracle==5.2.1
+Cheetah==2.4.0
+pyOpenSSL==18.0.0
+pyzmq==17.1.2
+psutil==5.6.6
+future==0.18.2
+retry==0.9.1 


### PR DESCRIPTION
As discussed privately with @amaltaro and in WMCore dev weekly meetings, I open this PR to provide T0 with its own `requirements.txt` file, based on its spec file.

Details of the spec file:

* used spec file `t0.spec`
* from the repo [cms-sw/cmsdist, branch comp_gcc630](https://github.com/cms-sw/cmsdist/tree/comp_gcc630)
* the current last commit in this repo is [cms-sw/cmsdist, commit 9e502ba](https://github.com/cms-sw/cmsdist/tree/9e502ba45b7dd50315872c72fa2b146013d811b2)

The `requirements.txt` file is build with

* [mapellidario/cmssw-dist-parse, tag 0.1](https://github.com/mapellidario/cmssw-dist-parse/releases/tag/0.1)
* with the command `python3 parse_spec.py -d /path/to/github.com/cmsdist/ -f t0.spec --no-recursive`
* with some manual changes to `cheetah`, `cx-oracle` and `mysqldb-python` package names