### PR TITLE
 Replay test with 12_1_0_pre3

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -33,7 +33,7 @@ tier0Config = createTier0Config()
 setConfigVersion(tier0Config, "replace with real version")
 
 # Set run number to replay
-setInjectRuns(tier0Config, [341169,341754,338628,338714,342154])
+setInjectRuns(tier0Config, [341169,341754,342154,344518])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"
@@ -100,7 +100,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_11_3_2"
+    'default': "CMSSW_12_1_0_pre3"
 }
 
 # Configure ScramArch
@@ -124,7 +124,7 @@ expressProcVersion = dt
 alcarawProcVersion = dt
 
 # Defaults for GlobalTag
-expressGlobalTag = "113X_dataRun3_Express_Candidate_2021_07_02_14_38_40"
+expressGlobalTag = "113X_dataRun3_Express_v4"
 promptrecoGlobalTag = "113X_dataRun3_Prompt_v3"
 alcap0GlobalTag = "113X_dataRun3_Prompt_v3"
 

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -152,7 +152,11 @@ repackVersionOverride = {
     "CMSSW_11_2_2" : defaultCMSSWVersion['default'],
     "CMSSW_11_2_3" : defaultCMSSWVersion['default'],
     "CMSSW_11_2_4" : defaultCMSSWVersion['default'],
-    "CMSSW_11_3_1" : defaultCMSSWVersion['default']
+    "CMSSW_11_3_1" : defaultCMSSWVersion['default'],
+    "CMSSW_11_3_2" : defaultCMSSWVersion['default'],
+    "CMSSW_11_3_3" : defaultCMSSWVersion['default'],
+    "CMSSW_11_3_4" : defaultCMSSWVersion['default'],
+    "CMSSW_12_0_0" : defaultCMSSWVersion['default']  
     }
 
 expressVersionOverride = {
@@ -165,7 +169,11 @@ expressVersionOverride = {
     "CMSSW_11_2_2" : defaultCMSSWVersion['default'],
     "CMSSW_11_2_3" : defaultCMSSWVersion['default'],
     "CMSSW_11_2_4" : defaultCMSSWVersion['default'],
-    "CMSSW_11_3_1" : defaultCMSSWVersion['default']
+    "CMSSW_11_3_1" : defaultCMSSWVersion['default'],
+    "CMSSW_11_3_2" : defaultCMSSWVersion['default'],
+    "CMSSW_11_3_3" : defaultCMSSWVersion['default'],
+    "CMSSW_11_3_4" : defaultCMSSWVersion['default'],
+    "CMSSW_12_0_0" : defaultCMSSWVersion['default']  
     }
 
 #set default repack settings for bulk streams

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -33,7 +33,7 @@ tier0Config = createTier0Config()
 setConfigVersion(tier0Config, "replace with real version")
 
 # Set run number to replay
-setInjectRuns(tier0Config, [341169,341754,342154,344518])
+setInjectRuns(tier0Config, [341169,341754,342154,343498])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"


### PR DESCRIPTION
See #4605 

Runs: 341169,341754,342154,344518

Release: CMSSW_12_1_0_pre3

GT: 
- Express: 113X_dataRun3_Express_v4
- Prompt: 113X_dataRun3_Prompt_v3