### PR TITLE
Replay testing CMSSW_12_3_0

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -32,7 +32,7 @@ tier0Config = createTier0Config()
 setConfigVersion(tier0Config, "replace with real version")
 
 # Set run number to replay
-setInjectRuns(tier0Config, [349840])
+setInjectRuns(tier0Config, [346512,347028,349840])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"
@@ -99,11 +99,11 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_12_2_3_patch1"
+    'default': "CMSSW_12_3_0"
 }
 
 # Configure ScramArch
-setDefaultScramArch(tier0Config, "slc7_amd64_gcc900")
+setDefaultScramArch(tier0Config, "slc7_amd64_gcc10")
 
 # Configure scenarios
 ppScenario = "ppEra_Run3"
@@ -117,15 +117,15 @@ alcaLumiPixelsScenario = "AlCaLumiPixels"
 hiTestppScenario = "ppEra_Run3"
 
 # Procesing version number replays
-dt = 212
+dt = 410
 defaultProcVersion = dt
 expressProcVersion = dt
 alcarawProcVersion = dt
 
 # Defaults for GlobalTag
-expressGlobalTag = "122X_dataRun3_Express_v3"
-promptrecoGlobalTag = "122X_dataRun3_Prompt_v3"
-alcap0GlobalTag = "122X_dataRun3_Prompt_v3"
+expressGlobalTag = "123X_dataRun3_Express_Candidate_2022_04_08_23_32_25"
+promptrecoGlobalTag = "	123X_dataRun3_Prompt_Candidate_2022_04_08_23_36_44"
+alcap0GlobalTag = "	123X_dataRun3_Prompt_Candidate_2022_04_08_23_36_44"
 
 # Mandatory for CondDBv2
 globalTagConnect = "frontier://PromptProd/CMS_CONDITIONS"
@@ -165,7 +165,8 @@ repackVersionOverride = {
     "CMSSW_12_2_1" : defaultCMSSWVersion['default'],
     "CMSSW_12_2_1_patch1" : defaultCMSSWVersion['default'],
     "CMSSW_12_2_2" : defaultCMSSWVersion['default'],
-    "CMSSW_12_2_3" : defaultCMSSWVersion['default']
+    "CMSSW_12_2_3" : defaultCMSSWVersion['default'],
+    "CMSSW_12_2_3_patch1" : defaultCMSSWVersion['default']
     }
 
 expressVersionOverride = {
@@ -192,7 +193,8 @@ expressVersionOverride = {
     "CMSSW_12_2_1" : defaultCMSSWVersion['default'],
     "CMSSW_12_2_1_patch1" : defaultCMSSWVersion['default'],
     "CMSSW_12_2_2" : defaultCMSSWVersion['default'],
-    "CMSSW_12_2_3" : defaultCMSSWVersion['default']
+    "CMSSW_12_2_3" : defaultCMSSWVersion['default'],
+    "CMSSW_12_2_3_patch1" : defaultCMSSWVersion['default']
     }
 
 #set default repack settings for bulk streams


### PR DESCRIPTION
# Replay Request

**Requestor**  
ORM

**Describe the configuration**  
* Release: CMSSW_12_3_0
* Run: 346512,347028,349840
* GTs:
   * expressGlobalTag: 123X_dataRun3_Express_Candidate_2022_04_08_23_32_25
   * promptrecoGlobalTag: 123X_dataRun3_Prompt_Candidate_2022_04_08_23_36_44
   * alcap0GlobalTag: 123X_dataRun3_Prompt_Candidate_2022_04_08_23_36_44
* Additional changes:

**Purpose of the test**  
Test CMSSW version to be used for first beams

**T0 Operations cmsTalk thread**  
[Tier0 Operations cmsTalk Forum](https://cms-talk.web.cern.ch/t/replay-testing-cmssw-12-3-0/9158)
