### PR TITLE
Add lifetime to dataset from ConfigFile

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -232,6 +232,7 @@ addDataset(tier0Config, "Default",
            timePerEvent=5,
            sizePerEvent=1500,
            maxMemoryperCore=2000,
+           dataset_lifetime=3*30*24*3600,#lifetime for container rules. Default 3 months
            scenario=ppScenario)
 
 #############################
@@ -263,6 +264,7 @@ addExpressConfig(tier0Config, "Express",
                  timePerEvent=4,
                  sizePerEvent=1700,
                  maxMemoryperCore=2000,
+                 dataset_lifetime=3*30*24*3600,#lifetime for container rules. Default 3 months
                  versionOverride=expressVersionOverride)
 
 addExpressConfig(tier0Config, "ExpressCosmics",
@@ -289,6 +291,7 @@ addExpressConfig(tier0Config, "ExpressCosmics",
                  timePerEvent=4, #I have to get some stats to set this properly
                  sizePerEvent=1700, #I have to get some stats to set this properly
                  maxMemoryperCore=2000,
+                 dataset_lifetime=3*30*24*3600,#lifetime for container rules. Default 3 months
                  versionOverride=expressVersionOverride)
 
 addExpressConfig(tier0Config, "HLTMonitor",
@@ -313,6 +316,7 @@ addExpressConfig(tier0Config, "HLTMonitor",
                  timePerEvent=4, #I have to get some stats to set this properly
                  sizePerEvent=1700, #I have to get some stats to set this properly
                  maxMemoryperCore=2000,
+                 dataset_lifetime=3*30*24*3600,#lifetime for container rules. Default 3 months
                  versionOverride=expressVersionOverride)
 
 addExpressConfig(tier0Config, "Calibration",
@@ -338,6 +342,7 @@ addExpressConfig(tier0Config, "Calibration",
                  maxMemoryperCore=2000,
                  archivalNode="T0_CH_CERN_MSS",
                  dataType="data",
+                 dataset_lifetime=3*30*24*3600,#lifetime for container rules. Default 3 months
                  tape_node="T1_US_FNAL_MSS")
 
 addExpressConfig(tier0Config, "ExpressAlignment",
@@ -362,6 +367,7 @@ addExpressConfig(tier0Config, "ExpressAlignment",
                  sizePerEvent=1700,
                  versionOverride=expressVersionOverride,
                  maxMemoryperCore=2000,
+                 dataset_lifetime=3*30*24*3600,#lifetime for container rules. Default 3 months
                  diskNode="T2_CH_CERN")
 
 addExpressConfig(tier0Config, "ALCALUMIPIXELSEXPRESS",
@@ -388,6 +394,7 @@ addExpressConfig(tier0Config, "ALCALUMIPIXELSEXPRESS",
                  maxMemoryperCore=2000,
                  archivalNode=None,
                  tapeNode=None,
+                 dataset_lifetime=3*30*24*3600,#lifetime for container rules. Default 3 months
                  diskNode=None)
 
 
@@ -420,6 +427,7 @@ addExpressConfig(tier0Config, "HIExpress",
                  timePerEvent=4,
                  sizePerEvent=1700,
                  maxMemoryperCore=2000,
+                 dataset_lifetime=3*30*24*3600,#lifetime for container rules. Default 3 months
                  versionOverride=expressVersionOverride)
 
 addExpressConfig(tier0Config, "HIExpressAlignment",
@@ -445,6 +453,7 @@ addExpressConfig(tier0Config, "HIExpressAlignment",
                  sizePerEvent=1700,
                  versionOverride=expressVersionOverride,
                  maxMemoryperCore=2000,
+                 dataset_lifetime=3*30*24*3600,#lifetime for container rules. Default 3 months
                  diskNode="T2_CH_CERN")
 
 ###################################

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -224,6 +224,7 @@ addDataset(tier0Config, "Default",
            timePerEvent=5,
            sizePerEvent=1500,
            maxMemoryperCore=2000,
+           dataset_lifetime=14*24*3600,#lifetime for container rules. Default 14 days
            scenario=ppScenario)
 
 #############################
@@ -253,6 +254,7 @@ addExpressConfig(tier0Config, "Express",
                  timePerEvent=4,
                  sizePerEvent=1700,
                  maxMemoryperCore=2000,
+                 dataset_lifetime=14*24*3600,#lifetime for container rules. Default 14 days
                  versionOverride=expressVersionOverride)
 
 addExpressConfig(tier0Config, "ExpressCosmics",
@@ -279,6 +281,7 @@ addExpressConfig(tier0Config, "ExpressCosmics",
                  timePerEvent=4, #I have to get some stats to set this properly
                  sizePerEvent=1700, #I have to get some stats to set this properly
                  maxMemoryperCore=2000,
+                 dataset_lifetime=14*24*3600,#lifetime for container rules. Default 14 days
                  versionOverride=expressVersionOverride)
 
 addExpressConfig(tier0Config, "HLTMonitor",
@@ -303,6 +306,7 @@ addExpressConfig(tier0Config, "HLTMonitor",
                  timePerEvent=4, #I have to get some stats to set this properly
                  sizePerEvent=1700, #I have to get some stats to set this properly
                  maxMemoryperCore=2000,
+                 dataset_lifetime=14*24*3600,#lifetime for container rules. Default 14 days
                  versionOverride=expressVersionOverride)
 
 addExpressConfig(tier0Config, "Calibration",
@@ -327,6 +331,7 @@ addExpressConfig(tier0Config, "Calibration",
                  versionOverride=expressVersionOverride,
                  maxMemoryperCore=2000,
                  dataType="data",
+                 dataset_lifetime=14*24*3600,#lifetime for container rules. Default 14 days
                  diskNode="T0_CH_CERN_Disk")
 
 addExpressConfig(tier0Config, "ExpressAlignment",
@@ -351,6 +356,7 @@ addExpressConfig(tier0Config, "ExpressAlignment",
                  sizePerEvent=1700,
                  versionOverride=expressVersionOverride,
                  maxMemoryperCore=2000,
+                 dataset_lifetime=14*24*3600,#lifetime for container rules. Default 14 days
                  diskNode="T0_CH_CERN_Disk")
 
 addExpressConfig(tier0Config, "ALCALUMIPIXELSEXPRESS",
@@ -375,6 +381,7 @@ addExpressConfig(tier0Config, "ALCALUMIPIXELSEXPRESS",
                  sizePerEvent=1700,
                  versionOverride=expressVersionOverride,
                  maxMemoryperCore=2000,
+                 dataset_lifetime=14*24*3600,#lifetime for container rules. Default 14 days
                  diskNode="T0_CH_CERN_Disk")
 
 #####################
@@ -406,6 +413,7 @@ addExpressConfig(tier0Config, "HIExpress",
                  timePerEvent=4,
                  sizePerEvent=1700,
                  maxMemoryperCore=2000,
+                 dataset_lifetime=14*24*3600,#lifetime for container rules. Default 14 days
                  versionOverride=expressVersionOverride)
 
 addExpressConfig(tier0Config, "HIExpressAlignment",
@@ -431,6 +439,7 @@ addExpressConfig(tier0Config, "HIExpressAlignment",
                  sizePerEvent=1700,
                  versionOverride=expressVersionOverride,
                  maxMemoryperCore=2000,
+                 dataset_lifetime=14*24*3600,#lifetime for container rules. Default 14 days
                  diskNode="T0_CH_CERN_Disk")
 
 ###################################

--- a/src/python/T0/RunConfig/RunConfigAPI.py
+++ b/src/python/T0/RunConfig/RunConfigAPI.py
@@ -354,7 +354,8 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
                                             'autoApproveSites' : autoApproveSites,
                                             'priority' : "high",
                                             'primaryDataset' : specialDataset,
-                                            'deleteFromSource' : True } )
+                                            'deleteFromSource' : True,
+                                            'datasetLifetime' : streamConfig.Express.datasetLifetime } )
 
             alcaSkim = None
             if len(streamConfig.Express.AlcaSkims) > 0:
@@ -487,7 +488,8 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
                                             'priority' : "high",
                                             'primaryDataset' : dataset,
                                             'deleteFromSource' : True,
-                                            'dataTier' : "RAW" } )
+                                            'dataTier' : "RAW",
+                                            'datasetLifetime' : datasetConfig.datasetLifetime } )
 
                 #
                 # set subscriptions for error dataset
@@ -500,7 +502,8 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
                                             'priority' : "high",
                                             'primaryDataset' : "%s-Error" % dataset,
                                             'deleteFromSource' : True,
-                                            'dataTier' : "RAW" } )
+                                            'dataTier' : "RAW",
+                                            'datasetLifetime' : datasetConfig.datasetLifetime } )
 
 
             elif streamConfig.ProcessingStyle == "Express":
