### PR TITLE
Test CMSSW_12_2_1_patch2

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -99,7 +99,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_12_2_1_patch1"
+    'default': "CMSSW_12_2_1_patch2"
 }
 
 # Configure ScramArch
@@ -162,7 +162,8 @@ repackVersionOverride = {
     "CMSSW_12_0_2_patch2" : defaultCMSSWVersion['default'],
     "CMSSW_12_0_3" : defaultCMSSWVersion['default'],
     "CMSSW_12_0_3_patch1" : defaultCMSSWVersion['default'],
-    "CMSSW_12_2_1" : defaultCMSSWVersion['default']
+    "CMSSW_12_2_1" : defaultCMSSWVersion['default'],
+    "CMSSW_12_2_1_patch1" : defaultCMSSWVersion['default']
     }
 
 expressVersionOverride = {
@@ -186,7 +187,8 @@ expressVersionOverride = {
     "CMSSW_12_0_2_patch2" : defaultCMSSWVersion['default'],
     "CMSSW_12_0_3" : defaultCMSSWVersion['default'],
     "CMSSW_12_0_3_patch1" : defaultCMSSWVersion['default'],
-    "CMSSW_12_2_1" : defaultCMSSWVersion['default']
+    "CMSSW_12_2_1" : defaultCMSSWVersion['default'],
+    "CMSSW_12_2_1_patch1" : defaultCMSSWVersion['default']
     }
 
 #set default repack settings for bulk streams


### PR DESCRIPTION
# Replay Request

**Requestor**  
JhonatanAmado

**Describe the configuration**  
* Release: CMSSW_12_2_1_patch2
* Run: [345755,346062,346512,347028]
* GTs:
   * expressGlobalTag: 122X_dataRun3_Express_v3
   * promptrecoGlobalTag: 122X_dataRun3_Prompt_v3
   * alcap0GlobalTag: 122X_dataRun3_Prompt_v3
* Additional changes:

**Purpose of the test**  
Test CMSSW_12_2_1_patch2 with the last CRAFT configuration. T0 agent 3.0.3

**T0 Operations HyperNews thread**  
If necessary, provide a link to the HN thread announcing the test to the relevant groups. 
