### PR TITLE
Replay to test SiStripHitEfficiency workflow in PCL with 2018 data

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -32,7 +32,8 @@ tier0Config = createTier0Config()
 setConfigVersion(tier0Config, "replace with real version")
 
 # Set run number to replay
-setInjectRuns(tier0Config, [347028,349840])
+# Run 324841 - pp collisions from 2018D
+setInjectRuns(tier0Config, [324841])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"
@@ -99,22 +100,23 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_12_3_2"
+    'default': "CMSSW_12_4_0_pre4"
 }
 
 # Configure ScramArch
-setDefaultScramArch(tier0Config, "slc7_amd64_gcc10")
+setDefaultScramArch(tier0Config, "slc7_amd64_gcc630")
+setScramArch(tier0Config, defaultCMSSWVersion['default'], "slc7_amd64_gcc900")
 
 # Configure scenarios
-ppScenario = "ppEra_Run3"
-ppScenarioB0T = "ppEra_Run3"
-cosmicsScenario = "cosmicsEra_Run3"
-hcalnzsScenario = "hcalnzsEra_Run3"
-hiScenario = "ppEra_Run3"
-alcaTrackingOnlyScenario = "trackingOnlyEra_Run3"
+ppScenario = "ppEra_Run2_2018"
+ppScenarioB0T = "ppEra_Run2_2018"
+cosmicsScenario = "cosmicsEra_Run2_2018"
+hcalnzsScenario = "hcalnzsEra_Run2_2018"
+hiScenario = "ppEra_Run2_2018"
+alcaTrackingOnlyScenario = "trackingOnlyEra_Run2_2018"
 alcaTestEnableScenario = "AlCaTestEnable"
 alcaLumiPixelsScenario = "AlCaLumiPixels"
-hiTestppScenario = "ppEra_Run3"
+hiTestppScenario = "ppEra_Run2_2018"
 
 # Procesing version number replays
 dt = 429
@@ -123,9 +125,9 @@ expressProcVersion = dt
 alcarawProcVersion = dt
 
 # Defaults for GlobalTag
-expressGlobalTag = "123X_dataRun3_Express_v5"
-promptrecoGlobalTag = "123X_dataRun3_Prompt_v6"
-alcap0GlobalTag = "123X_dataRun3_Prompt_v6"
+expressGlobalTag = "122X_dataRun3_Express_TIER0_REPLAY_Run2_v1"
+promptrecoGlobalTag = "122X_dataRun3_Prompt_TIER0_REPLAY_Run2_v1"
+alcap0GlobalTag = "122X_dataRun3_Prompt_TIER0_REPLAY_Run2_v1"
 
 # Mandatory for CondDBv2
 globalTagConnect = "frontier://PromptProd/CMS_CONDITIONS"
