### PR TITLE
Replay test with CMSSW_11_3_1

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -86,7 +86,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_11_2_4"
+    'default': "CMSSW_11_3_1"
 }
 
 # Configure ScramArch
@@ -110,9 +110,9 @@ expressProcVersion = dt
 alcarawProcVersion = dt
 
 # Defaults for GlobalTag
-expressGlobalTag = "112X_dataRun3_Express_v5"
-promptrecoGlobalTag = "112X_dataRun3_Prompt_v5"
-alcap0GlobalTag = "112X_dataRun3_Prompt_v5"
+expressGlobalTag = "113X_dataRun3_Express_v1"
+promptrecoGlobalTag = "113X_dataRun3_Prompt_v1"
+alcap0GlobalTag = "113X_dataRun3_Prompt_v1"
 
 # Mandatory for CondDBv2
 globalTagConnect = "frontier://PromptProd/CMS_CONDITIONS"
@@ -136,7 +136,8 @@ repackVersionOverride = {
     "CMSSW_11_1_5" : defaultCMSSWVersion['default'],
     "CMSSW_11_2_1" : defaultCMSSWVersion['default'],
     "CMSSW_11_2_2" : defaultCMSSWVersion['default'],
-    "CMSSW_11_2_3" : defaultCMSSWVersion['default']
+    "CMSSW_11_2_3" : defaultCMSSWVersion['default'],
+    "CMSSW_11_2_4" : defaultCMSSWVersion['default']
     }
 
 expressVersionOverride = {
@@ -147,7 +148,8 @@ expressVersionOverride = {
     "CMSSW_11_1_5" : defaultCMSSWVersion['default'],
     "CMSSW_11_2_1" : defaultCMSSWVersion['default'],
     "CMSSW_11_2_2" : defaultCMSSWVersion['default'],
-    "CMSSW_11_2_3" : defaultCMSSWVersion['default']
+    "CMSSW_11_2_3" : defaultCMSSWVersion['default'],
+    "CMSSW_11_2_4" : defaultCMSSWVersion['default']
     }
 
 #set default repack settings for bulk streams


### PR DESCRIPTION
Test of CMSSW_11_3_1 for the MWGR#4 (2-4 June).

Configuration followed from https://github.com/dmwm/T0/pull/4573

https://github.com/cms-sw/cmssw/pull/33867 should fix the issue reported in:
https://hypernews.cern.ch/HyperNews/CMS/get/tier0-Ops/2213/1/2/1/1/1/1/1.html