### PR TITLE
Adding deployment ID to DB and Tier0Config

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -4,7 +4,6 @@ Processing configuration for the Tier0 - Replay version
 """
 from __future__ import print_function
 
-import datetime
 from T0.RunConfig.Tier0Config import addDataset
 from T0.RunConfig.Tier0Config import createTier0Config
 from T0.RunConfig.Tier0Config import setAcquisitionEra
@@ -118,7 +117,7 @@ alcaLumiPixelsScenario = "AlCaLumiPixels"
 hiTestppScenario = "ppEra_Run3"
 
 # Procesing version number replays
-dt = int(datetime.datetime.now().strftime("%y%m%d%H%M"))
+dt = 1
 defaultProcVersion = dt
 expressProcVersion = dt
 alcarawProcVersion = dt

--- a/src/python/T0/RunConfig/RunConfigAPI.py
+++ b/src/python/T0/RunConfig/RunConfigAPI.py
@@ -554,8 +554,8 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
             taskName = "Repack"
 
             if tier0Config.Global.EnableUniqueWorkflowName:
-                workflowName = "Repack_Run%d_Stream%s_%s_v%s_%s" % (run, stream, 
-                    tier0Config.Global.AcquisitionEra, streamConfig.Repack.ProcessingVersion, 
+                workflowName = "Repack_Run%d_Stream%s_%s_ID%d_v%s_%s" % (run, stream, 
+                    tier0Config.Global.AcquisitionEra, tier0Config.Global.DeploymentID, streamConfig.Repack.ProcessingVersion, 
                     time.strftime('%y%m%d_%H%M', time.localtime(time.time())))
             else:
                 workflowName = "Repack_Run%d_Stream%s" % (run, stream)
@@ -605,8 +605,8 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
             taskName = "Express"
 
             if tier0Config.Global.EnableUniqueWorkflowName:
-                workflowName = "Express_Run%d_Stream%s_%s_v%s_%s" % (run, stream, 
-                    tier0Config.Global.AcquisitionEra, streamConfig.Express.ProcessingVersion,
+                workflowName = "Express_Run%d_Stream%s_%s_ID%d_v%s_%s" % (run, stream, 
+                    tier0Config.Global.AcquisitionEra, tier0Config.Global.DeploymentID, streamConfig.Express.ProcessingVersion,
                     time.strftime('%y%m%d_%H%M', time.localtime(time.time())))
             else:
                 workflowName = "Express_Run%d_Stream%s" % (run, stream)
@@ -1036,8 +1036,8 @@ def releasePromptReco(tier0Config, specDirectory, dqmUploadProxy):
                 taskName = "Reco"
 
                 if tier0Config.Global.EnableUniqueWorkflowName:
-                    workflowName = "PromptReco_Run%d_%s_%s_v%s_%s" % (run, dataset,
-                        tier0Config.Global.AcquisitionEra, datasetConfig.ProcessingVersion,
+                    workflowName = "PromptReco_Run%d_%s_%s_ID%d_v%s_%s" % (run, dataset,
+                        tier0Config.Global.AcquisitionEra, tier0Config.Global.DeploymentID, datasetConfig.ProcessingVersion,
                         time.strftime('%y%m%d_%H%M', time.localtime(time.time())))
                 else:
                     workflowName = "PromptReco_Run%d_%s" % (run, dataset)

--- a/src/python/T0/RunConfig/Tier0Config.py
+++ b/src/python/T0/RunConfig/Tier0Config.py
@@ -65,6 +65,8 @@ Tier0Configuration - Global configuration object
 | |       |--> DefaultScramArch - Default ScramArch if nothing else is specified for release
 | |       |
 | |       |--> BaseRequestPriority - Base for request priorities for PromptReco/Repack/Express
+| |       |
+| |       |--> DeploymentID - Unique identifier for every T0 Agent deployment
 | |
 | |
 | |--> Streams - Configuration parameters that belong to a particular stream
@@ -267,6 +269,8 @@ def createTier0Config():
     tier0Config.Global.BaseRequestPriority = 150000
 
     tier0Config.Global.EnableUniqueWorkflowName = False
+
+    tier0Config.Global.DeploymentID = 1
 
     return tier0Config
 
@@ -745,6 +749,15 @@ def setEnableUniqueWorkflowName(config):
     PromptReco_Run322057_Charmonium_Tier0_REPLAY_vocms047_v274_190221_121
     """
     config.Global.EnableUniqueWorkflowName = True
+    return
+
+def setDeploymentId(config, id):
+    """
+    _setDeploymentId_
+
+    Sets an ID for the current deployment of T0
+    """
+    config.Global.DeploymentID = id
     return
 
 def ignoreStream(config, streamName):

--- a/src/python/T0/WMBS/Oracle/Create.py
+++ b/src/python/T0/WMBS/Oracle/Create.py
@@ -37,6 +37,14 @@ class Create(DBCreator):
                ) ORGANIZATION INDEX"""
 
         self.create[len(self.create)] = \
+            """CREATE TABLE t0_deployment_id (
+                 name   varchar2(15)  not null,
+                 id     int           not null,
+                 primary key(name),
+                 constraint CK_DEPLOY_ID CHECK (name='deployment_id')
+               ) ORGANIZATION INDEX"""
+
+        self.create[len(self.create)] = \
             """CREATE TABLE run_status (
                  id     int          not null,
                  name   varchar2(25) not null,

--- a/src/python/T0/WMBS/Oracle/Tier0Feeder/GetDeploymentID.py
+++ b/src/python/T0/WMBS/Oracle/Tier0Feeder/GetDeploymentID.py
@@ -1,0 +1,22 @@
+"""
+_GetDeploymentID_
+
+Oracle implementation of GetDeploymentID
+Retrieves T0 deployment ID 
+"""
+from WMCore.Database.DBFormatter import DBFormatter
+
+class GetDeploymentID(DBFormatter):
+
+    def execute(self, conn = None, transaction = False):
+
+        sql = """SELECT id
+                 from t0_deployment_id"""
+
+        results = self.dbi.processData(sql, {}, conn = conn,
+                             transaction = transaction)[0].fetchall()
+        id = 0
+        if results:
+            id=results[0][0]
+
+        return id

--- a/src/python/T0/WMBS/Oracle/Tier0Feeder/SetDeploymentID.py
+++ b/src/python/T0/WMBS/Oracle/Tier0Feeder/SetDeploymentID.py
@@ -1,0 +1,21 @@
+"""
+_SetDeploymentID_
+
+Oracle implementation of SetDeploymentID
+Sets T0 deployment ID 
+"""
+from WMCore.Database.DBFormatter import DBFormatter
+
+class SetDeploymentID(DBFormatter):
+
+    def execute(self, id, conn = None, transaction = False):
+
+        sql = """INSERT INTO t0_deployment_id
+                 (name, id)
+                 VALUES ('deployment_id', :ID)"""
+
+        binds = {"ID" : id}
+        results = self.dbi.processData(sql, binds, conn = conn,
+                             transaction = transaction)
+
+        return


### PR DESCRIPTION
Add ID for each T0 deployment. 

The ID is the time and date of the deployment wiht the following format: ''%y%m%d%H%M%S"

The ID is stored in a new table in the T0AST database.  The table preventscratend multiple IDs unless the DB is wiped out.

The deployment ID is also added to the Unique workflow name in replays