### PR TITLE
Replay on CRUZET data with CMSSW_12_0_2

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -33,7 +33,7 @@ tier0Config = createTier0Config()
 setConfigVersion(tier0Config, "replace with real version")
 
 # Set run number to replay
-setInjectRuns(tier0Config, [341169,341754,342154,343498])
+setInjectRuns(tier0Config, [343498])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"
@@ -100,7 +100,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_12_1_0_pre3"
+    'default': "CMSSW_12_0_2"
 }
 
 # Configure ScramArch
@@ -124,9 +124,9 @@ expressProcVersion = dt
 alcarawProcVersion = dt
 
 # Defaults for GlobalTag
-expressGlobalTag = "113X_dataRun3_Express_v4"
-promptrecoGlobalTag = "113X_dataRun3_Prompt_Candidate_2021_09_10_23_04_14"
-alcap0GlobalTag = "113X_dataRun3_Prompt_Candidate_2021_09_10_23_04_14"
+expressGlobalTag = "120X_dataRun3_Express_Candidate_2021_09_30_18_36_13"
+promptrecoGlobalTag = "120X_dataRun3_Prompt_Candidate_2021_10_01_08_44_53"
+alcap0GlobalTag = "120X_dataRun3_Prompt_Candidate_2021_10_01_08_44_53"
 
 # Mandatory for CondDBv2
 globalTagConnect = "frontier://PromptProd/CMS_CONDITIONS"


### PR DESCRIPTION
Test on October data taking GTs. The configuration is the following:

```
Run: 343498
CMSSW: CMSSW_12_0_2
HLT     : 120X_dataRun3_HLT_Candidate_2021_09_30_19_21_44
Express : 120X_dataRun3_Express_Candidate_2021_09_30_18_36_13
Prompt  : 120X_dataRun3_Prompt_Candidate_2021_10_01_08_44_53
```
