### PR TITLE
Create a list of sites intead of modifying the dataset config

### DIFF
--- a/src/python/T0/RunConfig/RunConfigAPI.py
+++ b/src/python/T0/RunConfig/RunConfigAPI.py
@@ -1128,9 +1128,9 @@ def releasePromptReco(tier0Config, specDirectory, dqmUploadProxy):
                     wmSpec.setOverrideCatalog(tier0Config.Global.overrideCatalog)
 
                 #Overriding processing site in case we using T0 disk
-                datasetConfig.SiteWhitelist = [ 'T2_CH_CERN' if s=='T0_CH_CERN' else s for s in datasetConfig.SiteWhitelist]
+                siteWhitelist = [ 'T2_CH_CERN' if s=='T0_CH_CERN' else s for s in datasetConfig.SiteWhitelist]
 
-                wmSpec.updateArguments( { 'SiteWhitelist': datasetConfig.SiteWhitelist,
+                wmSpec.updateArguments( { 'SiteWhitelist': siteWhitelist,
                                           'SiteBlacklist': [],
                                           'TrustSitelists': "True",
                                           'BlockCloseMaxWaitTime': datasetConfig.BlockCloseDelay,


### PR DESCRIPTION
Fixes an issue that causes the agent to skip overriding the site config for a few of the workflows when deploying several runs at the same time