### PR TITLE
Paused failing jobs

### DIFF
--- a/bin/00_deploy_replay.sh
+++ b/bin/00_deploy_replay.sh
@@ -234,3 +234,8 @@ echo "config.RetryManager.PauseAlgo.section_('Processing')" >> ./config/tier0/co
 echo "config.RetryManager.PauseAlgo.Processing.retryErrorCodes = { 8001: 0, 70: 0, 50513: 0, 50660: 0, 50661: 0, 71304: 0, 99109: 0, 99303: 0, 99400: 0, 8001: 0, 50115: 0 }" >> ./config/tier0/config.py
 echo "config.RetryManager.PauseAlgo.section_('Repack')" >> ./config/tier0/config.py
 echo "config.RetryManager.PauseAlgo.Repack.retryErrorCodes = { 8001: 0, 70: 0, 50513: 0, 50660: 0, 50661: 0, 71304: 0, 99109: 0, 99303: 0, 99400: 0, 8001: 0, 50115: 0 }" >> ./config/tier0/config.py
+
+#Overwrite RetryManager for all type of jobs only replays
+sed -i "s/config.RetryManager.plugins.*/config.RetryManager.plugins={'default': 'PauseAlgo', 'Cleanup': 'PauseAlgo', 'LogCollect': 'PauseAlgo'}/g" ./config/tier0/config.py
+sed -i "s/config.ErrorHandler.maxRetries.*/config.ErrorHandler.maxRetries={'default': 30, 'Cleanup': 30, 'LogCollect': 30}/g" ./config/tier0/config.py
+

