### PR TITLE
Replay testing CMSSW_12_4_0

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -35,7 +35,7 @@ setConfigVersion(tier0Config, "replace with real version")
 # 346512 - 2021 pp
 # 349840 - 2022 CRAFT
 # 350966 - 2022 Splashes
-setInjectRuns(tier0Config, [353701,352929])
+setInjectRuns(tier0Config, [353701,352929,353796])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -35,7 +35,7 @@ setConfigVersion(tier0Config, "replace with real version")
 # 346512 - 2021 pp
 # 349840 - 2022 CRAFT
 # 350966 - 2022 Splashes
-setInjectRuns(tier0Config, [352705,352503])
+setInjectRuns(tier0Config, [353701,352929])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"
@@ -126,9 +126,9 @@ expressProcVersion = dt
 alcarawProcVersion = dt
 
 # Defaults for GlobalTag
-expressGlobalTag = "123X_dataRun3_Express_v9"
-promptrecoGlobalTag = "123X_dataRun3_Prompt_v11"
-alcap0GlobalTag = "123X_dataRun3_Prompt_v11"
+expressGlobalTag = "124X_dataRun3_Express_Candidate_2022_06_16_09_23_11"
+promptrecoGlobalTag = "124X_dataRun3_Prompt_Candidate_2022_06_16_09_23_34"
+alcap0GlobalTag = "124X_dataRun3_Prompt_Candidate_2022_06_16_09_23_34"
 
 # Mandatory for CondDBv2
 globalTagConnect = "frontier://PromptProd/CMS_CONDITIONS"

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -102,7 +102,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_12_3_5_patch1"
+    'default': "CMSSW_12_4_0"
 }
 
 # Configure ScramArch


### PR DESCRIPTION
# Replay Request

**Requestor**  
T0

**Describe the configuration**  
* Release: CMSSW_12_4_0
* Run: 353701, 352929
* GTs:
   * expressGlobalTag: 124X_dataRun3_Express_Candidate_2022_06_16_09_23_11
   * promptrecoGlobalTag: 124X_dataRun3_Prompt_Candidate_2022_06_16_09_23_34
   * alcap0GlobalTag: 124X_dataRun3_Prompt_Candidate_2022_06_16_09_23_34
* Additional changes:

**Purpose of the test**  
Early identification of issues with 12_4_X releases

**T0 Operations cmsTalk thread**  No post yet
[Tier0 Operations cmsTalk Forum](https://cms-talk.web.cern.ch/c/offcomp/compops/tier0/210?)
