### PR TITLE
Change CMSSW to CMSSW_12_3_6

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -94,7 +94,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_12_3_5_patch1"
+    'default': "CMSSW_12_3_6"
 }
 
 # Configure ScramArch
@@ -164,7 +164,9 @@ repackVersionOverride = {
     "CMSSW_12_3_3" : defaultCMSSWVersion['default'],
     "CMSSW_12_3_4" : defaultCMSSWVersion['default'],
     "CMSSW_12_3_4_patch2" : defaultCMSSWVersion['default'],
-    "CMSSW_12_3_5" : defaultCMSSWVersion['default']
+    "CMSSW_12_3_5" : defaultCMSSWVersion['default'],
+    "CMSSW_12_3_5_patch1" : defaultCMSSWVersion['default'],
+    "CMSSW_12_3_6" : defaultCMSSWVersion['default']
     }
 
 expressVersionOverride = {
@@ -186,7 +188,9 @@ expressVersionOverride = {
     "CMSSW_12_3_3" : defaultCMSSWVersion['default'],
     "CMSSW_12_3_4" : defaultCMSSWVersion['default'],
     "CMSSW_12_3_4_patch2" : defaultCMSSWVersion['default'],
-    "CMSSW_12_3_5" : defaultCMSSWVersion['default']
+    "CMSSW_12_3_5" : defaultCMSSWVersion['default'],
+    "CMSSW_12_3_5_patch1" : defaultCMSSWVersion['default'],
+    "CMSSW_12_3_6" : defaultCMSSWVersion['default']
     }
 
 #set default repack settings for bulk streams

--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -127,9 +127,9 @@ expressProcVersion = {
 }
 
 # Defaults for GlobalTag
-expressGlobalTag = "123X_dataRun3_Express_v9"
-promptrecoGlobalTag = "123X_dataRun3_Prompt_v11"
-alcap0GlobalTag = "123X_dataRun3_Prompt_v11"
+expressGlobalTag = "123X_dataRun3_Express_v10"
+promptrecoGlobalTag = "123X_dataRun3_Prompt_v12"
+alcap0GlobalTag = "123X_dataRun3_Prompt_v12"
 
 # Mandatory for CondDBv2
 globalTagConnect = "frontier://PromptProd/CMS_CONDITIONS"
@@ -677,7 +677,7 @@ for dataset in DATASETS:
                write_dqm=True,
                tape_node="T1_UK_RAL_MSS",
                disk_node="T1_UK_RAL_Disk",
-               alca_producers=["HcalCalIsoTrkProducerFilter", "TkAlMinBias"],
+               alca_producers=["HcalCalIsoTrkProducerFilter", "TkAlJetHT"],
                dqm_sequences=["@common", "@jetmet", "@L1TMon", "@hcal"],
                physics_skims=["JetHTJetPlusHOFilter", "LogError", "LogErrorMonitor"],
                timePerEvent=5.7,

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -126,9 +126,9 @@ expressProcVersion = dt
 alcarawProcVersion = dt
 
 # Defaults for GlobalTag
-expressGlobalTag = "123X_dataRun3_Express_v9"
-promptrecoGlobalTag = "123X_dataRun3_Prompt_v11"
-alcap0GlobalTag = "123X_dataRun3_Prompt_v11"
+expressGlobalTag = "123X_dataRun3_Express_v10"
+promptrecoGlobalTag = "123X_dataRun3_Prompt_v12"
+alcap0GlobalTag = "123X_dataRun3_Prompt_v12"
 
 # Mandatory for CondDBv2
 globalTagConnect = "frontier://PromptProd/CMS_CONDITIONS"
@@ -672,7 +672,7 @@ for dataset in DATASETS:
     addDataset(tier0Config, dataset,
                do_reco=True,
                write_dqm=True,
-               alca_producers=["HcalCalIsoTrkProducerFilter", "TkAlMinBias"],
+               alca_producers=["HcalCalIsoTrkProducerFilter", "TkAlJetHT"],
                dqm_sequences=["@common", "@jetmet", "@L1TMon", "@hcal"],
                physics_skims=["JetHTJetPlusHOFilter", "LogError", "LogErrorMonitor"],
                timePerEvent=5.7,

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -32,10 +32,10 @@ tier0Config = createTier0Config()
 setConfigVersion(tier0Config, "replace with real version")
 
 # Set run number to replay
-# 346512 - 2021 pp
-# 349840 - 2022 CRAFT
-# 350966 - 2022 Splashes
-setInjectRuns(tier0Config, [352929])
+# 352929 - 2022 pp with tracker
+# 353737 - 2022 circulating
+# 353739 - 2022 cosmics
+setInjectRuns(tier0Config, [352929,353737,353739])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"
@@ -102,7 +102,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_12_3_5_patch1"
+    'default': "CMSSW_12_3_6"
 }
 
 # Configure ScramArch
@@ -177,7 +177,8 @@ repackVersionOverride = {
     "CMSSW_12_3_4" : defaultCMSSWVersion['default'],
     "CMSSW_12_3_4_patch2" : defaultCMSSWVersion['default'],
     "CMSSW_12_3_5" : defaultCMSSWVersion['default'],
-    "CMSSW_12_3_5_patch1" : defaultCMSSWVersion['default']
+    "CMSSW_12_3_5_patch1" : defaultCMSSWVersion['default'],
+    "CMSSW_12_3_6" : defaultCMSSWVersion['default']
     }
 
 expressVersionOverride = {
@@ -213,7 +214,8 @@ expressVersionOverride = {
     "CMSSW_12_3_4" : defaultCMSSWVersion['default'],
     "CMSSW_12_3_4_patch2" : defaultCMSSWVersion['default'],
     "CMSSW_12_3_5" : defaultCMSSWVersion['default'],
-    "CMSSW_12_3_5_patch1" : defaultCMSSWVersion['default']
+    "CMSSW_12_3_5_patch1" : defaultCMSSWVersion['default'],
+    "CMSSW_12_3_6" : defaultCMSSWVersion['default']
     }
 
 #set default repack settings for bulk streams


### PR DESCRIPTION
# Replay Request

**Requestor**  

ORM

**Describe the configuration**  
* Release: CMSSW_12_3_6
* Run: 352929 - 2022 pp with tracker, 353737 - 2022 circulating, 353739 - 2022 cosmics
* GTs:
   * expressGlobalTag: [123X_dataRun3_Express_v10](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/123X_dataRun3_Express_v10)
   * promptrecoGlobalTag: [123X_dataRun3_Prompt_v12](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/123X_dataRun3_Prompt_v12)
   * alcap0GlobalTag: [123X_dataRun3_Prompt_v12](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/123X_dataRun3_Prompt_v12)
* Additional changes: Change `TkAlMinBias` to `TkAlJetHT` on the JetHT PD and change the GT accordingly

**Purpose of the test**  

CMSSW_12_3_6 came out 15 min ago, this PR is to test it and then merge the production config to be used for the collisions on Friday.

https://cms-talk.web.cern.ch/t/production-release-cmssw-12-3-6-now-available/12189

**T0 Operations cmsTalk thread**  

https://cms-talk.web.cern.ch/t/replay-for-changing-cmssw-to-cmssw-12-3-6/12192
