### PR TITLE
Replay for CRAFT 2022 with CMSSW_12_2_1_patch1

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -32,7 +32,11 @@ tier0Config = createTier0Config()
 setConfigVersion(tier0Config, "replace with real version")
 
 # Set run number to replay
-setInjectRuns(tier0Config, [345755,346062,346512,347028])
+# 345755 - 2021 CRAFT
+# 346062 - 2021 splashes
+# 346512 - 2021 pp
+# 347952 - 2022 MWGR
+setInjectRuns(tier0Config, [345755,346062,346512,347952])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"
@@ -99,7 +103,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_12_2_1"
+    'default': "CMSSW_12_2_1_patch1"
 }
 
 # Configure ScramArch
@@ -162,7 +166,8 @@ repackVersionOverride = {
     "CMSSW_12_0_2_patch2" : defaultCMSSWVersion['default'],
     "CMSSW_12_0_3" : defaultCMSSWVersion['default'],
     "CMSSW_12_0_3_patch1" : defaultCMSSWVersion['default'],
-    "CMSSW_12_2_1" : defaultCMSSWVersion['default']
+    "CMSSW_12_2_1" : defaultCMSSWVersion['default'],
+    "CMSSW_12_2_1_patch1" : defaultCMSSWVersion['default']
     }
 
 expressVersionOverride = {
@@ -186,7 +191,8 @@ expressVersionOverride = {
     "CMSSW_12_0_2_patch2" : defaultCMSSWVersion['default'],
     "CMSSW_12_0_3" : defaultCMSSWVersion['default'],
     "CMSSW_12_0_3_patch1" : defaultCMSSWVersion['default'],
-    "CMSSW_12_2_1" : defaultCMSSWVersion['default']
+    "CMSSW_12_2_1" : defaultCMSSWVersion['default'],
+    "CMSSW_12_2_1_patch1" : defaultCMSSWVersion['default']
     }
 
 #set default repack settings for bulk streams


### PR DESCRIPTION
# Replay Request

**Requestor**  
Francesco as ORM

**Describe the configuration**  
* Release: CMSSW_12_2_1_patch1
* Runs: 345755,346062,346512,347952
* GTs:
   * expressGlobalTag: 122X_dataRun3_Express_v3
   * promptrecoGlobalTag: 122X_dataRun3_Prompt_v3
   * alcap0GlobalTag: 122X_dataRun3_Prompt_v3
* Additional changes:

**Purpose of the test**  
Test new CMSSW in preparation of CRAFT 2022.

**T0 Operations HyperNews thread**
Will add a link later.

**Note**
This is supposed to be run only **after** [CMSSW_12_2_1_patch1](https://github.com/cms-sw/cmssw/issues/37073) is built successfully. 
EDIT: Now available, see: https://github.com/dmwm/T0/pull/4648#issuecomment-1052195485