### PR TITLE
Update deployment scripts for T0 Agent 3.0.1

### DIFF
--- a/bin/00_deploy_prod.sh
+++ b/bin/00_deploy_prod.sh
@@ -4,9 +4,9 @@ BASE_DIR=/data/tier0
 DEPLOY_DIR=$BASE_DIR/srv/wmagent
 SPEC_DIR=$BASE_DIR/admin/Specs
 
-TIER0_VERSION=2.2.4
+TIER0_VERSION=3.0.1
 TIER0_ARCH=slc7_amd64_gcc630
-DEPLOY_TAG=HG2105a
+DEPLOY_TAG=HG2110b
 
 function echo_header {
 	echo ''

--- a/bin/00_deploy_replay.sh
+++ b/bin/00_deploy_replay.sh
@@ -4,10 +4,9 @@ BASE_DIR=/data/tier0
 DEPLOY_DIR=$BASE_DIR/srv/wmagent
 SPEC_DIR=$BASE_DIR/admin/Specs
 
-TIER0_VERSION=2.2.4
+TIER0_VERSION=3.0.1
 TIER0_ARCH=slc7_amd64_gcc630
-DEPLOY_TAG=HG2105a
-
+DEPLOY_TAG=HG2110b
 
 function echo_header {
     echo ''

--- a/bin/00_patches.sh
+++ b/bin/00_patches.sh
@@ -6,5 +6,15 @@
 BASE_DIR=/data/tier0
 DEPLOY_DIR=$BASE_DIR/srv/wmagent
 
-wget -nv https://github.com/dmwm/T0/pull/4566.patch -O - | patch -f -d $DEPLOY_DIR/current/apps/t0/lib/python2*/site-packages/ -p 3
-wget -nv https://github.com/dmwm/WMCore/pull/10344.patch -O - | patch -f -d $DEPLOY_DIR/current/apps/t0/lib/python2*/site-packages/ -p 3
+
+#Patches on top of 2.2.4
+
+#wget -nv https://github.com/dmwm/T0/pull/4566.patch -O - | patch -f -d $DEPLOY_DIR/current/apps/t0/lib/python*/site-packages/ -p 3
+#wget -nv https://github.com/dmwm/WMCore/pull/10344.patch -O - | patch -f -d $DEPLOY_DIR/current/apps/t0/lib/python*/site-packages/ -p 3
+#wget -nv https://github.com/dmwm/T0/pull/4589.patch -O - | patch -f -d $DEPLOY_DIR/current/apps/t0/lib/python*/site-packages/ -p 3
+#wget -nv https://github.com/dmwm/T0/pull/4596.patch -O - | patch -f -d $DEPLOY_DIR/current/apps/t0/lib/python*/site-packages/ -p 3
+#wget -nv https://github.com/dmwm/T0/pull/4597.patch -O - | patch -f -d $DEPLOY_DIR/current/apps/t0/lib/python*/site-packages/ -p 3
+
+#Patches on top of 3.0.1
+wget -nv https://github.com/dmwm/WMCore/pull/10801.patch -O - | patch -f -d $DEPLOY_DIR/current/apps/t0/lib/python3*/site-packages/ -p 3
+wget -nv https://github.com/dmwm/T0/pull/4611.patch -O - | patch -f -d $DEPLOY_DIR/current/apps/t0/lib/python3*/site-packages/ -p 3


### PR DESCRIPTION
Update the scripts with T0 version, deployment tag and patches to run replay and production agents using T0 Agent 3.0.0or 3.0.1.
