### PR TITLE
Add parameters to block-level rules

### DIFF
--- a/bin/00_deploy_prod.sh
+++ b/bin/00_deploy_prod.sh
@@ -134,7 +134,7 @@ echo "config.RetryManager.PauseAlgo.default.coolOffTime = {'create': 10, 'job': 
 
 # Twiking Rucio configuration
 sed -i "s+config.RucioInjector.containerDiskRuleParams.*+config.RucioInjector.containerDiskRuleParams = {}+" ./config/tier0/config.py
-
+echo "config.RucioInjector.blockRuleParams = {}" >> ./config/tier0/config.py
 #
 # Set output datasets status to VALID in DBS
 #

--- a/bin/00_deploy_replay.sh
+++ b/bin/00_deploy_replay.sh
@@ -130,7 +130,7 @@ echo "config.RetryManager.PauseAlgo.default.coolOffTime = {'create': 10, 'job': 
 # Twiking Rucio configuration
 sed -i "s+config.RucioInjector.listTiersToInject.*+config.RucioInjector.listTiersToInject = ['AOD', 'MINIAOD', 'NANOAOD', 'NANOAODSIM', 'RAW', 'FEVT', 'USER', 'ALCARECO', 'ALCAPROMPT', 'DQMIO','RAW-RECO']+" ./config/tier0/config.py
 sed -i "s+config.RucioInjector.containerDiskRuleParams.*+config.RucioInjector.containerDiskRuleParams = {'lifetime': 7 * 24 * 60 * 60}+" ./config/tier0/config.py
-
+echo "config.RucioInjector.blockRuleParams = {'lifetime': 7 * 24 * 60 * 60}" >> ./config/tier0/config.py
 
 #
 # Set output datasets status to VALID in DBS


### PR DESCRIPTION
Add useful parameters for block-level rules via WMAgentConfig.
This changes will be useful to give a lifetime to all the block-level rules that each replay generates. Only small changes on our deployments scripts.
Linked with https://github.com/dmwm/WMCore/pull/10989