### PR TITLE
11_3_3 Replay test

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -31,7 +31,7 @@ tier0Config = createTier0Config()
 setConfigVersion(tier0Config, "replace with real version")
 
 # Set run number to replay
-setInjectRuns(tier0Config, [341169,341754,338628,338714,342154])
+setInjectRuns(tier0Config, [341169,341754,338628,338714,342154,343498])
 
 # Settings up sites
 processingSite = "T0_CH_CERN"


### PR DESCRIPTION
Test of CMSSW_11_3_3 for the CRUZET

Runs include 341169,341754,338628,338714,342154,343498

The GTs are:
expressGlobalTag = "113X_dataRun3_Express_Candidate_2021_07_02_14_38_40"
promptrecoGlobalTag = "113X_dataRun3_Prompt_v3"
alcap0GlobalTag = "113X_dataRun3_Prompt_v3"
