### PR TITLE
Update for CMSSW_12_2_3_patch1, requested by HLT

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -32,7 +32,7 @@ tier0Config = createTier0Config()
 setConfigVersion(tier0Config, "replace with real version")
 
 # Set run number to replay
-setInjectRuns(tier0Config, [345755,346062,346512,347028])
+setInjectRuns(tier0Config, [349840])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"
@@ -99,7 +99,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_12_2_3"
+    'default': "CMSSW_12_2_3_patch1"
 }
 
 # Configure ScramArch
@@ -164,7 +164,9 @@ repackVersionOverride = {
     "CMSSW_12_0_3_patch1" : defaultCMSSWVersion['default'],
     "CMSSW_12_2_1" : defaultCMSSWVersion['default'],
     "CMSSW_12_2_1_patch1" : defaultCMSSWVersion['default'],
-    "CMSSW_12_2_2" : defaultCMSSWVersion['default']
+    "CMSSW_12_2_2" : defaultCMSSWVersion['default'],
+    "CMSSW_12_2_3" : defaultCMSSWVersion['default'], 
+    "CMSSW_12_2_3_patch1" : defaultCMSSWVersion['default']
     }
 
 expressVersionOverride = {
@@ -190,7 +192,9 @@ expressVersionOverride = {
     "CMSSW_12_0_3_patch1" : defaultCMSSWVersion['default'],
     "CMSSW_12_2_1" : defaultCMSSWVersion['default'],
     "CMSSW_12_2_1_patch1" : defaultCMSSWVersion['default'],
-    "CMSSW_12_2_2" : defaultCMSSWVersion['default']
+    "CMSSW_12_2_2" : defaultCMSSWVersion['default'],
+    "CMSSW_12_2_3" : defaultCMSSWVersion['default'],
+    "CMSSW_12_2_3_patch1" : defaultCMSSWVersion['default']
     }
 
 #set default repack settings for bulk streams


### PR DESCRIPTION
# Replay Request

**Requestor**  
Salvatore Rappoccio (ORM) for HLT. 

**Describe the configuration**  
* Release: CMSSW_12_2_3_patch1
* Run: 349840
* GTs:
   * expressGlobalTag: 122X_dataRun3_Express_v3
   * promptrecoGlobalTag: 122X_dataRun3_Prompt_v3
   * alcap0GlobalTag: 122X_dataRun3_Prompt_v3
* Additional changes:

**Purpose of the test**  
This was requested by HLT to fix the ECAL GPU unpacker. 

**T0 Operations cmsTalk thread**  
If necessary, provide a link to the cmsTalk thread announcing the test to the relevant groups. 
[Tier0 Operations cmsTalk Forum](https://cms-talk.web.cern.ch/c/offcomp/compops/tier0/210?)
