### PR TITLE
Dont write RECO for DoubleMuon PD

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -539,7 +539,7 @@ DATASETS = ["DoubleMuon"]
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,
                do_reco=True,
-               write_reco=True,
+               write_reco=False,
                raw_to_disk=True,
                write_dqm=True,
                tape_node="T1_DE_KIT_MSS",

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -35,7 +35,7 @@ setConfigVersion(tier0Config, "replace with real version")
 # 346512 - 2021 pp
 # 349840 - 2022 CRAFT
 # 350966 - 2022 Splashes
-setInjectRuns(tier0Config, [352705,352503])
+setInjectRuns(tier0Config, [352929])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"
@@ -549,7 +549,7 @@ DATASETS = ["DoubleMuon"]
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,
                do_reco=True,
-               write_reco=True,
+               write_reco=False,
                write_dqm=True,
                alca_producers=["TkAlZMuMu", "MuAlCalIsolatedMu", "TkAlDiMuonAndVertex"],
                dqm_sequences=["@common", "@muon", "@lumi", "@L1TMuon"],


### PR DESCRIPTION
# Replay Request

**Requestor**  

ORM

**Describe the configuration**  
* Release: CMSSW_12_3_5_patch1
* Run: 
* GTs:
   * expressGlobalTag: 123X_dataRun3_Express_v9
   * promptrecoGlobalTag: 123X_dataRun3_Prompt_v11
   * alcap0GlobalTag:123X_dataRun3_Prompt_v11
* Additional changes: dont write RECO for DoubleMuon PD

**Purpose of the test**  

To test the removal of RECO output from DoubleMuon PD

**T0 Operations cmsTalk thread**  

https://cms-talk.web.cern.ch/t/replay-to-test-the-removal-of-reco-from-doublemuon-pd/12153