### PR TITLE
[DQM] Prompt Matrix reconfiguration

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -99,7 +99,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_12_1_0"
+    'default': "CMSSW_12_1_1"
 }
 
 # Configure ScramArch


### PR DESCRIPTION
Changes for Prompt Matrix DQM reduction:

Reduced:
- L1TMon to SingleMuon, SingleElectron/EG and ZB
- TAU to SingleMuon, SingleElectron/EG and TAU
- TRK to SingleMuon, SingleElectron/EG, DoubleMuon, JetHT, JetMET and ZB, by creating commonReduced which excludes TRK
- CTPPS to DoubleMuon, SingleElectron/EG y ZB

# Replay Request

**Requestor**  
PPD-DQM

**Describe the configuration**  
* Release: CMSSW_12_1_X and PR https://github.com/cms-sw/cmssw/pull/35605
* Run: 317696
* GTs:
        expressGlobalTag: 120X_dataRun3_Express_Candidate_2021_09_30_18_52_55
        promptrecoGlobalTag: 120X_dataRun3_Prompt_Candidate_2021_09_30_19_06_33
        alcap0GlobalTag: 120X_dataRun3_Prompt_Candidate_2021_09_30_19_06_33

* Additional changes:
This PR goes in sync with: cms-sw/cmssw#35605
   
**Purpose of the test**  

Not sure if a replay is needed. PPD started a campaign to reduce the DQM load on Prompt matrix. This PR reduces the number of sequences as agreed on:

https://docs.google.com/presentation/d/1AF65xzq7T70Yt-0o_OV47YTFBv-kbvHZDlRmUSCZsAw/edit#slide=id.geedc047305_0_0

**T0 Operations HyperNews thread**   
https://hypernews.cern.ch/HyperNews/CMS/get/tier0-Ops/2314.html

Thanks

