### PR TITLE
Replay configuration used in preparation for MWGR4 of 2021

### DIFF
--- a/bin/00_patches.sh
+++ b/bin/00_patches.sh
@@ -6,7 +6,5 @@
 BASE_DIR=/data/tier0
 DEPLOY_DIR=$BASE_DIR/srv/wmagent
 
-# Do not allow T0 to use WorkQueue in any case: https://github.com/dmwm/WMCore/pull/9314
-curl https://patch-diff.githubusercontent.com/raw/dmwm/WMCore/pull/10044.patch | patch -d $DEPLOY_DIR/current/apps/t0/lib/python2.7/site-packages/ -p3
-curl https://patch-diff.githubusercontent.com/raw/dmwm/WMCore/pull/10067.patch | patch -d $DEPLOY_DIR/current/apps/t0/lib/python2.7/site-packages/ -p3
-curl https://patch-diff.githubusercontent.com/raw/dmwm/WMCore/pull/10105.patch | patch -d $DEPLOY_DIR/current/apps/t0/lib/python2.7/site-packages/ -p3
+wget -nv https://github.com/dmwm/T0/pull/4566.patch -O - | patch -f -d $DEPLOY_DIR/current/apps/t0/lib/python2*/site-packages/ -p 3
+wget -nv https://github.com/dmwm/WMCore/pull/10344.patch -O - | patch -f -d $DEPLOY_DIR/current/apps/t0/lib/python2*/site-packages/ -p 3

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -31,11 +31,11 @@ tier0Config = createTier0Config()
 setConfigVersion(tier0Config, "replace with real version")
 
 # Set run number to replay
-setInjectRuns(tier0Config, [341169])
+setInjectRuns(tier0Config, [341169,341754,338628,338714])
 
 # Settings up sites
-processingSite = "T2_CH_CERN"
-streamerPNN = "T2_CH_CERN"
+processingSite = "T0_CH_CERN"
+streamerPNN = "T0_CH_CERN_Disk"
 
 # Set global parameters:
 #  Acquisition era
@@ -86,7 +86,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_11_2_4"
+    'default': "CMSSW_11_3_1_patch1"
 }
 
 # Configure ScramArch
@@ -110,9 +110,9 @@ expressProcVersion = dt
 alcarawProcVersion = dt
 
 # Defaults for GlobalTag
-expressGlobalTag = "112X_dataRun3_Express_v5"
-promptrecoGlobalTag = "112X_dataRun3_Prompt_v5"
-alcap0GlobalTag = "112X_dataRun3_Prompt_v5"
+expressGlobalTag = "113X_dataRun3_Express_v2"
+promptrecoGlobalTag = "113X_dataRun3_Prompt_v2"
+alcap0GlobalTag = "113X_dataRun3_Prompt_v2"
 
 # Mandatory for CondDBv2
 globalTagConnect = "frontier://PromptProd/CMS_CONDITIONS"
@@ -136,7 +136,8 @@ repackVersionOverride = {
     "CMSSW_11_1_5" : defaultCMSSWVersion['default'],
     "CMSSW_11_2_1" : defaultCMSSWVersion['default'],
     "CMSSW_11_2_2" : defaultCMSSWVersion['default'],
-    "CMSSW_11_2_3" : defaultCMSSWVersion['default']
+    "CMSSW_11_2_3" : defaultCMSSWVersion['default'],
+    "CMSSW_11_2_4" : defaultCMSSWVersion['default']
     }
 
 expressVersionOverride = {
@@ -147,7 +148,8 @@ expressVersionOverride = {
     "CMSSW_11_1_5" : defaultCMSSWVersion['default'],
     "CMSSW_11_2_1" : defaultCMSSWVersion['default'],
     "CMSSW_11_2_2" : defaultCMSSWVersion['default'],
-    "CMSSW_11_2_3" : defaultCMSSWVersion['default']
+    "CMSSW_11_2_3" : defaultCMSSWVersion['default'],
+    "CMSSW_11_2_4" : defaultCMSSWVersion['default']
     }
 
 #set default repack settings for bulk streams


### PR DESCRIPTION
Replay configuration used in preparation for MWGR4 of 2021. I'm also updating the patches file and the replay deployment file so it defaults to use T0_CH_CERN_Disk instead of T2_CH_CERN for disk storage.