### PR TITLE
Replay testing CMSSW_12_2_2

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -99,7 +99,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_12_2_1_patch1"
+    'default': "CMSSW_12_2_2"
 }
 
 # Configure ScramArch
@@ -117,7 +117,7 @@ alcaLumiPixelsScenario = "AlCaLumiPixels"
 hiTestppScenario = "ppEra_Run3"
 
 # Procesing version number replays
-dt = 212
+dt = 331
 defaultProcVersion = dt
 expressProcVersion = dt
 alcarawProcVersion = dt
@@ -162,7 +162,8 @@ repackVersionOverride = {
     "CMSSW_12_0_2_patch2" : defaultCMSSWVersion['default'],
     "CMSSW_12_0_3" : defaultCMSSWVersion['default'],
     "CMSSW_12_0_3_patch1" : defaultCMSSWVersion['default'],
-    "CMSSW_12_2_1" : defaultCMSSWVersion['default']
+    "CMSSW_12_2_1" : defaultCMSSWVersion['default'],
+    "CMSSW_12_2_1_patch1" : defaultCMSSWVersion['default']
     }
 
 expressVersionOverride = {
@@ -186,7 +187,8 @@ expressVersionOverride = {
     "CMSSW_12_0_2_patch2" : defaultCMSSWVersion['default'],
     "CMSSW_12_0_3" : defaultCMSSWVersion['default'],
     "CMSSW_12_0_3_patch1" : defaultCMSSWVersion['default'],
-    "CMSSW_12_2_1" : defaultCMSSWVersion['default']
+    "CMSSW_12_2_1" : defaultCMSSWVersion['default'],
+    "CMSSW_12_2_1_patch1" : defaultCMSSWVersion['default']
     }
 
 #set default repack settings for bulk streams


### PR DESCRIPTION
# Replay Request

**Requestor**  
ORM

**Describe the configuration**  
* Release: CMSSW_12_2_2
* Run: 345755, 346062, 346512, 347028
* GTs:
   * expressGlobalTag: 122X_dataRun3_Express_v3
   * promptrecoGlobalTag: 122X_dataRun3_Prompt_v3
   * alcap0GlobalTag: 122X_dataRun3_Prompt_v3
* Additional changes:

**Purpose of the test**  
Validate configuration for production data taking

**T0 Operations cmsTalk thread**  
https://cms-talk.web.cern.ch/t/organizing-replay-for-cmssw-12-2-2/8842