@@ -167,7 +169,8 @@ repackVersionOverride = {
     "CMSSW_12_2_2" : defaultCMSSWVersion['default'],
     "CMSSW_12_2_3" : defaultCMSSWVersion['default'],
     "CMSSW_12_2_3_patch1" : defaultCMSSWVersion['default'],
-    "CMSSW_12_3_0" : defaultCMSSWVersion['default']
+    "CMSSW_12_3_0" : defaultCMSSWVersion['default'],
+    "CMSSW_12_3_2" : defaultCMSSWVersion['default']
     }
 
 expressVersionOverride = {
@@ -196,7 +199,8 @@ expressVersionOverride = {
     "CMSSW_12_2_2" : defaultCMSSWVersion['default'],
     "CMSSW_12_2_3" : defaultCMSSWVersion['default'],
     "CMSSW_12_2_3_patch1" : defaultCMSSWVersion['default'],
-    "CMSSW_12_3_0" : defaultCMSSWVersion['default']
+    "CMSSW_12_3_0" : defaultCMSSWVersion['default'],
+    "CMSSW_12_3_2" : defaultCMSSWVersion['default']
     }
 
 #set default repack settings for bulk streams
@@ -244,10 +248,8 @@ addExpressConfig(tier0Config, "Express",
                  scenario=ppScenario,
                  data_tiers=["FEVT"],
                  write_dqm=True,
-                 alca_producers=["SiStripPCLHistos", "SiStripCalZeroBias", "SiStripCalMinBias", "SiStripCalMinBiasAAG",
-                                 "TkAlMinBias", "LumiPixelsMinBias", "SiPixelCalZeroBias",
-                                 "PromptCalibProd", "PromptCalibProdSiStrip", "PromptCalibProdSiPixelAli",
-                                 "PromptCalibProdSiStripGains", "PromptCalibProdSiStripGainsAAG", "PromptCalibProdSiPixel"
+                 alca_producers=["SiStripCalMinBias",
+                                 "PromptCalibProdSiStripHitEfficiency"
                                 ],
                  reco_version=defaultCMSSWVersion,
                  multicore=numberOfCores,
@@ -452,925 +454,6 @@ addExpressConfig(tier0Config, "HIExpressAlignment",
                  dataset_lifetime=14*24*3600,#lifetime for container rules. Default 14 days
                  diskNode="T0_CH_CERN_Disk")
 
-###################################
-### Standard Physics PDs (2017) ###
-###################################
-
-DATASETS = ["BTagCSV"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               dqm_sequences=["@common"],
-               physics_skims=["LogError", "LogErrorMonitor"],
-               scenario=ppScenario)
-
-DATASETS = ["BTagMu"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               dqm_sequences=["@common"],
-               physics_skims=["LogError", "LogErrorMonitor"],
-               scenario=ppScenario)
-
-DATASETS = ["Charmonium"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_reco=True,
-               write_dqm=True,
-               dqm_sequences=["@common"],
-               alca_producers=["TkAlJpsiMuMu"],
-               physics_skims=["BPHSkim", "MuonPOGJPsiSkim", "LogError", "LogErrorMonitor"],
-               scenario=ppScenario)
-
-DATASETS = ["Cosmics"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_reco=False,
-               write_aod=True,
-               write_miniaod=False,
-               write_dqm=True,
-               alca_producers=["SiStripCalCosmics", "SiPixelCalCosmics", "TkAlCosmics0T", "MuAlGlobalCosmics"],
-               physics_skims=["CosmicSP", "CosmicTP", "LogError", "LogErrorMonitor"],
-               timePerEvent=0.5,
-               sizePerEvent=155,
-               scenario=cosmicsScenario)
-
-DATASETS = ["DisplacedJet"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               dqm_sequences=["@common"],
-               physics_skims=["EXODisplacedJet", "LogError", "LogErrorMonitor"],
-               scenario=ppScenario)
-
-DATASETS = ["DoubleEG"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_reco=True,
-               write_dqm=True,
-               alca_producers=["EcalUncalZElectron", "EcalUncalWElectron", "HcalCalIterativePhiSym", "HcalCalIsoTrkFilter"],
-               dqm_sequences=["@common", "@ecal", "@egamma"],
-               physics_skims=["ZElectron", "LogError", "LogErrorMonitor"],
-               scenario=ppScenario)
-
-DATASETS = ["DoubleMuon"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_reco=True,
-               write_dqm=True,
-               alca_producers=["TkAlZMuMu", "MuAlCalIsolatedMu", "MuAlOverlaps", "MuAlZMuMu"],
-               dqm_sequences=["@common", "@muon", "@lumi", "@L1TMuon"],
-               physics_skims=["LogError", "LogErrorMonitor"],
-               scenario=ppScenario)
-
-DATASETS = ["DoubleMuonLowPU"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_reco=False,
-               raw_to_disk=True,
-               write_dqm=True,
-               alca_producers=["TkAlZMuMu", "MuAlCalIsolatedMu", "MuAlOverlaps", "MuAlZMuMu"],
-               dqm_sequences=["@common", "@muon", "@lumi", "@L1TMuon"],
-               physics_skims=["LogError", "LogErrorMonitor"],
-               timePerEvent=1,
-               scenario=ppScenario)
-
-DATASETS = ["DoubleMuonLowMass"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               dqm_sequences=["@common"],
-               physics_skims=["LogError", "LogErrorMonitor", "BPHSkim"],
-               scenario=ppScenario)
-
-DATASETS = ["EmptyBX"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               dqm_sequences=["@common"],
-               scenario=ppScenario)
-
-DATASETS = ["FSQJet1", "FSQJet2"]
-
-DATASETS = ["FSQJets", "FSQJets1", "FSQJets2", "FSQJets3"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               dqm_sequences=["@common", "@jetmet"],
-               scenario=ppScenario)
-
-DATASETS = ["HINCaloJets", "HINPFJets"]
-
-DATASETS += ["HINCaloJet40", "HINPFJet100", "HINCaloJet100", "HINCaloJetsOther", "HINPFJetsOther"]
-
-DATASETS += ["HINMuon", "HINPhoton"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               dqm_sequences=["@common"],
-               scenario=ppScenario)
-
-DATASETS = ["HTMHT"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               dqm_sequences=["@common"],
-               physics_skims=["LogError", "LogErrorMonitor"],
-               timePerEvent=9.4,
-               sizePerEvent=2000,
-               scenario=ppScenario)
-
-DATASETS = ["HighMultiplicity"]
-
-DATASETS += ["HighMultiplicityEOF0", "HighMultiplicityEOF1", "HighMultiplicityEOF2",
-             "HighMultiplicityEOF3", "HighMultiplicityEOF4", "HighMultiplicityEOF5"]
-
-DATASETS += ["HighMultiplicity85", "HighMultiplicity85EOF"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_reco=True,
-               write_dqm=True,
-               dqm_sequences=["@common"],
-               scenario=ppScenario)
-
-# 05/07/2018 HighMultiplicityEOF needs to have 1sec per event
-DATASETS = ["HighMultiplicityEOF"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_reco=False,
-               write_dqm=True,
-               dqm_sequences=["@common"],
-               timePerEvent=1,
-               scenario=ppScenario)
-
-DATASETS = ["HighPtLowerPhotons", "HighPtPhoton30AndZ"]
-
-DATASETS += ["ppForward", "HighPtLowerJets", "MuPlusX"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               dqm_sequences=["@common"],
-               scenario=ppScenario)
-
-DATASETS = ["JetHT"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               alca_producers=["HcalCalIsoTrkFilter", "HcalCalIsolatedBunchFilter"],
-               dqm_sequences=["@common", "@jetmet", "@L1TMon", "@hcal"],
-               physics_skims=["JetHTJetPlusHOFilter", "LogError", "LogErrorMonitor"],
-               timePerEvent=5.7,
-               sizePerEvent=2250,
-               scenario=ppScenario)
-
-DATASETS = ["MET"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               alca_producers=["HcalCalNoise"],
-               dqm_sequences=["@common", "@jetmet", "@L1TMon", "@hcal"],
-               physics_skims=["EXOMONOPOLE", "HighMET", "LogError", "LogErrorMonitor"],
-               scenario=ppScenario)
-
-DATASETS = ["MuOnia"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               alca_producers=["TkAlUpsilonMuMu"],
-               dqm_sequences=["@common", "@muon"],
-               physics_skims=["LogError", "LogErrorMonitor", "BPHSkim"],
-               scenario=ppScenario)
-
-DATASETS = ["MuonEG"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               dqm_sequences=["@common"],
-               physics_skims=["TopMuEG", "LogError", "LogErrorMonitor"],
-               scenario=ppScenario)
-
-DATASETS = ["NoBPTX"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_reco=True,
-               write_dqm=True,
-               alca_producers=["TkAlCosmicsInCollisions"],
-               dqm_sequences=["@common"],
-               physics_skims=["EXONoBPTXSkim", "LogError", "LogErrorMonitor"],
-               scenario=ppScenario)
-
-DATASETS = ["SingleElectron"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               alca_producers=["EcalUncalWElectron", "EcalUncalZElectron", "HcalCalIterativePhiSym", "EcalESAlign"],
-               dqm_sequences=["@common", "@ecal", "@egamma", "@L1TEgamma"],
-               physics_skims=["LogError", "LogErrorMonitor"],
-               scenario=ppScenario)
-
-DATASETS = ["SingleMuon", "SingleMuonTnP"] # SingleMuonTnP only for 2017 ppRef run
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               alca_producers=["TkAlMuonIsolated", "HcalCalIterativePhiSym", "MuAlCalIsolatedMu",
-                               "MuAlOverlaps", "MuAlZMuMu", "HcalCalHO", "HcalCalHBHEMuonFilter"],
-               dqm_sequences=["@common", "@muon", "@lumi", "@L1TMuon"],
-               physics_skims=["MuonPOGSkim", "MuTau", "ZMu", "LogError", "LogErrorMonitor"],
-               scenario=ppScenario)
-
-DATASETS = ["SinglePhoton"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               dqm_sequences=["@common", "@ecal", "@egamma"],
-               physics_skims=["EXOMONOPOLE", "LogError", "LogErrorMonitor"],
-               scenario=ppScenario)
-
-DATASETS = ["EGamma"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               alca_producers=["EcalUncalZElectron", "EcalUncalWElectron", "HcalCalIterativePhiSym",
-                               "HcalCalIsoTrkFilter", "EcalESAlign"],
-               dqm_sequences=["@common", "@ecal", "@egamma", "@L1TEgamma"],
-               physics_skims=["EXOMONOPOLE", "ZElectron", "LogError", "LogErrorMonitor"],
-               scenario=ppScenario)
-
-DATASETS = ["Tau"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               dqm_sequences=["@common"],
-               physics_skims=["LogError", "LogErrorMonitor"],
-               scenario=ppScenario)
-
-#############################################
-### Standard Commisioning PDs (2017)      ###
-#############################################
-
-DATASETS = ["Commissioning"]
-
-DATASETS += ["Commissioning1", "Commissioning2", "Commissioning3", "Commissioning4",
-             "CommissioningMuons", "CommissioningEGamma", "CommissioningTaus", "CommissioningSingleJet", "CommissioningDoubleJet"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               alca_producers=["TkAlMinBias", "SiStripCalMinBias", "HcalCalIsoTrk", "HcalCalIsolatedBunchSelector"],
-               dqm_sequences=["@common", "@L1TMon", "@hcal"],
-               physics_skims=["EcalActivity", "LogError", "LogErrorMonitor"],
-               timePerEvent=12,
-               sizePerEvent=4000,
-               scenario=ppScenario)
-
-DATASETS = ["HcalNZS"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               write_aod=True,
-               write_miniaod=True,
-               write_reco=False,
-               dqm_sequences=["@common", "@L1TMon", "@hcal"],
-               alca_producers=["HcalCalMinBias"],
-               physics_skims=["LogError", "LogErrorMonitor"],
-               timePerEvent=4.2,
-               sizePerEvent=1900,
-               scenario=hcalnzsScenario)
-
-DATASETS = ["TestEnablesEcalHcal", "TestEnablesEcalHcalDQM"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               alca_producers=["EcalTestPulsesRaw", "PromptCalibProdEcalPedestals", "HcalCalPedestal"],
-               dqm_sequences=["@common"],
-               scenario=alcaTestEnableScenario)
-
-DATASETS = ["OnlineMonitor", "EcalLaser"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=False,
-               scenario=ppScenario)
-
-DATASETS = ["CosmicsForEventDisplay"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=False,
-               write_miniaod=False,
-               scenario=cosmicsScenario)
-
-DATASETS = ["L1Accept", "L1Accepts"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=False,
-               write_dqm=False,
-               write_aod=True,
-               write_miniaod=True,
-               write_reco=False,
-               dqm_sequences=["@common"],
-               scenario=ppScenario)
-
-###########################
-### special AlcaRaw PDs ###
-###########################
-
-DATASETS = ["AlCaLumiPixels", "AlCaLumiPixels0", "AlCaLumiPixels1", "AlCaLumiPixels2", "AlCaLumiPixels3",
-            "AlCaLumiPixels4", "AlCaLumiPixels5", "AlCaLumiPixels6", "AlCaLumiPixels7",
-            "AlCaLumiPixels8", "AlCaLumiPixels9", "AlCaLumiPixels10", "AlCaLumiPixels11",
-            "AlCaLumiPixels12"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=False,
-               write_reco=False, write_aod=False, write_miniaod=False, write_dqm=True,
-               reco_split=alcarawSplitting,
-               proc_version=alcarawProcVersion,
-               alca_producers=[],
-               dqm_sequences=["@common"],
-               timePerEvent=0.02,
-               sizePerEvent=38,
-               disk_node="T2_CH_CERN",
-               scenario=alcaLumiPixelsScenario)
-
-########################################################
-### Pilot Tests PDs                                  ###
-########################################################
-DATASETS = ["AlCaLumiPixelsCountsPrompt0", "AlCaLumiPixelsCountsPrompt1", "AlCaLumiPixelsCountsPrompt2", "AlCaLumiPixelsCountsPrompt3",
-            "AlCaLumiPixelsCountsPrompt4", "AlCaLumiPixelsCountsPrompt5", "AlCaLumiPixelsCountsPrompt6", "AlCaLumiPixelsCountsPrompt7",
-            "AlCaLumiPixelsCountsPrompt8", "AlCaLumiPixelsCountsPrompt9", "AlCaLumiPixelsCountsPrompt10", "AlCaLumiPixelsCountsPrompt11",
-            "AlCaLumiPixelsCountsPrompt12", "AlCaLumiPixelsCountsPrompt"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=False,
-               write_reco=False, write_aod=False, write_miniaod=False, write_dqm=False,
-               disk_node=None,
-               tape_node=None,
-               reco_split=alcarawSplitting,
-               proc_version=alcarawProcVersion,
-               timePerEvent=0.02,
-               sizePerEvent=38,
-               scenario=alcaLumiPixelsScenario)
-
-DATASETS = ["ALCALumiPixelsCountsExpress0", "ALCALumiPixelsCountsExpress1", "ALCALumiPixelsCountsExpress2", "ALCALumiPixelsCountsExpress3",
-            "ALCALumiPixelsCountsExpress4", "ALCALumiPixelsCountsExpress5", "ALCALumiPixelsCountsExpress6", "ALCALumiPixelsCountsExpress7",
-            "ALCALumiPixelsCountsExpress8", "ALCALumiPixelsCountsExpress9", "ALCALumiPixelsCountsExpress10", "ALCALumiPixelsCountsExpress11",
-            "ALCALumiPixelsCountsExpress12", "ALCALumiPixelsCountsExpress"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=False,
-               write_reco=False, write_aod=False, write_miniaod=False, write_dqm=False,
-               disk_node=None,
-               tape_node=None,
-               reco_split=alcarawSplitting,
-               proc_version=alcarawProcVersion,
-               timePerEvent=0.02,
-               sizePerEvent=38,
-               scenario=alcaLumiPixelsScenario)
-
-DATASETS = ["AlCaPhiSym"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=False,
-               raw_to_disk=True,
-               alca_producers=["EcalCalPhiSym"],
-               scenario=ppScenario)
-
-DATASETS = ["AlCaP0"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=False,
-               raw_to_disk=True,
-               alca_producers=["EcalCalPi0Calib", "EcalCalEtaCalib"],
-               scenario=ppScenario)
-
-########################################################
-### HLTPhysics PDs                                   ###
-########################################################
-
-DATASETS = ["HLTPhysics", "HLTPhysics0", "HLTPhysics1",
-            "HLTPhysics2", "HLTPhysics3", "HLTPhysics4",
-            "HLTPhysics5", "HLTPhysics6", "HLTPhysics7",
-            "HLTPhysics8", "HLTPhysics9", "HLTPhysics10"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_reco=False,
-               write_dqm=True,
-               write_miniaod=True,
-               write_aod=True,
-               dqm_sequences=["@common", "@ecal", "@jetmet", "@L1TMon", "@hcal", "@L1TEgamma"],
-               alca_producers=["TkAlMinBias"],
-               physics_skims=["LogError", "LogErrorMonitor"],
-               scenario=ppScenario)
-
-DATASETS = ["HLTPhysicsBunchTrains", "HLTPhysicsIsolatedBunch"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               alca_producers=["SiStripCalMinBias", "TkAlMinBias", "HcalCalIsoTrkFilter"],
-               physics_skims=["LogError", "LogErrorMonitor"],
-               scenario=ppScenario)
-
-DATASETS = ["HLTPhysicspart0", "HLTPhysicspart1",
-            "HLTPhysicspart2", "HLTPhysicspart3", "HLTPhysicspart4",
-            "HLTPhysicspart5", "HLTPhysicspart6", "HLTPhysicspart7"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=False,
-               scenario=ppScenario)
-
-DATASETS = ["EphemeralHLTPhysics1", "EphemeralHLTPhysics2", "EphemeralHLTPhysics3",
-            "EphemeralHLTPhysics4", "EphemeralHLTPhysics5", "EphemeralHLTPhysics6",
-            "EphemeralHLTPhysics7", "EphemeralHLTPhysics8"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               scenario=ppScenario)
-
-DATASETS = ["HLTPhysicsCosmics", "HLTPhysicsCosmics1", "HLTPhysicsCosmics2",
-            "HLTPhysicsCosmics3", "HLTPhysicsCosmics4", "HLTPhysicsCosmics5",
-            "HLTPhysicsCosmics6", "HLTPhysicsCosmics7", "HLTPhysicsCosmics8"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_miniaod=False,
-               dqm_sequences=["@common"],
-               scenario=cosmicsScenario)
-
-########################################################
-### MinimumBias PDs                                  ###
-########################################################
-
-DATASETS = ["MinimumBias", "MinimumBias0", "MinimumBias1", "MinimumBias2", "MinimumBias3",
-            "MinimumBias4", "MinimumBias5", "MinimumBias6", "MinimumBias7",
-            "MinimumBias8", "MinimumBias9", "MinimumBias10", "MinimumBias11",
-            "MinimumBias12", "MinimumBias13", "MinimumBias14", "MinimumBias15",
-            "MinimumBias16", "MinimumBias17", "MinimumBias18", "MinimumBias19",
-            "MinimumBias20"
-           ]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               dqm_sequences=["@commonSiStripZeroBias", "@ecal", "@L1TMon", "@hcal", "@muon", "@jetmet"],
-               timePerEvent=1,
-               alca_producers=["SiStripCalZeroBias", "SiStripCalMinBias", "TkAlMinBias", "HcalCalHO", 
-                               "HcalCalIterativePhiSym", "HcalCalHBHEMuonFilter", "HcalCalIsoTrkFilter"],
-               scenario=ppScenario)
-
-DATASETS = ["L1MinimumBias"]
-
-DATASETS += ["L1MinimumBiasHF1", "L1MinimumBiasHF2", "L1MinimumBiasHF3", "L1MinimumBiasHF4",
-             "L1MinimumBiasHF5", "L1MinimumBiasHF6", "L1MinimumBiasHF7", "L1MinimumBiasHF8"]
-
-DATASETS += ["L1MinimumBias0", "L1MinimumBias1", "L1MinimumBias2", "L1MinimumBias3", "L1MinimumBias4",
-             "L1MinimumBias5", "L1MinimumBias6", "L1MinimumBias7", "L1MinimumBias8", "L1MinimumBias9",
-             "L1MinimumBias10"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               dqm_sequences=["@common"],
-               scenario=ppScenario)
-
-########################################################
-### ZeroBias PDs                                     ###
-########################################################
-
-DATASETS = ["ZeroBias"]
-
-DATASETS += ["ZeroBias0", "ZeroBias1", "ZeroBias2",
-             "ZeroBias3", "ZeroBias4", "ZeroBias5", "ZeroBias6",
-             "ZeroBias7", "ZeroBias8", "ZeroBias9", "ZeroBias10",
-             "ZeroBias11", "ZeroBias12", "ZeroBias13", "ZeroBias14",
-             "ZeroBias15", "ZeroBias16", "ZeroBias17", "ZeroBias18",
-             "ZeroBias19", "ZeroBias20"]
-
-DATASETS += ["ZeroBiasIsolatedBunches", "ZeroBiasIsolatedBunches0", "ZeroBiasIsolatedBunches1", "ZeroBiasIsolatedBunches2",
-             "ZeroBiasIsolatedBunches3", "ZeroBiasIsolatedBunches4", "ZeroBiasIsolatedBunches5", "ZeroBiasIsolatedBunches6",
-             "ZeroBiasIsolatedBunches7", "ZeroBiasIsolatedBunches8", "ZeroBiasIsolatedBunches9", "ZeroBiasIsolatedBunches10"]
-
-DATASETS += ["ZeroBiasIsolatedBunch", "ZeroBiasAfterIsolatedBunch",
-             "ZeroBiasIsolatedBunch0", "ZeroBiasIsolatedBunch1", "ZeroBiasIsolatedBunch2",
-             "ZeroBiasIsolatedBunch3", "ZeroBiasIsolatedBunch4", "ZeroBiasIsolatedBunch5"]
-
-DATASETS += ["ZeroBiasBunchTrains0", "ZeroBiasBunchTrains1", "ZeroBiasBunchTrains2",
-             "ZeroBiasBunchTrains3", "ZeroBiasBunchTrains4", "ZeroBiasBunchTrains5"]
-
-DATASETS += ["ZeroBiasFirstBunchAfterTrain", "ZeroBiasFirstBunchInTrain"]
-
-DATASETS += ["ZeroBiasPixelHVScan0", "ZeroBiasPixelHVScan1", "ZeroBiasPixelHVScan2",
-             "ZeroBiasPixelHVScan3", "ZeroBiasPixelHVScan4", "ZeroBiasPixelHVScan5",
-             "ZeroBiasPixelHVScan6", "ZeroBiasPixelHVScan7"]
-
-DATASETS += ["ZeroBias8b4e1", "ZeroBias8b4e2", "ZeroBias8b4e3",
-             "ZeroBias8b4e4", "ZeroBias8b4e5", "ZeroBias8b4e6",
-             "ZeroBias8b4e7", "ZeroBias8b4e8", "ZeroBias8b4e10",
-             "ZeroBias8b4e9"]
-
-DATASETS += ["ZeroBiasNominalTrains1", "ZeroBiasNominalTrains2", "ZeroBiasNominalTrains3",
-             "ZeroBiasNominalTrains4", "ZeroBiasNominalTrains5", "ZeroBiasNominalTrains6",
-             "ZeroBiasNominalTrains7", "ZeroBiasNominalTrains8", "ZeroBiasNominalTrains10",
-             "ZeroBiasNominalTrains9"]
-
-DATASETS += ["ZeroBiasPD01", "ZeroBiasPD02", "ZeroBiasPD03",
-             "ZeroBiasPD04", "ZeroBiasPD05", "ZeroBiasPD06",
-             "ZeroBiasPD07", "ZeroBiasPD08", "ZeroBiasPD09",
-             "ZeroBiasPD10"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_reco=True,
-               write_dqm=True,
-               dqm_sequences=["@commonSiStripZeroBias", "@ecal", "@L1TMon", "@hcal", "@muon", "@jetmet", "@ctpps"],
-               alca_producers=["SiStripCalZeroBias", "TkAlMinBias", "LumiPixelsMinBias", "SiStripCalMinBias", "AlCaPCCZeroBiasFromRECO"],
-               physics_skims=["LogError", "LogErrorMonitor"],
-               timePerEvent=3.5,
-               sizePerEvent=1500,
-               scenario=ppScenario)
-
-DATASETS = ["EphemeralZeroBias1", "EphemeralZeroBias2", "EphemeralZeroBias3",
-            "EphemeralZeroBias4", "EphemeralZeroBias5", "EphemeralZeroBias6",
-            "EphemeralZeroBias7", "EphemeralZeroBias8"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               scenario=ppScenario)
-
-########################################################
-### Parking and Scouting PDs                         ###
-########################################################
-
-DATASETS = ["ParkingMonitor"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               dqm_sequences=["@common"],
-               write_reco=False, write_aod=False, write_miniaod=True, write_dqm=True,
-               scenario=ppScenario)
-
-DATASETS = ["ParkingScoutingMonitor"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               dqm_sequences=["@common"],
-               write_reco=False, write_aod=False, write_miniaod=True, write_dqm=True,
-               scenario=ppScenario)
-
-DATASETS = ["ParkingMuon", "ParkingHT"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=False,
-               scenario=ppScenario)
-
-DATASETS = ["ParkingBPH1", "ParkingBPH2", "ParkingBPH3", "ParkingBPH4", "ParkingBPH5", "ParkingBPH6"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=False,
-               tape_node=None,
-               scenario=ppScenario)
-
-# Parking PD to be PR'ed at CSCS
-DATASETS = ["ParkingBPHPromptCSCS"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=False,
-               siteWhitelist=["T0_CH_CSCS_HPC"],
-               scenario=ppScenario)
-
-DATASETS = ["RPCMonitor"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=False,
-               scenario=ppScenario)
-
-DATASETS = ["ScoutingMonitor"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               dqm_sequences=["@common"],
-               write_reco=False, write_aod=False, write_miniaod=True, write_dqm=True,
-               scenario=ppScenario)
-
-DATASETS = ["ScoutingCaloCommissioning", "ScoutingCaloHT", "ScoutingCaloMuon",
-            "ScoutingPFCommissioning", "ScoutingPFHT", "ScoutingPFMuon"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=False,
-               scenario=ppScenario)
-
-DATASETS = ["ParkingHT410to430", "ParkingHT500to550", "ParkingHT430to450", "ParkingHT470to500", "ParkingHT450to470"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=False,
-               scenario=ppScenario)
-
-DATASETS = ["ParkingHT550to650", "ParkingHT650"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=False,
-               scenario=ppScenario)
-
-DATASETS = ["ParkingHLTPhysics", "ParkingHLTPhysics0", "ParkingHLTPhysics1",
-            "ParkingHLTPhysics2", "ParkingHLTPhysics3", "ParkingHLTPhysics4",
-            "ParkingHLTPhysics5", "ParkingHLTPhysics6", "ParkingHLTPhysics7",
-            "ParkingHLTPhysics8", "ParkingHLTPhysics9", "ParkingHLTPhysics10",
-            "ParkingHLTPhysics11", "ParkingHLTPhysics12", "ParkingHLTPhysics13",
-            "ParkingHLTPhysics14", "ParkingHLTPhysics15", "ParkingHLTPhysics16",
-            "ParkingHLTPhysics17", "ParkingHLTPhysics18", "ParkingHLTPhysics19",
-            "ParkingHLTPhysics20"]
-
-DATASETS += ["ParkingZeroBias", "ParkingZeroBias0",
-             "ParkingZeroBias1", "ParkingZeroBias2", "ParkingZeroBias3",
-             "ParkingZeroBias4", "ParkingZeroBias5", "ParkingZeroBias6",
-             "ParkingZeroBias7", "ParkingZeroBias8", "ParkingZeroBias9",
-             "ParkingZeroBias10", "ParkingZeroBias11", "ParkingZeroBias12",
-             "ParkingZeroBias13", "ParkingZeroBias14", "ParkingZeroBias15",
-             "ParkingZeroBias16", "ParkingZeroBias17", "ParkingZeroBias18",
-             "ParkingZeroBias19", "ParkingZeroBias20"]
-
-DATASETS += ["AlCaElectron", "VRRandom", "VRRandom0", "VRRandom1", "VRRandom2", "VRRandom3",
-             "VRRandom4", "VRRandom5", "VRRandom6", "VRRandom7", "VRZeroBias", "VirginRaw"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=False,
-               scenario=ppScenario)
-
-#########################################
-### New PDs for pp Reference Run 2017 ###
-#########################################
-
-DATASETS = ["HighEGJet", "LowEGJet"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               dqm_sequences=["@common", "@ecal", "@egamma", "@L1TMon", "@hcal", "@jetmet"],
-               scenario=ppScenario)
-
-DATASETS = ["HeavyFlavor", "SingleTrack"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               dqm_sequences=["@common"],
-               scenario=ppScenario)
-
-DATASETS = ["HIZeroBias1", "HIZeroBias2", "HIZeroBias3", "HIZeroBias4",
-            "HIZeroBias5", "HIZeroBias6", "HIZeroBias7", "HIZeroBias8",
-            "HIZeroBias9", "HIZeroBias10", "HIZeroBias11", "HIZeroBias12"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               dqm_sequences=["@commonSiStripZeroBias", "@ecal", "@L1TMon", "@hcal", "@muon"],
-               alca_producers=["SiStripCalZeroBias", "TkAlMinBias", "LumiPixelsMinBias", "SiStripCalMinBias", "AlCaPCCZeroBiasFromRECO"],
-               timePerEvent=3.5,
-               sizePerEvent=1500,
-               scenario=ppScenario)
-
-DATASETS = ["Totem12", "Totem34"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               dqm_sequences=["@common"],
-               scenario=ppScenario)
-
-################################
-### Low PU collisions 13 TeV ###
-################################
-
-DATASETS = ["CastorJets", "EGMLowPU", "FullTrack"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               dqm_sequences=["@common"],
-               scenario=ppScenario)
-
-DATASETS = ["HcalHPDNoise"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               dqm_sequences=["@common"],
-               physics_skims=["LogError", "LogErrorMonitor"],
-               scenario=ppScenario)
-
-DATASETS = ["HINMuon_HFveto"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               dqm_sequences=["@common"],
-               scenario=ppScenario)
-
-################################
-### Special Totem runs       ###
-################################
-
-DATASETS = ["TOTEM_minBias", "TOTEM_romanPots", "ToTOTEM", "ToTOTEM_DoubleJet32_0", "ToTOTEM_DoubleJet32_1",
-            "ToTOTEM_DoubleJet32_2", "ToTOTEM_DoubleJet32_3", "TOTEM_zeroBias", "ZeroBiasTotem", "MinimumBiasTotem",
-            "TOTEM_minBias1", "TOTEM_minBias2", "TOTEM_romanPots1", "TOTEM_romanPots2", "TOTEM_romanPots2_0",
-            "TOTEM_romanPots2_1", "TOTEM_romanPots2_2", "TOTEM_romanPots2_3", "TOTEM_romanPots2_4",
-            "TOTEM_romanPots2_5", "TOTEM_romanPots2_6", "TOTEM_romanPots2_7", "TOTEM_romanPots3",
-            "TOTEM_romanPotsTTBB_0", "TOTEM_romanPotsTTBB_1", "TOTEM_romanPotsTTBB_2", "TOTEM_romanPotsTTBB_3",
-            "TOTEM_romanPotsTTBB_4", "TOTEM_romanPotsTTBB_5", "TOTEM_romanPotsTTBB_6", "TOTEM_romanPotsTTBB_7"]
-
-DATASETS += ["Totem1", "Totem2", "Totem3", "Totem4"]
-
-### TOTEM DATASETS for 90m and LowPileUp menu - 2018/06/22
-DATASETS += ["HFvetoTOTEM", "JetsTOTEM"]
-
-DATASETS += ["RandomTOTEM1", "RandomTOTEM2", "RandomTOTEM3", "RandomTOTEM4"]
-
-DATASETS += ["TOTEM10", "TOTEM11", "TOTEM12", "TOTEM13", "TOTEM20", "TOTEM21", "TOTEM22",
-             "TOTEM23", "TOTEM3", "TOTEM40", "TOTEM41", "TOTEM42", "TOTEM43"]
-
-DATASETS += ["ZeroBiasTOTEM1", "ZeroBiasTOTEM2", "ZeroBiasTOTEM3", "ZeroBiasTOTEM4"]
-### TOTEM DATASETS for 90m and LowPileUp menu - 2018/06/22
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_reco=True,
-               dqm_sequences=["@common"],
-               scenario=ppScenario)
-
-### TOTEM EGamma dataset for 90m and LowPileUp with egamma dqm sequence
-DATASETS = ["MuonEGammaTOTEM"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_reco=False,
-               write_dqm=True,
-               dqm_sequences=["@common", "@egamma"],
-               scenario=ppScenario)
-
-################################
-### 50 ns Physics Menu       ###
-################################
-
-DATASETS = ["L1TechBPTXPlusOnly", "L1TechBPTXMinusOnly", "L1TechBPTXQuiet"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               dqm_sequences=["@common"],
-               scenario=ppScenario)
-
-DATASETS = ["SingleMu"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               dqm_sequences=["@common"],
-               scenario=ppScenario)
-
-DATASETS = ["DoubleMu"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               dqm_sequences=["@common"],
-               alca_producers=["TkAlZMuMu", "TkAlJpsiMuMu", "TkAlUpsilonMuMu", "MuAlCalIsolatedMu", "MuAlOverlaps", "MuAlZMuMu", "HcalCalIsoTrkFilter"],
-               physics_skims=["Onia"],
-               scenario=ppScenario)
-
-DATASETS = ["DoublePhoton"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               dqm_sequences=["@common", "@ecal", "@egamma"],
-               scenario=ppScenario)
-
-
-#########################################
-### New PDs for pp Reference Run 2015 ###
-#########################################
-
-# new PD with same name added for 2017 ppRef
-# keeping this config for reference
-# addDataset(tier0Config, "HeavyFlavor",
-#           do_reco=True,
-#            write_dqm=True,
-#            dqm_sequences=["@common"],
-#            physics_skims=["D0Meson"],
-#            scenario=ppScenario)
-
-addDataset(tier0Config, "HighPtJet80",
-           do_reco=True,
-           write_dqm=True,
-           dqm_sequences=["@common"],
-           physics_skims=["HighPtJet"],
-           scenario=ppScenario)
-
-addDataset(tier0Config, "SingleMuHighPt",
-           do_reco=True,
-           write_dqm=True,
-           alca_producers=["TkAlMuonIsolated", "HcalCalIterativePhiSym", "MuAlCalIsolatedMu", "MuAlOverlaps", "MuAlZMuMu"],
-           dqm_sequences=["@common"],
-           physics_skims=["ZMM"],
-           scenario=ppScenario)
-
-addDataset(tier0Config, "SingleMuLowPt",
-           do_reco=True,
-           write_dqm=True,
-           alca_producers=["TkAlMuonIsolated", "HcalCalIterativePhiSym", "MuAlCalIsolatedMu", "MuAlOverlaps", "MuAlZMuMu"],
-           dqm_sequences=["@common"],
-           scenario=ppScenario)
-
 ###############################
 ### ExpressPA configuration ###
 ###############################
