### PR TITLE
Update production node CMSSW_12_0_3_patch2

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -94,7 +94,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_12_0_3_patch1"
+    'default': "CMSSW_12_0_3_patch2"
 }
 
 # Configure ScramArch
@@ -166,7 +166,8 @@ repackVersionOverride = {
     "CMSSW_12_0_2" : defaultCMSSWVersion['default'],
     "CMSSW_12_0_2_patch1" : defaultCMSSWVersion['default'],
     "CMSSW_12_0_2_patch2" : defaultCMSSWVersion['default'],
-    "CMSSW_12_0_3" : defaultCMSSWVersion['default']
+    "CMSSW_12_0_3" : defaultCMSSWVersion['default'],
+    "CMSSW_12_0_3_patch1" : defaultCMSSWVersion['default']
     }
 
 expressVersionOverride = {
@@ -190,7 +191,8 @@ expressVersionOverride = {
     "CMSSW_12_0_2" : defaultCMSSWVersion['default'],
     "CMSSW_12_0_2_patch1" : defaultCMSSWVersion['default'],
     "CMSSW_12_0_2_patch2" : defaultCMSSWVersion['default'],
-    "CMSSW_12_0_3" : defaultCMSSWVersion['default']
+    "CMSSW_12_0_3" : defaultCMSSWVersion['default'],
+    "CMSSW_12_0_3_patch1" : defaultCMSSWVersion['default']
     }
 
 #set default repack settings for bulk streams
@@ -1023,7 +1025,7 @@ for dataset in DATASETS:
                write_dqm=True,
                tape_node="T1_RU_JINR_MSS",
                disk_node="T1_RU_JINR_Disk",
-               dqm_sequences=["@common", "@commonSiStripZeroBias", "@ecal", "@hcal", "@muon", "@jetmet"],
+               dqm_sequences=["@commonSiStripZeroBias", "@ecal", "@hcal", "@muon", "@jetmet"],
                timePerEvent=1,
                alca_producers=["SiStripCalZeroBias", "SiStripCalMinBias", "TkAlMinBias", "HcalCalHO", 
                                "HcalCalIterativePhiSym", "HcalCalHBHEMuonFilter", "HcalCalIsoTrkFilter"],


### PR DESCRIPTION
Update the production node with a new CMSSW release and a fix in dqm sequences for MinimumBias PDs
