### PR TITLE
Replay testing CMSSW_12_0_3 in collisions21 run

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -33,7 +33,7 @@ tier0Config = createTier0Config()
 setConfigVersion(tier0Config, "replace with real version")
 
 # Set run number to replay
-setInjectRuns(tier0Config, [345970])
+setInjectRuns(tier0Config, [345595, 345881, 345915, 345970])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"


### PR DESCRIPTION
# Replay Request

**Requestor**  
ORM

**Describe the configuration**  
* Release: CMSSW_12_0_3
* Run: 345970
* GTs:
   * expressGlobalTag: 120X_dataRun3_Express_v2
   * promptrecoGlobalTag: 120X_dataRun3_Prompt_v2
   * alcap0GlobalTag: 120X_dataRun3_Prompt_v2

**Purpose of the test**  
While CMSSW_12_0_3 was successfully tested in #4627 with cosmics and splashes runs. an issue has been identified in collisions21 runs that do not include ECAL [(HN Report)](https://hypernews.cern.ch/HyperNews/CMS/get/tier0-Ops/2301/1.html). ORM wants to test the release in a collision run that does include ECAL.

**T0 Operations HyperNews thread**  
https://hypernews.cern.ch/HyperNews/CMS/get/tier0-Ops/2301/1.html