@@ -543,7 +546,8 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
                                                 'autoApproveSites' : autoApproveSites,
                                                 'priority' : "high",
                                                 'primaryDataset' : dataset,
-                                                'deleteFromSource' : True } )
+                                                'deleteFromSource' : True,
+                                                'datasetLifetime' : streamConfig.Express.datasetLifetime } )
 
         #
         # finally create WMSpec
@@ -936,7 +940,8 @@ def releasePromptReco(tier0Config, specDirectory, dqmUploadProxy):
                                                 'useSkim' : True,
                                                 'isSkim' : False,
                                                 'deleteFromSource' : True,
-                                                'dataTier' : dataTier } )
+                                                'dataTier' : dataTier,
+                                                'datasetLifetime' : datasetConfig.datasetLifetime } )
 
                     for dataTier in skimDataTiers:
                         subscriptions.append( { 'custodialSites' : [phedexConfig['tape_node']],
@@ -951,7 +956,8 @@ def releasePromptReco(tier0Config, specDirectory, dqmUploadProxy):
                                                 'useSkim' : True,
                                                 'isSkim' : True,
                                                 'deleteFromSource' : True,
-                                                'dataTier' : dataTier } )
+                                                'dataTier' : dataTier,
+                                                'datasetLifetime' : datasetConfig.datasetLifetime } )
 
                     for dataTier in tapeDataTiers - diskDataTiers:
                         subscriptions.append( { 'custodialSites' : [phedexConfig['tape_node']],
@@ -963,7 +969,8 @@ def releasePromptReco(tier0Config, specDirectory, dqmUploadProxy):
                                                 'useSkim' : True,
                                                 'isSkim' : False,
                                                 'deleteFromSource' : True,
-                                                'dataTier' : dataTier } )
+                                                'dataTier' : dataTier,
+                                                'datasetLifetime' : datasetConfig.datasetLifetime } )
 
                     for dataTier in alcaDataTiers:
                         subscriptions.append( { 'custodialSites' : [phedexConfig['tape_node']],
@@ -975,7 +982,8 @@ def releasePromptReco(tier0Config, specDirectory, dqmUploadProxy):
                                                 'useSkim' : True,
                                                 'isSkim' : True,
                                                 'deleteFromSource' : True,
-                                                'dataTier' : dataTier } )
+                                                'dataTier' : dataTier,
+                                                'datasetLifetime' : datasetConfig.datasetLifetime } )
 
                     for dataTier in diskDataTiers - tapeDataTiers:
 
