### PR TITLE
Add sites configuration to easily switch storage sites

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -37,8 +37,14 @@ setInjectMinRun(tier0Config, 341801)
 setInjectMaxRun(tier0Config, 9999999)
 
 # Settings up sites
-processingSite = "T0_CH_CERN"
+processingSite = "T2_CH_CERN"
+storageSite = "T0_CH_CERN_Disk"
 streamerPNN = "T0_CH_CERN_Disk"
+
+addSiteConfig(tier0Config, "T0_CH_CERN_Disk",
+                siteLocalConfig="/cvmfs/cms.cern.ch/SITECONF/T0_CH_CERN/JobConfig/site-local-config.xml",
+                overrideCatalog="trivialcatalog_file:/cvmfs/cms.cern.ch/SITECONF/T0_CH_CERN/PhEDEx/storage.xml?protocol=eos"
+                )
 
 # Set global parameters:
 #  Acquisition era

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -20,8 +20,10 @@ from T0.RunConfig.Tier0Config import setConfigVersion
 from T0.RunConfig.Tier0Config import ignoreStream
 from T0.RunConfig.Tier0Config import addRepackConfig
 from T0.RunConfig.Tier0Config import addExpressConfig
+from T0.RunConfig.Tier0Config import addSiteConfig
 from T0.RunConfig.Tier0Config import setInjectRuns
 from T0.RunConfig.Tier0Config import setStreamerPNN
+from T0.RunConfig.Tier0Config import setStorageSite
 from T0.RunConfig.Tier0Config import setEnableUniqueWorkflowName
 
 # Create the Tier0 configuration object
@@ -34,8 +36,19 @@ setConfigVersion(tier0Config, "replace with real version")
 setInjectRuns(tier0Config, [341169,341754,338628,338714,342154])
 
 # Settings up sites
-processingSite = "T0_CH_CERN"
+processingSite = "T2_CH_CERN"
+storageSite = "T0_CH_CERN_Disk"
 streamerPNN = "T0_CH_CERN_Disk"
+
+addSiteConfig(tier0Config, "T0_CH_CERN_Disk",
+                siteLocalConfig="/cvmfs/cms.cern.ch/SITECONF/T0_CH_CERN/JobConfig/site-local-config.xml",
+                overrideCatalog="trivialcatalog_file:/cvmfs/cms.cern.ch/SITECONF/T0_CH_CERN/PhEDEx/storage.xml?protocol=eos"
+                )
+
+addSiteConfig(tier0Config, "EOS_PILOT",
+                siteLocalConfig="/cvmfs/cms.cern.ch/SITECONF/T0_CH_CERN/JobConfig/site-local-config_EOS_PILOT.xml",
+                overrideCatalog="trivialcatalog_file:/cvmfs/cms.cern.ch/SITECONF/T0_CH_CERN/PhEDEx/storage_EOS_PILOT.xml?protocol=eos"
+                )
 
 # Set global parameters:
 #  Acquisition era
@@ -50,6 +63,7 @@ setBackfill(tier0Config, 1)
 setBulkDataType(tier0Config, "data")
 setProcessingSite(tier0Config, processingSite)
 setStreamerPNN(tier0Config, streamerPNN)
+setStorageSite(tier0Config, storageSite)
 
 # Override for DQM data tier
 setDQMDataTier(tier0Config, "DQMIO")


### PR DESCRIPTION
Before #4566, choosing a particular processing site implied that we were using the same site as storage. Now we have the ability to process data in T2_CH_CERN while storing output in different disk sites. This feature is currently being use in production to write output data to T0_CH_CERN_Disk and to test EOS configurations with EOS_PILOT.

Given this development, our previous way of configuring sites needed to be reworked. This PR does that by adding the following fields to the Tier0 configuration:

- Added StorageSite as a Global configuration parameter aside from ProcessingSite: This makes it more clear to pick different storage sites.  

- Added Site configurations: Now we can specify relevant information when using a new site

Now  TFC and site local config files are overriten only when there is a difference between ProcessingSite and StorageSite