### PR TITLE
Switch of AOD and RECO for AlCaLumiPixelsCountsPrompt

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -912,7 +912,7 @@ DATASETS = ["AlCaLumiPixelsCountsPrompt0", "AlCaLumiPixelsCountsPrompt1", "AlCaL
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,
                do_reco=True,
-               write_reco=True, write_aod=True, write_miniaod=False, write_dqm=False,
+               write_reco=False, write_aod=False, write_miniaod=False, write_dqm=False,
                disk_node="T2_CH_CERN",
                tape_node=None,
                reco_split=alcarawSplitting,

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -882,7 +882,7 @@ DATASETS = ["AlCaLumiPixelsCountsPrompt0", "AlCaLumiPixelsCountsPrompt1", "AlCaL
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,
                do_reco=True,
-               write_reco=True, write_aod=True, write_miniaod=False, write_dqm=False,
+               write_reco=False, write_aod=False, write_miniaod=False, write_dqm=False,
                disk_node="T2_CH_CERN",
                tape_node=None,
                reco_split=alcarawSplitting,


### PR DESCRIPTION
These datasets are being produced
[/AlCaLumiPixelsCountsPrompt/Run2022A-PromptReco-v1/RECO](https://cmsweb.cern.ch/das/request?input=dataset%3D%2FAlCaLumiPixelsCountsPrompt%2FRun2022A-PromptReco-v1%2FRECO&instance=prod/global)

[/AlCaLumiPixelsCountsPrompt/Run2022A-PromptReco-v1/AOD](https://cmsweb.cern.ch/das/request?input=dataset%3D%2FAlCaLumiPixelsCountsPrompt%2FRun2022A-PromptReco-v1%2FAOD&instance=prod/global)

and have zero content (as expected). Apparently we just forgot to switch them off, so this PR does that. 