--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -38,8 +38,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'T0 System'
-copyright = u'2012, CMS collaboration'
+project = 'T0 System'
+copyright = '2012, CMS collaboration'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -176,8 +176,8 @@ htmlhelp_basename = 'T0doc'
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'T0.tex', u'T0 Documentation',
-   u'Valentin Kuznetsov', 'manual'),
+  ('index', 'T0.tex', 'T0 Documentation',
+   'Valentin Kuznetsov', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ To install  : python setup.py install --prefix=<some dir>
 To clean    : python setup.py clean
 To run tests: python setup.py test
 """
-from __future__ import print_function
+
 __author__ = "Valentin Kuznetsov"
 
 import sys
@@ -185,7 +185,7 @@ def main():
 
     # set default location for "data_files" to
     # platform specific "site-packages" location
-    for scheme in INSTALL_SCHEMES.values():
+    for scheme in list(INSTALL_SCHEMES.values()):
         scheme['data'] = scheme['purelib']
 
     setup(

--- a/src/python/T0/ConditionUpload/ConditionUploadAPI.py
+++ b/src/python/T0/ConditionUpload/ConditionUploadAPI.py
@@ -62,7 +62,7 @@ def uploadConditions(username, password, serviceProxy):
         dropboxHost = conditions[run]['dropboxHost']
         validationMode = conditions[run]['validationMode']
 
-        for streamid, uploadableFiles in conditions[run]['streams'].items():
+        for streamid, uploadableFiles in list(conditions[run]['streams'].items()):
 
             if len(uploadableFiles) > 0:
 
@@ -104,7 +104,7 @@ def uploadConditions(username, password, serviceProxy):
         dropboxHost = conditions[run]['dropboxHost']
         validationMode = conditions[run]['validationMode']
 
-        for streamid, uploadableFiles in conditions[run]['streams'].items():
+        for streamid, uploadableFiles in list(conditions[run]['streams'].items()):
 
             if len(uploadableFiles) > 0:
 
@@ -148,7 +148,7 @@ def uploadConditions(username, password, serviceProxy):
                 advanceToNextRun = False
 
         # check for timeout, but only if there is a next run
-        if not advanceToNextRun and index < len(conditions.keys()):
+        if not advanceToNextRun and index < len(list(conditions.keys())):
 
             getRunStopTimeDAO = daoFactory(classname = "ConditionUpload.GetRunStopTime")
             stopTime = getRunStopTimeDAO.execute(run, transaction = False)
@@ -184,7 +184,7 @@ def uploadToDropbox(condFiles, dropboxHost, validationMode,
                 filesDict[filenamePrefix] = {}
             filesDict[filenamePrefix][filenameExt] = condFile
 
-    for filenamePrefix in filesDict.keys():
+    for filenamePrefix in list(filesDict.keys()):
 
         sqliteFile = filesDict[filenamePrefix]['db']
         metaFile = filesDict[filenamePrefix]['txt']

--- a/src/python/T0/ConditionUpload/upload.py
+++ b/src/python/T0/ConditionUpload/upload.py
@@ -2,7 +2,7 @@
 '''Script that uploads to the new CMS conditions uploader.
 Adapted to the new infrastructure from v6 of the upload.py script for the DropBox from Miguel Ojeda.
 '''
-from __future__ import print_function
+
 
 __author__ = 'Andreas Pfeiffer'
 __copyright__ = 'Copyright 2015, CERN CMS'
@@ -36,7 +36,7 @@ defaultWorkflow = 'offline'
 # common/http.py start (plus the "# Try to extract..." section bit)
 import time
 import logging
-import cStringIO
+import io
 
 import pycurl
 import copy
@@ -45,7 +45,7 @@ def getInput(default, prompt = ''):
     '''Like raw_input() but with a default and automatic strip().
     '''
 
-    answer = raw_input(prompt)
+    answer = input(prompt)
     if answer:
         return answer.strip()
 
@@ -85,7 +85,7 @@ def getInputRepeat(prompt = ''):
     '''
 
     while True:
-        answer = raw_input(prompt)
+        answer = input(prompt)
         if answer:
             return answer.strip()
 
@@ -120,7 +120,7 @@ I will ask you some questions to fill the metadata file. For some of the questio
             inputTags = dataCursor.fetchall()
             if len(inputTags) == 0:
                 raise Exception()
-            inputTags = zip(*inputTags)[0]
+            inputTags = list(zip(*inputTags))[0]
 
         except Exception:
             inputTags = []
@@ -334,7 +334,7 @@ class HTTP(object):
         # self.curl.setopt( self.curl.POST, {})
         self.curl.setopt(self.curl.HTTPGET, 0)
 
-        response = cStringIO.StringIO()
+        response = io.StringIO()
         self.curl.setopt(pycurl.WRITEFUNCTION, response.write)
         self.curl.setopt(pycurl.USERPWD, '%s:%s' % (username, password) )
 
@@ -380,7 +380,7 @@ class HTTP(object):
         # make sure the logs are safe ... at least somewhat :)
         data4log = copy.copy(data)
         if data4log:
-            if 'password' in data4log.keys():
+            if 'password' in list(data4log.keys()):
                 data4log['password'] = '*'
 
         retries = [0] + list(self.retries)
@@ -407,13 +407,13 @@ class HTTP(object):
                         finalData.update(data)
 
                     if files is not None:
-                        for (key, fileName) in files.items():
+                        for (key, fileName) in list(files.items()):
                             finalData[key] = (self.curl.FORM_FILE, fileName)
-                    self.curl.setopt( self.curl.HTTPPOST, finalData.items() )
+                    self.curl.setopt( self.curl.HTTPPOST, list(finalData.items()) )
 
                 self.curl.setopt(pycurl.VERBOSE, 0)
 
-                response = cStringIO.StringIO()
+                response = io.StringIO()
                 self.curl.setopt(self.curl.WRITEFUNCTION, response.write)
                 self.curl.perform()
 
@@ -603,7 +603,7 @@ class ConditionsUploader(object):
         okTags      = []
         skippedTags = []
         failedTags  = []
-        for tag, info in statusInfo['itemStatus'].items():
+        for tag, info in list(statusInfo['itemStatus'].items()):
             logging.debug('checking tag %s, info %s', tag, str(json.dumps(info, indent=4, sort_keys=True)) )
             if 'ok'   in info['status'].lower() :
                 okTags.append( tag )
@@ -816,7 +816,7 @@ def main():
     results = uploadAllFiles(options, arguments)
 
     print("uploadAllFiles returned:")
-    for hash, res in results.items():
+    for hash, res in list(results.items()):
         print("\t %s : %s " % (hash, str(res)))
 
 def testTier0Upload():

--- a/src/python/T0/JobSplitting/Repack.py
+++ b/src/python/T0/JobSplitting/Repack.py
@@ -147,7 +147,7 @@ class Repack(JobFactory):
         Return age of youngest streamer in filesByLumi
         """
         maxInsertTime = 0
-        for filesInfos in filesByLumi.values():
+        for filesInfos in list(filesByLumi.values()):
             for fileInfo in filesInfos:
                 if fileInfo['insert_time'] > maxInsertTime:
                     maxInsertTime = fileInfo['insert_time']

--- a/src/python/T0/JobSplitting/RepackMerge.py
+++ b/src/python/T0/JobSplitting/RepackMerge.py
@@ -148,7 +148,7 @@ class RepackMerge(JobFactory):
         Return age of youngest streamer in filesByLumi
         """
         maxInsertTime = 0
-        for filesInfos in filesByLumi.values():
+        for filesInfos in list(filesByLumi.values()):
             for fileInfo in filesInfos:
                 if fileInfo['insert_time'] > maxInsertTime:
                     maxInsertTime = fileInfo['insert_time']

--- a/src/python/T0/RunConfig/RunConfigAPI.py
+++ b/src/python/T0/RunConfig/RunConfigAPI.py
@@ -110,9 +110,9 @@ def configureRun(tier0Config, run, hltConfig, referenceHltConfig = None):
         bindsTrigger = []
         bindsDatasetTrigger = []
 
-        for stream, datasetDict in hltConfig['mapping'].items():
+        for stream, datasetDict in list(hltConfig['mapping'].items()):
             bindsStream.append( { 'STREAM' : stream } )
-            for dataset, paths in datasetDict.items():
+            for dataset, paths in list(datasetDict.items()):
 
                 if dataset == "Unassigned path":
 
@@ -201,7 +201,7 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
     if runInfo['hltkey'] != None:
 
         # streams not explicitely configured are repacked
-        if stream not in tier0Config.Streams.dictionary_().keys():
+        if stream not in list(tier0Config.Streams.dictionary_().keys()):
             addRepackConfig(tier0Config, stream)
 
         streamConfig = tier0Config.Streams.dictionary_()[stream]
@@ -429,7 +429,7 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
         getStreamDatasetTriggersDAO = daoFactory(classname = "RunConfig.GetStreamDatasetTriggers")
         datasetTriggers = getStreamDatasetTriggersDAO.execute(run, stream, transaction = False)
 
-        for dataset, paths in datasetTriggers.items():
+        for dataset, paths in list(datasetTriggers.items()):
 
             datasetConfig = retrieveDatasetConfig(tier0Config, dataset)
 
@@ -750,7 +750,7 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
                 insertWorkflowMonitoringDAO.execute([fileset.id],  conn = myThread.transaction.conn, transaction = True)
             if streamConfig.ProcessingStyle == "Bulk":
                 bindsRecoReleaseConfig = []
-                for fileset, primds in wmbsHelper.getMergeOutputMapping().items():
+                for fileset, primds in list(wmbsHelper.getMergeOutputMapping().items()):
                     bindsRecoReleaseConfig.append( { 'RUN' : run,
                                                      'PRIMDS' : primds,
                                                      'FILESET' : fileset } )
@@ -1141,11 +1141,11 @@ def releasePromptReco(tier0Config, specDirectory, dqmUploadProxy):
                 insertStorageNodeDAO.execute(bindsStorageNode, conn = myThread.transaction.conn, transaction = True)
             if len(bindsReleasePromptReco) > 0:
                 releasePromptRecoDAO.execute(bindsReleasePromptReco, conn = myThread.transaction.conn, transaction = True)
-            for (wmbsHelper, wmSpec, fileset) in recoSpecs.values():
+            for (wmbsHelper, wmSpec, fileset) in list(recoSpecs.values()):
                 wmbsHelper.createSubscription(wmSpec.getTask(taskName), Fileset(id = fileset), alternativeFilesetClose = True)
                 insertWorkflowMonitoringDAO.execute([fileset],  conn = myThread.transaction.conn, transaction = True)
             if len(recoSpecs) > 0:
-                markWorkflowsInjectedDAO.execute(recoSpecs.keys(), injected = True, conn = myThread.transaction.conn, transaction = True)
+                markWorkflowsInjectedDAO.execute(list(recoSpecs.keys()), injected = True, conn = myThread.transaction.conn, transaction = True)
         except Exception as ex:
             logging.exception(ex)
             myThread.transaction.rollback()

--- a/src/python/T0/RunLumiCloseout/RunLumiCloseoutAPI.py
+++ b/src/python/T0/RunLumiCloseout/RunLumiCloseoutAPI.py
@@ -51,7 +51,7 @@ def stopRuns(dbInterfaceStorageManager):
         stoppedRuns = findStoppedRunsDAO.execute(runs = activeRuns, transaction = False)
 
         bindVarList = []
-        for run, (start_time, stop_time) in stoppedRuns.items():
+        for run, (start_time, stop_time) in list(stoppedRuns.items()):
             bindVarList.append( { 'RUN' : run,
                                   'START_TIME' : start_time,
                                   'STOP_TIME' : stop_time } )
@@ -102,15 +102,15 @@ def closeRuns(dbInterfaceStorageManager):
     # find all runs with open run/stream filesets and check which have changed lumicount, update those
     runLumicountT0 = getOpenRunStreamLumicountDAO.execute(transaction = False)
     if len(runLumicountT0) > 0:
-        runLumicountSM = findClosedRunsDAO.execute(runs = runLumicountT0.keys(), transaction = False)
-        for run, lumicount in runLumicountSM.items():
+        runLumicountSM = findClosedRunsDAO.execute(runs = list(runLumicountT0.keys()), transaction = False)
+        for run, lumicount in list(runLumicountSM.items()):
             if lumicount != runLumicountT0[run]:
                 closedRuns[run] = lumicount
 
     if len(closedRuns) > 0:
         bindVarList = []
         currentTime = int(time.time())
-        for run, lumicount in closedRuns.items():
+        for run, lumicount in list(closedRuns.items()):
             bindVarList.append( { 'RUN' : run,
                                   'LUMICOUNT' : lumicount,
                                   'CLOSE_TIME' : currentTime } )
@@ -183,7 +183,7 @@ def closeLumiSections(dbInterfaceStorageManager):
             runLumis[run].add(lumi)
 
         bindVarList = []
-        for run, lumis in runLumis.items():
+        for run, lumis in list(runLumis.items()):
             for lumi in lumis:
                 bindVarList.append( { 'RUN' : run,
                                       'LUMI' : lumi } )

--- a/src/python/T0/WMBS/Oracle/Create.py
+++ b/src/python/T0/WMBS/Oracle/Create.py
@@ -860,7 +860,7 @@ class Create(DBCreator):
                       8 : "CloseOutExport",
                       9 : "CloseOutT1Skimming",
                       10 : "Complete" }
-        for id, name in runStates.items():
+        for id, name in list(runStates.items()):
             sql = """INSERT INTO run_status
                      (ID, NAME)
                      VALUES (%d, '%s')
@@ -873,7 +873,7 @@ class Create(DBCreator):
                              4 : "Convert",
                              5 : "RegisterAndConvert",
                              6 : "Ignore" }
