### PR TITLE
Replay test with CMSSW_11_3_2

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -137,7 +137,8 @@ repackVersionOverride = {
     "CMSSW_11_2_1" : defaultCMSSWVersion['default'],
     "CMSSW_11_2_2" : defaultCMSSWVersion['default'],
     "CMSSW_11_2_3" : defaultCMSSWVersion['default'],
-    "CMSSW_11_2_4" : defaultCMSSWVersion['default']
+    "CMSSW_11_2_4" : defaultCMSSWVersion['default'],
+    "CMSSW_11_3_1" : defaultCMSSWVersion['default']
     }
 
 expressVersionOverride = {
@@ -149,7 +150,8 @@ expressVersionOverride = {
     "CMSSW_11_2_1" : defaultCMSSWVersion['default'],
     "CMSSW_11_2_2" : defaultCMSSWVersion['default'],
     "CMSSW_11_2_3" : defaultCMSSWVersion['default'],
-    "CMSSW_11_2_4" : defaultCMSSWVersion['default']
+    "CMSSW_11_2_4" : defaultCMSSWVersion['default'],
+    "CMSSW_11_3_1" : defaultCMSSWVersion['default']
     }
 
 #set default repack settings for bulk streams

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -225,7 +225,7 @@ addExpressConfig(tier0Config, "ExpressCosmics",
                  write_dqm=True,
                  alca_producers=["SiStripPCLHistos", "SiStripCalZeroBias", "TkAlCosmics0T",
                                  "SiPixelCalZeroBias",
-                                 "PromptCalibProdSiStrip", "PromptCalibProdSiPixel", "SiStripCalCosmics"
+                                 "PromptCalibProdSiStrip", "PromptCalibProdSiPixel"
                                 ],
                  reco_version=defaultCMSSWVersion,
                  multicore=numberOfCores,
@@ -434,7 +434,7 @@ for dataset in DATASETS:
                write_aod=True,
                write_miniaod=False,
                write_dqm=True,
-               alca_producers=["TkAlCosmics0T", "MuAlGlobalCosmics"],
+               alca_producers=["TkAlCosmics0T", "MuAlGlobalCosmics", "SiStripCalCosmics", "SiPixelCalCosmics", "DtCalibCosmics"],
                physics_skims=["CosmicSP", "CosmicTP", "LogError", "LogErrorMonitor"],
                timePerEvent=0.5,
                sizePerEvent=155,

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -31,7 +31,7 @@ tier0Config = createTier0Config()
 setConfigVersion(tier0Config, "replace with real version")
 
 # Set run number to replay
-setInjectRuns(tier0Config, [341169,341754,338628,338714])
+setInjectRuns(tier0Config, [341169,341754,338628,338714,342154])
 
 # Settings up sites
 processingSite = "T0_CH_CERN"
@@ -86,7 +86,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_11_3_1_patch1"
+    'default': "CMSSW_11_3_2"
 }
 
 # Configure ScramArch
@@ -110,9 +110,9 @@ expressProcVersion = dt
 alcarawProcVersion = dt
 
 # Defaults for GlobalTag
-expressGlobalTag = "113X_dataRun3_Express_v2"
-promptrecoGlobalTag = "113X_dataRun3_Prompt_v2"
-alcap0GlobalTag = "113X_dataRun3_Prompt_v2"
+expressGlobalTag = "113X_dataRun3_Express_Candidate_2021_07_02_14_38_40"
+promptrecoGlobalTag = "113X_dataRun3_Prompt_v3"
+alcap0GlobalTag = "113X_dataRun3_Prompt_v3"
 
 # Mandatory for CondDBv2
 globalTagConnect = "frontier://PromptProd/CMS_CONDITIONS"


### PR DESCRIPTION
Test of CMSSW_11_3_2 for the CRUZET (July 12 - Aug 14).

Runs include 341169, 341754, 338628, 338714, 342154. 

The GTs are: 
 HLT    : 113X_dataRun3_HLT_Candidate_2021_07_02_14_05_25
 Express: 113X_dataRun3_Express_Candidate_2021_07_02_14_38_40
 Prompt : 113X_dataRun3_Prompt_v3