### PR TITLE
11_3_4 Replay test

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -31,7 +31,7 @@ tier0Config = createTier0Config()
 setConfigVersion(tier0Config, "replace with real version")
 
 # Set run number to replay
-setInjectRuns(tier0Config, [341169,341754,338628,338714,342154,343498])
+setInjectRuns(tier0Config, [341169,341754,338628,338714,342154,343498,344063])
 
 # Settings up sites
 processingSite = "T0_CH_CERN"

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -31,7 +31,7 @@ tier0Config = createTier0Config()
 setConfigVersion(tier0Config, "replace with real version")
 
 # Set run number to replay
-setInjectRuns(tier0Config, [341169,341754,338628,338714,342154])
+setInjectRuns(tier0Config, [341169,341754,338628,338714,342154,343498])
 
 # Settings up sites
 processingSite = "T0_CH_CERN"
@@ -86,7 +86,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_11_3_2"
+    'default': "CMSSW_11_3_4"
 }
 
 # Configure ScramArch
@@ -110,7 +110,7 @@ expressProcVersion = dt
 alcarawProcVersion = dt
 
 # Defaults for GlobalTag
-expressGlobalTag = "113X_dataRun3_Express_Candidate_2021_07_02_14_38_40"
+expressGlobalTag = "113X_dataRun3_Express_v4"
 promptrecoGlobalTag = "113X_dataRun3_Prompt_v3"
 alcap0GlobalTag = "113X_dataRun3_Prompt_v3"
 
@@ -138,7 +138,9 @@ repackVersionOverride = {
     "CMSSW_11_2_2" : defaultCMSSWVersion['default'],
     "CMSSW_11_2_3" : defaultCMSSWVersion['default'],
     "CMSSW_11_2_4" : defaultCMSSWVersion['default'],
-    "CMSSW_11_3_1" : defaultCMSSWVersion['default']
+    "CMSSW_11_3_1" : defaultCMSSWVersion['default'],
+    "CMSSW_11_3_2" : defaultCMSSWVersion['default'],
+    "CMSSW_11_3_3" : defaultCMSSWVersion['default']
     }
 
 expressVersionOverride = {
@@ -151,7 +153,9 @@ expressVersionOverride = {
     "CMSSW_11_2_2" : defaultCMSSWVersion['default'],
     "CMSSW_11_2_3" : defaultCMSSWVersion['default'],
     "CMSSW_11_2_4" : defaultCMSSWVersion['default'],
-    "CMSSW_11_3_1" : defaultCMSSWVersion['default']
+    "CMSSW_11_3_1" : defaultCMSSWVersion['default'],
+    "CMSSW_11_3_2" : defaultCMSSWVersion['default'],
+    "CMSSW_11_3_3" : defaultCMSSWVersion['default']
     }
 
 #set default repack settings for bulk streams


### PR DESCRIPTION
Test CMSSW_11_3_4 for CRUZET.

Runs include: 341169,341754,338628,338714,342154,343498,344063

Global Tags:
- expressGlobalTag = "113X_dataRun3_Express_v4"
- promptrecoGlobalTag = "113X_dataRun3_Prompt_v3"
- alcap0GlobalTag = "113X_dataRun3_Prompt_v3"