-        for id, name in processingStyles.items():
+        for id, name in list(processingStyles.items()):
             sql = """INSERT INTO processing_style
                      (ID, NAME)
                      VALUES (%d, '%s')
@@ -920,7 +920,7 @@ class Create(DBCreator):
                            38 : "cosmicsEra_Run3",
                            39 : "hcalnzsEra_Run3",
                            40 : "trackingOnlyEra_Run3" }
-        for id, name in eventScenarios.items():
+        for id, name in list(eventScenarios.items()):
             sql = """INSERT INTO event_scenario
                      (ID, NAME)
                      VALUES (%d, '%s')

--- a/src/python/T0/WMBS/Oracle/RunConfig/FindRecoRelease.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/FindRecoRelease.py
@@ -33,7 +33,7 @@ class FindRecoRelease(DBFormatter):
         now = int(time.time())
 
         binds = []
-        for dataset, delays in datasetDelays.items():
+        for dataset, delays in list(datasetDelays.items()):
             binds.append( { 'NOW' : now,
                             'DATASET' : dataset,
                             'DELAY' : delays[0],

--- a/src/python/T0/WMBS/Oracle/Subscriptions/GetAllFiles.py
+++ b/src/python/T0/WMBS/Oracle/Subscriptions/GetAllFiles.py
@@ -40,4 +40,4 @@ class GetAllFiles(DBFormatter):
             else:
                 result[entry['lfn']]['location'].add(entry['location'])
 
-        return result.values()
+        return list(result.values())

--- a/src/python/T0/WMBS/Oracle/Subscriptions/GetAvailableExpressFiles.py
+++ b/src/python/T0/WMBS/Oracle/Subscriptions/GetAvailableExpressFiles.py
@@ -53,4 +53,4 @@ class GetAvailableExpressFiles(DBFormatter):
             else:
                 result[entry['lfn']]['location'].add(entry['location'])
 
-        return result.values()
+        return list(result.values())

--- a/src/python/T0/WMBS/Oracle/Subscriptions/GetAvailableExpressMergeFiles.py
+++ b/src/python/T0/WMBS/Oracle/Subscriptions/GetAvailableExpressMergeFiles.py
@@ -66,4 +66,4 @@ class GetAvailableExpressMergeFiles(DBFormatter):
             else:
                 result[entry['lfn']]['location'].add(entry['location'])
 
-        return result.values()
+        return list(result.values())

--- a/src/python/T0/WMBS/Oracle/Subscriptions/GetAvailableRepackFiles.py
+++ b/src/python/T0/WMBS/Oracle/Subscriptions/GetAvailableRepackFiles.py
@@ -56,4 +56,4 @@ class GetAvailableRepackFiles(DBFormatter):
             else:
                 result[entry['lfn']]['location'].add(entry['location'])
 
-        return result.values()
+        return list(result.values())

--- a/src/python/T0/WMBS/Oracle/Subscriptions/GetAvailableRepackMergeFiles.py
+++ b/src/python/T0/WMBS/Oracle/Subscriptions/GetAvailableRepackMergeFiles.py
@@ -77,4 +77,4 @@ class GetAvailableRepackMergeFiles(DBFormatter):
             else:
                 result[entry['lfn']]['location'].add(entry['location'])
 
-        return result.values()
+        return list(result.values())

--- a/src/python/T0Component/Tier0Auditor/Tier0Auditor.py
+++ b/src/python/T0Component/Tier0Auditor/Tier0Auditor.py
@@ -6,7 +6,7 @@ _Tier0Auditor_
 Component wrapper, for real work look at Tier0AuditorPoller
 
 """
-from __future__ import print_function
+
 import logging
 import threading
 

--- a/src/python/T0Component/Tier0Feeder/Tier0Feeder.py
+++ b/src/python/T0Component/Tier0Feeder/Tier0Feeder.py
@@ -6,7 +6,7 @@ _Tier0Feeder_
 Component wrapper, for real work look at Tier0FeederPoller
 
 """
-from __future__ import print_function
+
 import logging
 import threading
 

--- a/test/python/T0Component_t/Tier0Feeder_t/ExampleConfig.py
+++ b/test/python/T0Component_t/Tier0Feeder_t/ExampleConfig.py
@@ -4,7 +4,7 @@ _ExampleConfig_
 Example configuration for RunConfig unittest
 
 """
-from __future__ import print_function
+
 from T0.RunConfig.Tier0Config import addDataset
 from T0.RunConfig.Tier0Config import createTier0Config
 from T0.RunConfig.Tier0Config import setAcquisitionEra

--- a/test/python/T0Component_t/Tier0Feeder_t/Tier0Feeder_t.py
+++ b/test/python/T0Component_t/Tier0Feeder_t/Tier0Feeder_t.py
@@ -5,7 +5,7 @@ _Tier0Feeder_t_
 Testing the Tier0Feeder code
 
 """
-from __future__ import print_function
+
 import unittest
 import threading
 import logging
@@ -1263,7 +1263,7 @@ class Tier0FeederTest(unittest.TestCase):
                          "ERROR: there should be no new run")
 
         runStreams = self.findNewRunStreamsDAO.execute(transaction = False)
-        self.assertEqual(len(runStreams.keys()), 0,
+        self.assertEqual(len(list(runStreams.keys())), 0,
                          "ERROR: there should be no new run/stream")
 
         self.feedStreamers()
@@ -1277,7 +1277,7 @@ class Tier0FeederTest(unittest.TestCase):
         self.assertEqual(len(runs), 1,
                          "ERROR: there should be one new run")
         runStreams = self.findNewRunStreamsDAO.execute(transaction = False)
-        self.assertEqual(len(runStreams.keys()), 0,
+        self.assertEqual(len(list(runStreams.keys())), 0,
                          "ERROR: there should be no new run/stream")
 
         RunConfigAPI.configureRun(self.tier0Config, 176161,
@@ -1302,7 +1302,7 @@ class Tier0FeederTest(unittest.TestCase):
         RunConfigAPI.configureRunStream(self.tier0Config, 176161, "A", self.testDir, self.dqmUploadProxy)
 
         runStreams = self.findNewRunStreamsDAO.execute(transaction = False)
-        self.assertEqual(len(runStreams.keys()), 0,
+        self.assertEqual(len(list(runStreams.keys())), 0,
                          "ERROR: there should be no new run/stream")
 
         self.feedStreamers()
@@ -1391,7 +1391,7 @@ class Tier0FeederTest(unittest.TestCase):
                          "ERROR: there should be two new runs")
 
         runStreams = self.findNewRunStreamsDAO.execute(transaction = False)
-        self.assertEqual(len(runStreams.keys()), 0,
+        self.assertEqual(len(list(runStreams.keys())), 0,
                          "ERROR: there should be no new run/stream")
 
         self.feedStreamers()
@@ -1518,7 +1518,7 @@ class Tier0FeederTest(unittest.TestCase):
         RunConfigAPI.configureRunStream(self.tier0Config, 176163, "A", self.testDir, self.dqmUploadProxy)
 
         runStreams = self.findNewRunStreamsDAO.execute(transaction = False)
-        self.assertEqual(len(runStreams.keys()), 0,
+        self.assertEqual(len(list(runStreams.keys())), 0,
                          "ERROR: there should be no new run/stream")
 
         self.feedStreamers()
@@ -1564,7 +1564,7 @@ class Tier0FeederTest(unittest.TestCase):
 
         RunLumiCloseoutAPI.closeRuns(self.dbInterfaceStorageManager)
         endedRuns = self.getEndedRuns()
-        self.assertEqual(endedRuns.keys(), [176161],
+        self.assertEqual(list(endedRuns.keys()), [176161],
                          "ERROR: there should be 1 ended run: 176161")
         self.assertEqual(endedRuns[176161], 23,
                          "ERROR: there should be 23 lumis in run 176161")
@@ -1593,11 +1593,11 @@ class Tier0FeederTest(unittest.TestCase):
         RunLumiCloseoutAPI.closeLumiSections(self.dbInterfaceStorageManager)
 
         runStreamLumiDict = self.getClosedLumis()
-        self.assertEqual(runStreamLumiDict.keys(), [176161],
+        self.assertEqual(list(runStreamLumiDict.keys()), [176161],
                          "ERROR: there should be closed lumis for run 176161")
-        self.assertEqual(runStreamLumiDict[176161].keys(), ['A'],
+        self.assertEqual(list(runStreamLumiDict[176161].keys()), ['A'],
                          "ERROR: there should be closed lumis for run 176161 and stream A")
-        self.assertEqual(sorted(runStreamLumiDict[176161]['A'].keys()), range(1, 24),
+        self.assertEqual(sorted(runStreamLumiDict[176161]['A'].keys()), list(range(1, 24)),
                          "ERROR: there should be closed lumis for run 176161, stream A and lumi 1 to 23")
 
         for lumi in range(1, 24):
@@ -1611,13 +1611,13 @@ class Tier0FeederTest(unittest.TestCase):
         RunLumiCloseoutAPI.closeLumiSections(self.dbInterfaceStorageManager)
 
         runStreamLumiDict = self.getClosedLumis()
-        self.assertEqual(runStreamLumiDict.keys(), [176161],
+        self.assertEqual(list(runStreamLumiDict.keys()), [176161],
                          "ERROR: there should be closed lumis for run 176161")
         self.assertEqual(sorted(runStreamLumiDict[176161].keys()), ['A', 'HLTMON'],
                          "ERROR: there should be closed lumis for run 176161 and stream A and HLTMON")
-        self.assertEqual(sorted(runStreamLumiDict[176161]['A'].keys()), range(1, 24),
+        self.assertEqual(sorted(runStreamLumiDict[176161]['A'].keys()), list(range(1, 24)),
                          "ERROR: there should be closed lumis for run 176161, stream A and lumi 1 to 23")
-        self.assertEqual(sorted(runStreamLumiDict[176161]['HLTMON'].keys()), range(1, 24),
+        self.assertEqual(sorted(runStreamLumiDict[176161]['HLTMON'].keys()), list(range(1, 24)),
                          "ERROR: there should be closed lumis for run 176161, stream HLTMON and lumi 1 to 23")
 
         for lumi in range(1, 24):

--- a/test/python/T0_t/WMBS_t/RunConfig_t/ExampleConfig.py
+++ b/test/python/T0_t/WMBS_t/RunConfig_t/ExampleConfig.py
@@ -4,7 +4,7 @@ _ExampleConfig_
 Example configuration for RunConfig unittest
 
 """
-from __future__ import print_function
+
 from T0.RunConfig.Tier0Config import addDataset
 from T0.RunConfig.Tier0Config import createTier0Config
 from T0.RunConfig.Tier0Config import setAcquisitionEra

--- a/test/python/T0_t/WMBS_t/RunConfig_t/RunConfig_t.py
+++ b/test/python/T0_t/WMBS_t/RunConfig_t/RunConfig_t.py
@@ -5,7 +5,7 @@ _RunConfig_t_
 Testing the RunConfig code
 
 """
-from __future__ import print_function
+
 import unittest
 import threading
 import logging
@@ -1162,7 +1162,7 @@ class RunConfigTest(unittest.TestCase):
 
             self.assertEqual(sorted(mapping.keys()), sorted(self.referenceMapping[stream].keys()),
                              "ERROR: primary datasets do not match reference")
-            for primds in mapping.keys():
+            for primds in list(mapping.keys()):
                 self.assertEqual(sorted(mapping[primds]), sorted(self.referenceMapping[stream][primds]),
                                  "ERROR: trigger paths do not match reference")
 
@@ -1365,7 +1365,7 @@ class RunConfigTest(unittest.TestCase):
         recoConfigs = self.getRecoConfigDAO.execute(176161, "A",
                                                    transaction = False)
 
-        self.assertEqual(len(recoConfigs.keys()), 0,
+        self.assertEqual(len(list(recoConfigs.keys())), 0,
                          "ERROR: there are reco configs present")
 
         RunConfigAPI.releasePromptReco(self.tier0Config, self.testDir, self.dqmUploadProxy)
@@ -1373,7 +1373,7 @@ class RunConfigTest(unittest.TestCase):
         recoConfigs = self.getRecoConfigDAO.execute(176161, "A",
                                                    transaction = False)
 
-        self.assertEqual(len(recoConfigs.keys()), 0,
+        self.assertEqual(len(list(recoConfigs.keys())), 0,
                          "ERROR: there are reco configs present")
 
         self.removeRecoDelay("Cosmics")
@@ -1383,7 +1383,7 @@ class RunConfigTest(unittest.TestCase):
         recoConfigs = self.getRecoConfigDAO.execute(176161, "A",
                                                    transaction = False)
 
-        self.assertEqual(len(recoConfigs.keys()), 0,
+        self.assertEqual(len(list(recoConfigs.keys())), 0,
                          "ERROR: there are reco configs present")
 
         delay = self.delay
@@ -1398,7 +1398,7 @@ class RunConfigTest(unittest.TestCase):
         recoConfigs = self.getRecoConfigDAO.execute(176161, "A",
                                                    transaction = False)
 
-        self.assertEqual(len(recoConfigs.keys()), 0,
+        self.assertEqual(len(list(recoConfigs.keys())), 0,
                          "ERROR: there are reco configs present")
       
         self.closeRunsDAO.execute(binds = { 'RUN' : 176161,
@@ -1431,7 +1431,7 @@ class RunConfigTest(unittest.TestCase):
         self.assertEqual(set(recoConfigs.keys()), set(datasets),
                          "ERROR: problems retrieving reco configs for stream A")
 
-        for primds, recoConfig in recoConfigs.items():
+        for primds, recoConfig in list(recoConfigs.items()):
 
             if primds == "Cosmics":
 
@@ -1570,7 +1570,7 @@ class RunConfigTest(unittest.TestCase):
         self.assertEqual(set(phedexConfigs.keys()),set(['MinimumBias','Cosmics']),
                          "ERROR: problems retrieving PhEDEx configs")
 
-        for primds, phedexConfig in phedexConfigs.items():
+        for primds, phedexConfig in list(phedexConfigs.items()):
 
             if primds == "Cosmics":
 


### PR DESCRIPTION
While testing new WMCore releases with replays, we need to ensure that all types of CMS jobs finished successful instead of go failing after x attempts (for example for LogCollect and CleanUp jobs). The Tier0Config.py file shows the [following](https://github.com/dmwm/T0/blob/fa9a200af6d492a80beefe158afcad9015e4d630/etc/Tier0Config.py#L23-L29) logic so we only need to overwrite this configuration only for replays.