@@ -993,7 +1001,8 @@ def releasePromptReco(tier0Config, specDirectory, dqmUploadProxy):
                                                 'useSkim' : True,
                                                 'isSkim' : False,
                                                 'deleteFromSource' : True,
-                                                'dataTier' : dataTier } )
+                                                'dataTier' : dataTier,
+                                                'datasetLifetime' : datasetConfig.datasetLifetime } )
 
                 elif phedexConfig['archival_node'] != None:
 
@@ -1006,7 +1015,8 @@ def releasePromptReco(tier0Config, specDirectory, dqmUploadProxy):
                                                 'priority' : "high",
                                                 'primaryDataset' : dataset,
                                                 'deleteFromSource' : True,
-                                                'dataTier' : dataTier } )
+                                                'dataTier' : dataTier,
+                                                'datasetLifetime' : datasetConfig.datasetLifetime } )
 
             writeTiers = []
             if datasetConfig.WriteRECO:

--- a/src/python/T0/RunConfig/Tier0Config.py
+++ b/src/python/T0/RunConfig/Tier0Config.py
@@ -164,6 +164,9 @@ Tier0Configuration - Global configuration object
 |             |     |--> PhEDExGroup - The PhEDEx group for the subscriptions.
 |             |     |
 |             |     |--> BlockCloseDelay - delay to close block in WMAgent
+|             |     |
+|             |     |--> DatasetLifetime - dataset_lifetime for subscription to
+|             |     |                       disk in seconds. 0 means lifetime of None
 |             |
 |             |--> Register - Configuration section for register streams
 |             |     |
@@ -230,6 +233,9 @@ Tier0Configuration - Global configuration object
             |--> BlockCloseDelay - Delay to close block in WMAgent
             |
             |--> SiteWhitelist - Site whitelist for PromptReco
+            |
+            |--> DatasetLifetime - dataset_lifetime for subscription to disk in
+                                    seconds. 0 means lifetime of None
 """
 
 import logging
@@ -560,6 +566,11 @@ def addDataset(config, datasetName, **settings):
         datasetConfig.MaxMemoryperCore = settings.get("maxMemoryperCore", datasetConfig.MaxMemoryperCore)
     else:
         datasetConfig.MaxMemoryperCore = settings.get("maxMemoryperCore", 2000)
+
+    if hasattr(datasetConfig, "datasetLifetime"):
+        datasetConfig.datasetLifetime = settings.get("dataset_lifetime", datasetConfig.datasetLifetime)
+    else:
+        datasetConfig.datasetLifetime = settings.get("dataset_lifetime", 0)
 
     return
 
@@ -941,6 +952,11 @@ def addExpressConfig(config, streamName, **options):
         streamConfig.Express.MaxMemoryperCore = options.get("maxMemoryperCore", streamConfig.Express.MaxMemoryperCore)
     else:
         streamConfig.Express.MaxMemoryperCore = options.get("maxMemoryperCore", 2000)
+
+    if hasattr(streamConfig, "datasetLifetime"):
+        streamConfig.Express.datasetLifetime = options.get("dataset_lifetime", streamConfig.Express.datasetLifetime)
+    else:
+        streamConfig.Express.datasetLifetime = options.get("dataset_lifetime", 0)
 
     return
 


### PR DESCRIPTION
Add lifetime for dataset (RucioContainerRules) that will be subscribed to only disk sites via our ConfigFile

