### PR TITLE
fix duplicated DQM sequences for `MinimumBias` PDs

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -33,7 +33,7 @@ tier0Config = createTier0Config()
 setConfigVersion(tier0Config, "replace with real version")
 
 # Set run number to replay
-setInjectRuns(tier0Config, [343082,344063])
+setInjectRuns(tier0Config, [346062])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"
@@ -100,7 +100,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_12_0_2_patch2"
+    'default': "CMSSW_12_0_3_patch1"
 }
 
 # Configure ScramArch
@@ -158,7 +158,10 @@ repackVersionOverride = {
     "CMSSW_11_3_4" : defaultCMSSWVersion['default'],
     "CMSSW_12_0_0" : defaultCMSSWVersion['default'],
     "CMSSW_12_0_1" : defaultCMSSWVersion['default'],
-    "CMSSW_12_0_2" : defaultCMSSWVersion['default']
+    "CMSSW_12_0_2" : defaultCMSSWVersion['default'],
+    "CMSSW_12_0_2_patch1" : defaultCMSSWVersion['default'],
+    "CMSSW_12_0_2_patch2" : defaultCMSSWVersion['default'],
+    "CMSSW_12_0_3" : defaultCMSSWVersion['default']
     }
 
 expressVersionOverride = {
@@ -177,7 +180,10 @@ expressVersionOverride = {
     "CMSSW_11_3_4" : defaultCMSSWVersion['default'],
     "CMSSW_12_0_0" : defaultCMSSWVersion['default'],
     "CMSSW_12_0_1" : defaultCMSSWVersion['default'],
-    "CMSSW_12_0_2" : defaultCMSSWVersion['default']
+    "CMSSW_12_0_2" : defaultCMSSWVersion['default'],
+    "CMSSW_12_0_2_patch1" : defaultCMSSWVersion['default'],
+    "CMSSW_12_0_2_patch2" : defaultCMSSWVersion['default'],
+    "CMSSW_12_0_3" : defaultCMSSWVersion['default']
     }
 
 #set default repack settings for bulk streams

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -946,7 +946,7 @@ for dataset in DATASETS:
     addDataset(tier0Config, dataset,
                do_reco=True,
                write_dqm=True,
-               dqm_sequences=["@common", "@commonSiStripZeroBias", "@ecal", "@hcal", "@muon", "@jetmet"],
+               dqm_sequences=["@commonSiStripZeroBias", "@ecal", "@hcal", "@muon", "@jetmet"],
                timePerEvent=1,
                alca_producers=["SiStripCalZeroBias", "SiStripCalMinBias", "TkAlMinBias", "HcalCalHO", 
                                "HcalCalIterativePhiSym", "HcalCalHBHEMuonFilter", "HcalCalIsoTrkFilter"],


### PR DESCRIPTION
Casually looking at the T0 configuration I noticed that e.g.:

```console
{
  "run": 345687, 
  "write_miniaod": true, 
  "scram_arch": "slc7_amd64_gcc900", 
  "write_aod": true, 
  "write_reco": false, 
  "alca_skim": "SiStripCalZeroBias,SiStripCalMinBias,TkAlMinBias", 
  "cmssw": "CMSSW_12_0_2_patch1", 
  "physics_skim": null, 
  "write_dqm": true, 
  "scenario": "ppEra_Run3", 
  "global_tag": "120X_dataRun3_Prompt_v2", 
  "multicore": 8, 
  "dqm_seq": "@common,@commonSiStripZeroBias,@ecal,@hcal,@muon,@jetmet", 
  "primary_dataset": "MinimumBias"
}
```

while `@common` and `@commonSiStripZeroBias` have many sequences in common, excepted the Pixel, Strip and Tracking DQM sequences.

https://github.com/cms-sw/cmssw/blob/027525058713f5a07c90d0530bb8c4a7448d3306/DQMOffline/Configuration/python/autoDQM.py#L9-L11

vs

https://github.com/cms-sw/cmssw/blob/027525058713f5a07c90d0530bb8c4a7448d3306/DQMOffline/Configuration/python/autoDQM.py#L17-L19

I think only `@commonSiStripZeroBias` is the one to keep.
@jfernan2 @tvami
