### PR TITLE
Adding replay for run 345915 in CMSSW_12_0_3_patch1

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -33,7 +33,7 @@ tier0Config = createTier0Config()
 setConfigVersion(tier0Config, "replace with real version")
 
 # Set run number to replay
-setInjectRuns(tier0Config, [345595, 345881, 345915, 345970])
+setInjectRuns(tier0Config, [345915])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"
@@ -100,7 +100,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_12_0_3"
+    'default': "CMSSW_12_0_3_patch1"
 }
 
 # Configure ScramArch

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -161,7 +161,7 @@ repackVersionOverride = {
     "CMSSW_12_0_2" : defaultCMSSWVersion['default'],
     "CMSSW_12_0_2_patch1" : defaultCMSSWVersion['default'],
     "CMSSW_12_0_2_patch2" : defaultCMSSWVersion['default'],
-    "CMSSW_12_0_3_patch1" : defaultCMSSWVersion['default'],
+    "CMSSW_12_0_3_patch1" : defaultCMSSWVersion['default']
     }
 
 expressVersionOverride = {

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -160,7 +160,8 @@ repackVersionOverride = {
     "CMSSW_12_0_1" : defaultCMSSWVersion['default'],
     "CMSSW_12_0_2" : defaultCMSSWVersion['default'],
     "CMSSW_12_0_2_patch1" : defaultCMSSWVersion['default'],
-    "CMSSW_12_0_2_patch2" : defaultCMSSWVersion['default']
+    "CMSSW_12_0_2_patch2" : defaultCMSSWVersion['default'],
+    "CMSSW_12_0_3_patch1" : defaultCMSSWVersion['default'],
     }
 
 expressVersionOverride = {
@@ -182,7 +183,8 @@ expressVersionOverride = {
     "CMSSW_12_0_2" : defaultCMSSWVersion['default'],
     "CMSSW_12_0_2" : defaultCMSSWVersion['default'],
     "CMSSW_12_0_2_patch1" : defaultCMSSWVersion['default'],
-    "CMSSW_12_0_2_patch2" : defaultCMSSWVersion['default']
+    "CMSSW_12_0_2_patch2" : defaultCMSSWVersion['default'],
+    "CMSSW_12_0_3_patch1" : defaultCMSSWVersion['default']    
     }
 
 #set default repack settings for bulk streams


### PR DESCRIPTION
# Replay Request

Salvatore Rappoccio (ORM)
Team or person that requests this replay

**Describe the configuration**  
* Release: CMSSW_12_0_3_patch
* Run: 345915
* GTs:
   * expressGlobalTag: 120X_dataRun3_Express_v2
   * promptrecoGlobalTag: 120X_dataRun3_Prompt_v2
   * alcap0GlobalTag: 120X_dataRun3_Prompt_v2
* Additional changes: None

**Purpose of the test**  
Required to ensure that PR [#35807](https://github.com/cms-sw/cmssw/pull/35807) fixes issue seen in HCAL reconstruction [#35785](https://github.com/cms-sw/cmssw/issues/35785)

**T0 Operations HyperNews thread**  
If necessary, provide a link to the HN thread announcing the test to the relevant groups. 
[Tier0 Operations HN Forum](https://hypernews.cern.ch/HyperNews/CMS/get/tier0-Ops.html?)