@@ -1423,150 +506,6 @@ addExpressConfig(tier0Config, "HLTMonitorPA",
                  diskNode="T0_CH_CERN_Disk",
                  versionOverride=expressVersionOverride)
 
-#########################################
-### New PDs for PARun 2016 ###
-#########################################
-
-DATASETS = ["PAHighMultiplicity0", "PAHighMultiplicity1", "PAHighMultiplicity2", "PAHighMultiplicity3",
-            "PAHighMultiplicity4", "PAHighMultiplicity5", "PAHighMultiplicity6", "PAHighMultiplicity7"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               dqm_sequences=["@common"],
-               scenario=hiScenario)
-
-addDataset(tier0Config, "PACastor",
-           do_reco=True,
-           write_dqm=True,
-           dqm_sequences=["@common"],
-           scenario=hiScenario)
-
-addDataset(tier0Config, "PAForward",
-           do_reco=True,
-           write_dqm=True,
-           dqm_sequences=["@common"],
-           scenario=hiScenario)
-
-addDataset(tier0Config, "PADoubleMuon",
-           do_reco=True,
-           write_dqm=True,
-           dqm_sequences=["@common", "@muon"],
-           alca_producers=["TkAlMuonIsolatedPA", "TkAlZMuMuPA", "TkAlUpsilonMuMuPA"],
-           scenario=hiScenario)
-
-addDataset(tier0Config, "PASingleMuon",
-           do_reco=True,
-           write_dqm=True,
-           dqm_sequences=["@common", "@muon"],
-           alca_producers=["TkAlMuonIsolatedPA"],
-           physics_skims=["PAZMM"],
-           scenario=hiScenario)
-
-DATASETS = ["PADTrack1", "PADTrack2"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               dqm_sequences=["@common"],
-               scenario=hiScenario)
-
-addDataset(tier0Config, "PAEGJet1",
-           do_reco=True,
-           write_dqm=True,
-           dqm_sequences=["@common", "@ecal", "@egamma", "@L1TMon", "@hcal", "@jetmet"],
-           physics_skims=["PAZEE"],
-           scenario=hiScenario)
-
-DATASETS = ["PAMinimumBias1", "PAMinimumBias2", "PAMinimumBias3", "PAMinimumBias4",
-            "PAMinimumBias5", "PAMinimumBias6", "PAMinimumBias7", "PAMinimumBias8",
-            "PAMinimumBias9", "PAMinimumBias10", "PAMinimumBias11", "PAMinimumBias12",
-            "PAMinimumBias13", "PAMinimumBias14", "PAMinimumBias15", "PAMinimumBias16",
-            "PAMinimumBias17", "PAMinimumBias18", "PAMinimumBias19", "PAMinimumBias20"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               dqm_sequences=["@common"],
-               alca_producers=["SiStripCalMinBias", "TkAlMinBias"],
-               scenario=hiScenario)
-
-addDataset(tier0Config, "PAMinimumBiasBkg",
-           do_reco=True,
-           write_dqm=True,
-           dqm_sequences=["@common"],
-           physics_skims=["PAMinBias"],
-           scenario=hiScenario)
-
-
-addDataset(tier0Config, "PAEmptyBX",
-           do_reco=True,
-           write_dqm=True,
-           dqm_sequences=["@common"],
-           scenario=hiScenario)
-
-#############################
-###   PDs pA VdM scan     ###
-#############################
-
-DATASETS = ["PAL1AlwaysTrue0", "PAL1AlwaysTrue1", "PAL1AlwaysTrue2", "PAL1AlwaysTrue3",
-            "PAL1AlwaysTrue4", "PAL1AlwaysTrue5", "PAL1AlwaysTrue6", "PAL1AlwaysTrue7",
-            "PAL1AlwaysTrue8", "PAL1AlwaysTrue9"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               alca_producers=["LumiPixelsMinBias"],
-               dqm_sequences=["@common"],
-               scenario=hiScenario)
-
-DATASETS = ["PAMinimumBiasHFOR0", "PAMinimumBiasHFOR1", "PAMinimumBiasHFOR2"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               alca_producers=["LumiPixelsMinBias"],
-               dqm_sequences=["@common"],
-               scenario=hiScenario)
-
-DATASETS = ["PAZeroBias0", "PAZeroBias1", "PAZeroBias2", "PAZeroBias3",
-            "PAZeroBias4", "PAZeroBias5", "PAZeroBias6", "PAZeroBias7",
-            "PAZeroBias8", "PAZeroBias9"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               alca_producers=["LumiPixelsMinBias"],
-               dqm_sequences=["@commonSiStripZeroBias", "@ecal", "@L1TMon", "@hcal", "@muon"],
-               scenario=hiScenario)
-
-addDataset(tier0Config, "PADoubleMuOpen",
-           do_reco=True,
-           write_dqm=True,
-           alca_producers=["LumiPixelsMinBias"],
-           dqm_sequences=["@common", "@muon"],
-           scenario=hiScenario)
-
-#####################
-### HI TESTS 2018 ###
-#####################
-
-DATASETS = ["HITestFull", "HITestReduced"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               raw_to_disk=True,
-               write_dqm=True,
-               dqm_sequences=["@common"],
-               scenario=hiTestppScenario)
-
 #######################
 ### ignored streams ###
 #######################
