### PR TITLE
test 12_0_2_patch2

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -100,7 +100,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_12_0_2_patch1"
+    'default': "CMSSW_12_0_2_patch2"
 }
 
 # Configure ScramArch
@@ -158,7 +158,8 @@ repackVersionOverride = {
     "CMSSW_11_3_4" : defaultCMSSWVersion['default'],
     "CMSSW_12_0_0" : defaultCMSSWVersion['default'],
     "CMSSW_12_0_1" : defaultCMSSWVersion['default'],
-    "CMSSW_12_0_2" : defaultCMSSWVersion['default']
+    "CMSSW_12_0_2" : defaultCMSSWVersion['default'],
+    "CMSSW_12_0_2_patch1" : defaultCMSSWVersion['default']
     }
 
 expressVersionOverride = {
@@ -177,7 +178,8 @@ expressVersionOverride = {
     "CMSSW_11_3_4" : defaultCMSSWVersion['default'],
     "CMSSW_12_0_0" : defaultCMSSWVersion['default'],
     "CMSSW_12_0_1" : defaultCMSSWVersion['default'],
-    "CMSSW_12_0_2" : defaultCMSSWVersion['default']
+    "CMSSW_12_0_2" : defaultCMSSWVersion['default'],
+    "CMSSW_12_0_2_patch1" : defaultCMSSWVersion['default']
     }
 
 #set default repack settings for bulk streams

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -124,9 +124,9 @@ expressProcVersion = dt
 alcarawProcVersion = dt
 
 # Defaults for GlobalTag
-expressGlobalTag = "120X_dataRun3_Express_Candidate_2021_09_30_18_36_13"
-promptrecoGlobalTag = "120X_dataRun3_Prompt_Candidate_2021_10_01_08_44_53"
-alcap0GlobalTag = "120X_dataRun3_Prompt_Candidate_2021_10_01_08_44_53"
+expressGlobalTag = "120X_dataRun3_Express_v2"
+promptrecoGlobalTag = "120X_dataRun3_Prompt_v2"
+alcap0GlobalTag = "120X_dataRun3_Prompt_v2"
 
 # Mandatory for CondDBv2
 globalTagConnect = "frontier://PromptProd/CMS_CONDITIONS"


### PR DESCRIPTION
# Replay Request

**Requetor
ORP, T0 (@germanfgv @qliphy, @perrotta)

Following https://github.com/dmwm/T0/pull/4614 and #4621

**Describe the configuration**  
* Release: CMSSW_12_0_2_patch2
* Run: 343082,344063
* GTs:
   * expressGlobalTag: 120X_dataRun3_Express_v2
   * promptrecoGlobalTag: 120X_dataRun3_Prompt_v2
   * alcap0GlobalTag: 120X_dataRun3_Prompt_v2
* Additional changes:

**Purpose of the test**  
 T0 validation of CMSSW pre-releases for early detection of issues with T0 workflows

**T0 Operations HyperNews thread**   
https://hypernews.cern.ch/HyperNews/CMS/get/tier0-Ops/2285.html
