### PR TITLE
Using WMWorkloadHelper.setTaskEnvironmentVariables to override site config

### DIFF
--- a/etc/ContainterConfig.sh
+++ b/etc/ContainterConfig.sh
@@ -3,11 +3,11 @@
 ###
 
 #T0_VERSION specifies which image tag to use
-T0_VERSION=2.2.1
+T0_VERSION=2.2.3
 
 #WMC_PR specifies a list of WMCore Pull Request to be tested
 #WMC_PR=""
-WMC_PR="10044 10067"
+WMC_PR="10344"
 
 
 #If REPLAY_TEST=1, specify the type of run you want to test picking one of the following options

--- a/src/python/T0/RunConfig/RunConfigAPI.py
+++ b/src/python/T0/RunConfig/RunConfigAPI.py
@@ -711,6 +711,11 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
                                       'GracePeriod': 3600,
                                       'Dashboard': "t0" } )
 
+            if tier0Config.Global.ProcessingSite=='T0_CH_CERN':
+                wmSpec.setTaskEnvironmentVariables({'WMAGENT_SITE_CONFIG_OVERRIDE':tier0Config.Global.siteLocalConfig})
+                wmSpec.setOverrideCatalog(tier0Config.Global.overrideCatalog)
+                wmSpec.updateArguments( { 'SiteWhitelist': [ 'T2_CH_CERN' ] } )
+
             wmbsHelper = WMBSHelper(wmSpec, taskName, cachepath = specDirectory)
 
         filesetName = "Run%d_Stream%s" % (run, stream)
@@ -1116,6 +1121,14 @@ def releasePromptReco(tier0Config, specDirectory, dqmUploadProxy):
                 wmSpec.setOwnerDetails("Dirk.Hufnagel@cern.ch", "T0",
                                        { 'vogroup': 'DEFAULT', 'vorole': 'DEFAULT',
                                          'dn' : "Dirk.Hufnagel@cern.ch" } )
+
+                #Overriding site configuration
+                if 'T0_CH_CERN' in datasetConfig.SiteWhitelist:
+                    wmSpec.setTaskEnvironmentVariables({'WMAGENT_SITE_CONFIG_OVERRIDE':tier0Config.Global.siteLocalConfig})
+                    wmSpec.setOverrideCatalog(tier0Config.Global.overrideCatalog)
+
+                #Overriding processing site in case we using T0 disk
+                datasetConfig.SiteWhitelist = [ 'T2_CH_CERN' if s=='T0_CH_CERN' else s for s in datasetConfig.SiteWhitelist]
 
                 wmSpec.updateArguments( { 'SiteWhitelist': datasetConfig.SiteWhitelist,
                                           'SiteBlacklist': [],

--- a/src/python/T0/RunConfig/Tier0Config.py
+++ b/src/python/T0/RunConfig/Tier0Config.py
@@ -253,6 +253,10 @@ def createTier0Config():
 
     tier0Config.Global.StreamerPNN = "T0_CH_CERN_Disk"
 
+    tier0Config.Global.overrideCatalog = "trivialcatalog_file:/cvmfs/cms.cern.ch/SITECONF/T0_CH_CERN/PhEDEx/storage.xml?protocol=eos"
+
+    tier0Config.Global.siteLocalConfig = "/cvmfs/cms.cern.ch/SITECONF/T0_CH_CERN/JobConfig/site-local-config.xml"
+
     tier0Config.Global.DQMDataTier = "DQMIO"
 
     tier0Config.Global.BaseRequestPriority = 150000
@@ -576,6 +580,25 @@ def setStreamerPNN(config, pnn):
     Set the (CERN) location for streamer files.
     """
     config.Global.StreamerPNN = pnn
+    return
+
+def setOverrideCatalog(config, overrideCatalog):
+    """
+    _setOverrideCatalog_
+
+    Set the catalog to use in case override is necessary.
+    """
+    config.Global.overrideCatalog = overrideCatalog
+    return
+
+
+def setSiteLocalConfig(config, siteLocalConfig):
+    """
+    _setSiteLocalConfig_
+
+    Set the site local config file to use in case override is necessary.
+    """
+    config.Global.siteLocalConfig = siteLocalConfig
     return
 
 def setBulkDataType(config, type):


### PR DESCRIPTION
Uses changes introduced in https://github.com/dmwm/WMCore/pull/10344 to override the site configuration file used by T0 jobs