@@ -1581,6 +520,36 @@ ignoreStream(tier0Config, "DQMOffline")
 ignoreStream(tier0Config, "streamHLTRates")
 ignoreStream(tier0Config, "streamL1Rates")
 ignoreStream(tier0Config, "streamDQMRates")
+
+############################################
+### ignored streams for the current test ###
+############################################
+ignoreStream(tier0Config, "ALCALUMIPIXELS")
+ignoreStream(tier0Config, "ALCALUMIPIXELSEXPRESS")
+ignoreStream(tier0Config, "ALCAP0")
+ignoreStream(tier0Config, "ALCAPHISYM")
+ignoreStream(tier0Config, "Calibration")
+ignoreStream(tier0Config, "ExpressAlignment")
+ignoreStream(tier0Config, "ExpressCosmics")
+ignoreStream(tier0Config, "ExpressPA")
+ignoreStream(tier0Config, "HIExpress")
+ignoreStream(tier0Config, "HIExpressAlignment")
+ignoreStream(tier0Config, "HLTMonitor")
+ignoreStream(tier0Config, "HLTMonitorPA")
+ignoreStream(tier0Config, "NanoDST")
+ignoreStream(tier0Config, "ParkingBPH1")
+ignoreStream(tier0Config, "ParkingBPH2")
+ignoreStream(tier0Config, "ParkingBPH3")
+ignoreStream(tier0Config, "ParkingBPH4")
+ignoreStream(tier0Config, "ParkingBPH5")
+ignoreStream(tier0Config, "PhysicsCommissioning")
+ignoreStream(tier0Config, "PhysicsEGamma")
+ignoreStream(tier0Config, "PhysicsHadronsTaus")
+ignoreStream(tier0Config, "PhysicsMuons")
+ignoreStream(tier0Config, "PhysicsScoutingMonitor")
+ignoreStream(tier0Config, "RPCMON")
+ignoreStream(tier0Config, "ScoutingCaloMuon")
+ignoreStream(tier0Config, "ScoutingPF")
 
 ###################################
 ### currently inactive settings ###


