### PR TITLE
Replay configuration for CMSSW_12_0_3

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -33,7 +33,7 @@ tier0Config = createTier0Config()
 setConfigVersion(tier0Config, "replace with real version")
 
 # Set run number to replay
-setInjectRuns(tier0Config, [343082,344063])
+setInjectRuns(tier0Config, [344063, 345595, 345881])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"
@@ -100,7 +100,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_12_0_2_patch2"
+    'default': "CMSSW_12_0_3"
 }
 
 # Configure ScramArch
@@ -158,7 +158,9 @@ repackVersionOverride = {
     "CMSSW_11_3_4" : defaultCMSSWVersion['default'],
     "CMSSW_12_0_0" : defaultCMSSWVersion['default'],
     "CMSSW_12_0_1" : defaultCMSSWVersion['default'],
-    "CMSSW_12_0_2" : defaultCMSSWVersion['default']
+    "CMSSW_12_0_2" : defaultCMSSWVersion['default'],
+    "CMSSW_12_0_2_patch1" : defaultCMSSWVersion['default'],
+    "CMSSW_12_0_2_patch2" : defaultCMSSWVersion['default']
     }
 
 expressVersionOverride = {
@@ -177,7 +179,10 @@ expressVersionOverride = {
     "CMSSW_11_3_4" : defaultCMSSWVersion['default'],
     "CMSSW_12_0_0" : defaultCMSSWVersion['default'],
     "CMSSW_12_0_1" : defaultCMSSWVersion['default'],
-    "CMSSW_12_0_2" : defaultCMSSWVersion['default']
+    "CMSSW_12_0_2" : defaultCMSSWVersion['default'],
+    "CMSSW_12_0_2" : defaultCMSSWVersion['default'],
+    "CMSSW_12_0_2_patch1" : defaultCMSSWVersion['default'],
+    "CMSSW_12_0_2_patch2" : defaultCMSSWVersion['default']
     }
 
 #set default repack settings for bulk streams


### PR DESCRIPTION
# Replay Request

**Requestor**  
ORM, RC

**Describe the configuration**  
* Release: CMSSW_12_0_3
* Run: 344063, 345595, 345881
* GTs:
   * expressGlobalTag: 120X_dataRun3_Express_v2
   * promptrecoGlobalTag: 120X_dataRun3_Prompt_v2
   * alcap0GlobalTag: 120X_dataRun3_Prompt_v2

**Purpose of the test**  
Test new CMSSW patch release in preparation for next week's collisions during Pilot Beam Test 

**T0 Operations HyperNews thread**  
https://hypernews.cern.ch/HyperNews/CMS/get/tier0-Ops/2298.html
