### PR TITLE
Replay test with CMSSW_11_3_0_patch1

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -136,7 +136,7 @@ repackVersionOverride = {
     "CMSSW_11_1_5" : defaultCMSSWVersion['default'],
     "CMSSW_11_2_1" : defaultCMSSWVersion['default'],
     "CMSSW_11_2_2" : defaultCMSSWVersion['default'],
-    "CMSSW_11_2_3" : defaultCMSSWVersion['default']
+    "CMSSW_11_2_3" : defaultCMSSWVersion['default'],
     "CMSSW_11_2_4" : defaultCMSSWVersion['default']
     }
 
@@ -148,7 +148,7 @@ expressVersionOverride = {
     "CMSSW_11_1_5" : defaultCMSSWVersion['default'],
     "CMSSW_11_2_1" : defaultCMSSWVersion['default'],
     "CMSSW_11_2_2" : defaultCMSSWVersion['default'],
-    "CMSSW_11_2_3" : defaultCMSSWVersion['default']
+    "CMSSW_11_2_3" : defaultCMSSWVersion['default'],
     "CMSSW_11_2_4" : defaultCMSSWVersion['default']
     }
 

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -86,7 +86,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_11_3_0_pre6"
+    'default': "CMSSW_11_3_0"
 }
 
 # Configure ScramArch

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -110,9 +110,9 @@ expressProcVersion = dt
 alcarawProcVersion = dt
 
 # Defaults for GlobalTag
-expressGlobalTag = "112X_dataRun3_Express_v5"
-promptrecoGlobalTag = "112X_dataRun3_Prompt_v5"
-alcap0GlobalTag = "112X_dataRun3_Prompt_v5"
+expressGlobalTag = "113X_dataRun3_Express_v1"
+promptrecoGlobalTag = "113X_dataRun3_Prompt_v1"
+alcap0GlobalTag = "113X_dataRun3_Prompt_v1"
 
 # Mandatory for CondDBv2
 globalTagConnect = "frontier://PromptProd/CMS_CONDITIONS"
@@ -137,6 +137,7 @@ repackVersionOverride = {
     "CMSSW_11_2_1" : defaultCMSSWVersion['default'],
     "CMSSW_11_2_2" : defaultCMSSWVersion['default'],
     "CMSSW_11_2_3" : defaultCMSSWVersion['default']
+    "CMSSW_11_2_4" : defaultCMSSWVersion['default']
     }
 
 expressVersionOverride = {
@@ -148,6 +149,7 @@ expressVersionOverride = {
     "CMSSW_11_2_1" : defaultCMSSWVersion['default'],
     "CMSSW_11_2_2" : defaultCMSSWVersion['default'],
     "CMSSW_11_2_3" : defaultCMSSWVersion['default']
+    "CMSSW_11_2_4" : defaultCMSSWVersion['default']
     }
 
 #set default repack settings for bulk streams

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -86,7 +86,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_11_2_4"
+    'default': "CMSSW_11_3_0_pre6"
 }
 
 # Configure ScramArch

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -86,7 +86,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_11_3_0"
+    'default': "CMSSW_11_3_0_patch1"
 }
 
 # Configure ScramArch


### PR DESCRIPTION
Test of CMSSW_11_3_0_patch1 for the MWGR#4 (2-4 June).
I've also updated the global tag according to https://github.com/cms-sw/cmssw/blob/master/Configuration/AlCa/python/autoCond.py

In the previous test #4572 - based on CMSSW_11_3_0 - there was an issue related to the CSCTriggerPrimitive.
The bug should disappear in CMSSW_11_3_0_patch1 thanks to https://github.com/cms-sw/cmssw/pull/33679 .