### PR DESCRIPTION
# Replay Request

**Requestor**  
Francesco Brivio for AlCaDB/Tracking POG (FYI @mmusich @vmariani @slava77)

**Describe the configuration**  
* Release: CMSSW_12_4_0_pre4
* Run: 324841 (pp collisions from 2018D)
* GTs:
   * expressGlobalTag: 122X_dataRun3_Express_TIER0_REPLAY_Run2_v1
   * promptrecoGlobalTag: 122X_dataRun3_Prompt_TIER0_REPLAY_Run2_v1
   * alcap0GlobalTag: 122X_dataRun3_Prompt_TIER0_REPLAY_Run2_v1
* Additional changes:
   * Added `PromptCalibProdSiStripHitEfficiency` producer to `StreamExpress` (which is the only stream needed in this replay)

**Purpose of the test**  
This replay aims to test the SiStripHitEfficiency workflow in the Prompt Calibration Loop: the `PromptCalibProdSiStripHitEfficiency` producer was introduced in https://github.com/cms-sw/cmssw/pull/37708 and if everything works fine with this replay we will merge the CMSSW_12_3_X backport and deploy it for the first stable collisions of Run3.

**Important note** In order to reduce the cost of the replay all prompt producer have been removed from the config as well as all the Express streams except for `StreamExpress` (which is needed for this test), for which all the non-needed producers are removed as well.


**T0 Operations cmsTalk thread**  
N/A