### PR TITLE
test CMSSW_12_0_3_patch2

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -33,7 +33,7 @@ tier0Config = createTier0Config()
 setConfigVersion(tier0Config, "replace with real version")
 
 # Set run number to replay
-setInjectRuns(tier0Config, [345595, 345881, 345915, 345970])
+setInjectRuns(tier0Config, [345915])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"
@@ -100,7 +100,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_12_0_3"
+    'default': "CMSSW_12_0_3_patch2"
 }
 
 # Configure ScramArch
@@ -160,7 +160,9 @@ repackVersionOverride = {
     "CMSSW_12_0_1" : defaultCMSSWVersion['default'],
     "CMSSW_12_0_2" : defaultCMSSWVersion['default'],
     "CMSSW_12_0_2_patch1" : defaultCMSSWVersion['default'],
-    "CMSSW_12_0_2_patch2" : defaultCMSSWVersion['default']
+    "CMSSW_12_0_2_patch2" : defaultCMSSWVersion['default'],
+    "CMSSW_12_0_3" : defaultCMSSWVersion['default'],
+    "CMSSW_12_0_3_patch1" : defaultCMSSWVersion['default']
     }
 
 expressVersionOverride = {
@@ -182,7 +184,9 @@ expressVersionOverride = {
     "CMSSW_12_0_2" : defaultCMSSWVersion['default'],
     "CMSSW_12_0_2" : defaultCMSSWVersion['default'],
     "CMSSW_12_0_2_patch1" : defaultCMSSWVersion['default'],
-    "CMSSW_12_0_2_patch2" : defaultCMSSWVersion['default']
+    "CMSSW_12_0_2_patch2" : defaultCMSSWVersion['default'],
+    "CMSSW_12_0_3" : defaultCMSSWVersion['default'],
+    "CMSSW_12_0_3_patch1" : defaultCMSSWVersion['default']
     }
 
 #set default repack settings for bulk streams


### PR DESCRIPTION
# Replay Request

Test CMSSW_12_0_3_patch2, with configurations following
https://github.com/dmwm/T0/pull/4630

**Requestor**  
Qiang Li [ORP]

**Describe the configuration**  
* Release:  CMSSW_12_0_3_patch2
* Run: 345915
* GTs:
   * expressGlobalTag:   120X_dataRun3_Express_v2
   * promptrecoGlobalTag:  120X_dataRun3_Prompt_v2
   * alcap0GlobalTag:  120X_dataRun3_Prompt_v2
* Additional changes:  None

**Purpose of the test**  
Test CMSSW_12_0_3_patch2, with a few minor fixes on top of 12_0_3_patch1

**T0 Operations HyperNews thread**  
https://hypernews.cern.ch/HyperNews/CMS/get/tier0-Ops/2315.html