### PR TITLE
Production configuration for splashes April 2022 (CMSSW_12_3_0)

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -94,11 +94,11 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_12_2_3_patch1"
+    'default': "CMSSW_12_3_0"
 }
 
 # Configure ScramArch
-setDefaultScramArch(tier0Config, "slc7_amd64_gcc900")
+setDefaultScramArch(tier0Config, "slc7_amd64_gcc10")
 
 # Configure scenarios
 ppScenario = "ppEra_Run3"
@@ -127,9 +127,9 @@ expressProcVersion = {
 }
 
 # Defaults for GlobalTag
-expressGlobalTag = "122X_dataRun3_Express_v3"
-promptrecoGlobalTag = "122X_dataRun3_Prompt_v3"
-alcap0GlobalTag = "122X_dataRun3_Prompt_v3"
+expressGlobalTag = "123X_dataRun3_Express_v5"
+promptrecoGlobalTag = "123X_dataRun3_Prompt_v6"
+alcap0GlobalTag = "123X_dataRun3_Prompt_v6"
 
 # Mandatory for CondDBv2
 globalTagConnect = "frontier://PromptProd/CMS_CONDITIONS"
@@ -171,7 +171,8 @@ repackVersionOverride = {
     "CMSSW_12_2_1" : defaultCMSSWVersion['default'],
     "CMSSW_12_2_1_patch1" : defaultCMSSWVersion['default'],
     "CMSSW_12_2_2" : defaultCMSSWVersion['default'],
-    "CMSSW_12_2_3" : defaultCMSSWVersion['default']
+    "CMSSW_12_2_3" : defaultCMSSWVersion['default'],
+    "CMSSW_12_2_3_patch1" : defaultCMSSWVersion['default']
     }
 
 expressVersionOverride = {
@@ -200,7 +201,8 @@ expressVersionOverride = {
     "CMSSW_12_2_1" : defaultCMSSWVersion['default'],
     "CMSSW_12_2_1_patch1" : defaultCMSSWVersion['default'],
     "CMSSW_12_2_2" : defaultCMSSWVersion['default'],
-    "CMSSW_12_2_3" : defaultCMSSWVersion['default']
+    "CMSSW_12_2_3" : defaultCMSSWVersion['default'],
+    "CMSSW_12_2_3_patch1" : defaultCMSSWVersion['default']
     }
 
 #set default repack settings for bulk streams

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -123,9 +123,9 @@ expressProcVersion = dt
 alcarawProcVersion = dt
 
 # Defaults for GlobalTag
-expressGlobalTag = "123X_dataRun3_Express_Candidate_2022_04_08_23_32_25"
-promptrecoGlobalTag = "	123X_dataRun3_Prompt_Candidate_2022_04_08_23_36_44"
-alcap0GlobalTag = "	123X_dataRun3_Prompt_Candidate_2022_04_08_23_36_44"
+expressGlobalTag = "123X_dataRun3_Express_v5"
+promptrecoGlobalTag = "123X_dataRun3_Prompt_v6"
+alcap0GlobalTag = "123X_dataRun3_Prompt_v6"
 
 # Mandatory for CondDBv2
 globalTagConnect = "frontier://PromptProd/CMS_CONDITIONS"

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -32,7 +32,7 @@ tier0Config = createTier0Config()
 setConfigVersion(tier0Config, "replace with real version")
 
 # Set run number to replay
-setInjectRuns(tier0Config, [349840])
+setInjectRuns(tier0Config, [346512,347028,349840])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"
@@ -99,11 +99,11 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_12_2_3_patch1"
+    'default': "CMSSW_12_3_0"
 }
 
 # Configure ScramArch
-setDefaultScramArch(tier0Config, "slc7_amd64_gcc900")
+setDefaultScramArch(tier0Config, "slc7_amd64_gcc10")
 
 # Configure scenarios
 ppScenario = "ppEra_Run3"
@@ -117,15 +117,15 @@ alcaLumiPixelsScenario = "AlCaLumiPixels"
 hiTestppScenario = "ppEra_Run3"
 
 # Procesing version number replays
-dt = 212
+dt = 410
 defaultProcVersion = dt
 expressProcVersion = dt
 alcarawProcVersion = dt
 
 # Defaults for GlobalTag
-expressGlobalTag = "122X_dataRun3_Express_v3"
-promptrecoGlobalTag = "122X_dataRun3_Prompt_v3"
-alcap0GlobalTag = "122X_dataRun3_Prompt_v3"
+expressGlobalTag = "123X_dataRun3_Express_Candidate_2022_04_08_23_32_25"
+promptrecoGlobalTag = "	123X_dataRun3_Prompt_Candidate_2022_04_08_23_36_44"
+alcap0GlobalTag = "	123X_dataRun3_Prompt_Candidate_2022_04_08_23_36_44"
 
 # Mandatory for CondDBv2
 globalTagConnect = "frontier://PromptProd/CMS_CONDITIONS"
@@ -165,7 +165,8 @@ repackVersionOverride = {
     "CMSSW_12_2_1" : defaultCMSSWVersion['default'],
     "CMSSW_12_2_1_patch1" : defaultCMSSWVersion['default'],
     "CMSSW_12_2_2" : defaultCMSSWVersion['default'],
-    "CMSSW_12_2_3" : defaultCMSSWVersion['default']
+    "CMSSW_12_2_3" : defaultCMSSWVersion['default'],
+    "CMSSW_12_2_3_patch1" : defaultCMSSWVersion['default']
     }
 
 expressVersionOverride = {
@@ -192,7 +193,8 @@ expressVersionOverride = {
     "CMSSW_12_2_1" : defaultCMSSWVersion['default'],
     "CMSSW_12_2_1_patch1" : defaultCMSSWVersion['default'],
     "CMSSW_12_2_2" : defaultCMSSWVersion['default'],
-    "CMSSW_12_2_3" : defaultCMSSWVersion['default']
+    "CMSSW_12_2_3" : defaultCMSSWVersion['default'],
+    "CMSSW_12_2_3_patch1" : defaultCMSSWVersion['default']
     }
 
 #set default repack settings for bulk streams


### PR DESCRIPTION
Update T0 prod configuration to CMSSW_12_3_0

The configuration was tested in #4662 