### PR TITLE
Test new high granularity Tracker Alignment PCL

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -35,7 +35,7 @@ setConfigVersion(tier0Config, "replace with real version")
 # 352929 - 2022 pp with tracker
 # 353737 - 2022 circulating
 # 353739 - 2022 cosmics
-setInjectRuns(tier0Config, [352929,353737,353739])
+setInjectRuns(tier0Config, [352929])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"
@@ -102,11 +102,11 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_12_3_6"
+    'default': "CMSSW_12_4_1"
 }
 
 # Configure ScramArch
-setDefaultScramArch(tier0Config, "slc7_amd64_gcc10")
+setDefaultScramArch(tier0Config, "el8_amd64_gcc10")
 
 # Configure scenarios
 ppScenario = "ppEra_Run3"
@@ -120,15 +120,15 @@ alcaLumiPixelsScenario = "AlCaLumiPixels_Run3"
 hiTestppScenario = "ppEra_Run3"
 
 # Procesing version number replays
-dt = 434
+dt = 464
 defaultProcVersion = dt
 expressProcVersion = dt
 alcarawProcVersion = dt
 
 # Defaults for GlobalTag
-expressGlobalTag = "123X_dataRun3_Express_v10"
-promptrecoGlobalTag = "123X_dataRun3_Prompt_v12"
-alcap0GlobalTag = "123X_dataRun3_Prompt_v12"
+expressGlobalTag = "124X_dataRun3_Express_v3"
+promptrecoGlobalTag = "124X_dataRun3_Prompt_v3"
+alcap0GlobalTag = "124X_dataRun3_Prompt_v3"
 
 # Mandatory for CondDBv2
 globalTagConnect = "frontier://PromptProd/CMS_CONDITIONS"
@@ -267,7 +267,7 @@ addExpressConfig(tier0Config, "Express",
                                  "TkAlMinBias", "SiPixelCalZeroBias", "SiPixelCalSingleMuon",
                                  "PromptCalibProd", "PromptCalibProdSiStrip", "PromptCalibProdSiPixelAli",
                                  "PromptCalibProdSiStripGains", "PromptCalibProdSiStripGainsAAG", "PromptCalibProdSiPixel",
-                                 "PromptCalibProdSiPixelLA", "PromptCalibProdSiStripHitEff"
+                                 "PromptCalibProdSiPixelLA", "PromptCalibProdSiStripHitEff", "PromptCalibProdSiPixelAliHG"
                                 ],
                  reco_version=defaultCMSSWVersion,
                  multicore=numberOfCores,
@@ -1603,16 +1603,33 @@ for dataset in DATASETS:
 ### ignored streams ###
 #######################
 
-ignoreStream(tier0Config, "Error")
-ignoreStream(tier0Config, "HLTMON")
-ignoreStream(tier0Config, "EventDisplay")
-ignoreStream(tier0Config, "DQM")
-ignoreStream(tier0Config, "DQMEventDisplay")
-ignoreStream(tier0Config, "LookArea")
-ignoreStream(tier0Config, "DQMOffline")
-ignoreStream(tier0Config, "streamHLTRates")
-ignoreStream(tier0Config, "streamL1Rates")
-ignoreStream(tier0Config, "streamDQMRates")
+ignoreStream(tier0Config, "ALCALumiPixelsCountsExpress")
+ignoreStream(tier0Config, "ALCALumiPixelsCountsPrompt")
+ignoreStream(tier0Config, "ALCAP0")
+ignoreStream(tier0Config, "ALCAPHISYM")
+ignoreStream(tier0Config, "ALCAPPS")
+ignoreStream(tier0Config, "Calibration")
+ignoreStream(tier0Config, "ExpressAlignment")
+ignoreStream(tier0Config, "HLTMonitor")
+ignoreStream(tier0Config, "NanoDST")
+ignoreStream(tier0Config, "Physics")
+ignoreStream(tier0Config, "PhysicsMinimumBias0")
+ignoreStream(tier0Config, "PhysicsMinimumBias1")
+ignoreStream(tier0Config, "PhysicsMinimumBias2")
+ignoreStream(tier0Config, "PhysicsMinimumBias3")
+ignoreStream(tier0Config, "PhysicsMinimumBias4")
+ignoreStream(tier0Config, "PhysicsZeroBias0")
+ignoreStream(tier0Config, "PhysicsZeroBias1")
+ignoreStream(tier0Config, "PhysicsZeroBias2")
+ignoreStream(tier0Config, "PhysicsZeroBias3")
+ignoreStream(tier0Config, "PhysicsZeroBias4")
+ignoreStream(tier0Config, "PhysicsZeroBias5")
+ignoreStream(tier0Config, "PhysicsZeroBias6")
+ignoreStream(tier0Config, "PhysicsZeroBias7")
+ignoreStream(tier0Config, "PhysicsZeroBias8")
+ignoreStream(tier0Config, "PhysicsZeroBias9")
+ignoreStream(tier0Config, "RPCMON")
+ignoreStream(tier0Config, "ScoutingPF")
 
 ###################################
 ### currently inactive settings ###

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -24,6 +24,7 @@ from T0.RunConfig.Tier0Config import setStreamerPNN
 from T0.RunConfig.Tier0Config import setEnableUniqueWorkflowName
 from T0.RunConfig.Tier0Config import addSiteConfig
 from T0.RunConfig.Tier0Config import setStorageSite
+from T0.RunConfig.Tier0Config import setScramArch
 
 # Create the Tier0 configuration object
 tier0Config = createTier0Config()
@@ -35,7 +36,7 @@ setConfigVersion(tier0Config, "replace with real version")
 # 352929 - 2022 pp with tracker
 # 353737 - 2022 circulating
 # 353739 - 2022 cosmics
-setInjectRuns(tier0Config, [352929])
+setInjectRuns(tier0Config, [324841])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"
@@ -106,10 +107,11 @@ defaultCMSSWVersion = {
 }
 
 # Configure ScramArch
-setDefaultScramArch(tier0Config, "el8_amd64_gcc10")
+setDefaultScramArch(tier0Config, "slc7_amd64_gcc630")
+setScramArch(tier0Config, defaultCMSSWVersion['default'], "el8_amd64_gcc10")
 
 # Configure scenarios
-ppScenario = "ppEra_Run3"
+ppScenario = "ppEra_Run2_2018"
 ppScenarioB0T = "ppEra_Run3"
 cosmicsScenario = "cosmicsEra_Run3"
 hcalnzsScenario = "hcalnzsEra_Run3"
@@ -120,15 +122,15 @@ alcaLumiPixelsScenario = "AlCaLumiPixels_Run3"
 hiTestppScenario = "ppEra_Run3"
 
 # Procesing version number replays
-dt = 464
+dt = 466
 defaultProcVersion = dt
 expressProcVersion = dt
 alcarawProcVersion = dt
 
 # Defaults for GlobalTag
-expressGlobalTag = "124X_dataRun3_Express_v3"
-promptrecoGlobalTag = "124X_dataRun3_Prompt_v3"
-alcap0GlobalTag = "124X_dataRun3_Prompt_v3"
+expressGlobalTag = "124X_dataRun3_Express_TIER0_REPLAY_Run2_v1"
+promptrecoGlobalTag = "124X_dataRun3_Prompt_TIER0_REPLAY_Run2_v1"
+alcap0GlobalTag = "124X_dataRun3_Prompt_TIER0_REPLAY_Run2_v1"
 
 # Mandatory for CondDBv2
 globalTagConnect = "frontier://PromptProd/CMS_CONDITIONS"

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -108,7 +108,7 @@ defaultCMSSWVersion = {
 
 # Configure ScramArch
 setDefaultScramArch(tier0Config, "slc7_amd64_gcc630")
-setScramArch(tier0Config, defaultCMSSWVersion['default'], "el8_amd64_gcc10")
+setScramArch(tier0Config, defaultCMSSWVersion['default'], "slc7_amd64_gcc10")
 
 # Configure scenarios
 ppScenario = "ppEra_Run2_2018"
@@ -180,7 +180,8 @@ repackVersionOverride = {
     "CMSSW_12_3_4_patch2" : defaultCMSSWVersion['default'],
     "CMSSW_12_3_5" : defaultCMSSWVersion['default'],
     "CMSSW_12_3_5_patch1" : defaultCMSSWVersion['default'],
-    "CMSSW_12_3_6" : defaultCMSSWVersion['default']
+    "CMSSW_12_3_6" : defaultCMSSWVersion['default'],
+    "CMSSW_12_4_1" : defaultCMSSWVersion['default']
     }
 
 expressVersionOverride = {
@@ -217,7 +218,8 @@ expressVersionOverride = {
     "CMSSW_12_3_4_patch2" : defaultCMSSWVersion['default'],
     "CMSSW_12_3_5" : defaultCMSSWVersion['default'],
     "CMSSW_12_3_5_patch1" : defaultCMSSWVersion['default'],
-    "CMSSW_12_3_6" : defaultCMSSWVersion['default']
+    "CMSSW_12_3_6" : defaultCMSSWVersion['default'],
+    "CMSSW_12_4_1" : defaultCMSSWVersion['default']
     }
 
 #set default repack settings for bulk streams
@@ -1605,33 +1607,28 @@ for dataset in DATASETS:
 ### ignored streams ###
 #######################
 
-ignoreStream(tier0Config, "ALCALumiPixelsCountsExpress")
-ignoreStream(tier0Config, "ALCALumiPixelsCountsPrompt")
+ignoreStream(tier0Config, "ALCALUMIPIXELS")
+ignoreStream(tier0Config, "ALCALUMIPIXELSEXPRESS")
 ignoreStream(tier0Config, "ALCAP0")
 ignoreStream(tier0Config, "ALCAPHISYM")
-ignoreStream(tier0Config, "ALCAPPS")
 ignoreStream(tier0Config, "Calibration")
 ignoreStream(tier0Config, "ExpressAlignment")
 ignoreStream(tier0Config, "HLTMonitor")
 ignoreStream(tier0Config, "NanoDST")
-ignoreStream(tier0Config, "Physics")
-ignoreStream(tier0Config, "PhysicsMinimumBias0")
-ignoreStream(tier0Config, "PhysicsMinimumBias1")
-ignoreStream(tier0Config, "PhysicsMinimumBias2")
-ignoreStream(tier0Config, "PhysicsMinimumBias3")
-ignoreStream(tier0Config, "PhysicsMinimumBias4")
-ignoreStream(tier0Config, "PhysicsZeroBias0")
-ignoreStream(tier0Config, "PhysicsZeroBias1")
-ignoreStream(tier0Config, "PhysicsZeroBias2")
-ignoreStream(tier0Config, "PhysicsZeroBias3")
-ignoreStream(tier0Config, "PhysicsZeroBias4")
-ignoreStream(tier0Config, "PhysicsZeroBias5")
-ignoreStream(tier0Config, "PhysicsZeroBias6")
-ignoreStream(tier0Config, "PhysicsZeroBias7")
-ignoreStream(tier0Config, "PhysicsZeroBias8")
-ignoreStream(tier0Config, "PhysicsZeroBias9")
+ignoreStream(tier0Config, "ParkingBPH1")
+ignoreStream(tier0Config, "ParkingBPH2")
+ignoreStream(tier0Config, "ParkingBPH3")
+ignoreStream(tier0Config, "ParkingBPH4")
+ignoreStream(tier0Config, "ParkingBPH5")
+ignoreStream(tier0Config, "PhysicsCommissioning")
+ignoreStream(tier0Config, "PhysicsEGamma")
+ignoreStream(tier0Config, "PhysicsHadronsTaus")
+ignoreStream(tier0Config, "PhysicsMuons")
+ignoreStream(tier0Config, "PhysicsScoutingMonitor")
 ignoreStream(tier0Config, "RPCMON")
+ignoreStream(tier0Config, "ScoutingCaloMuon")
 ignoreStream(tier0Config, "ScoutingPF")
+
 
 ###################################
 ### currently inactive settings ###


### PR DESCRIPTION
# Replay Request

**Requestor**  

AlCaDB

**Describe the configuration**  
* Release: CMSSW_12_4_1
* Run: ~352929~, then 324841
* GTs:
   * expressGlobalTag: ~124X_dataRun3_Express_v3~, then 124X_dataRun3_Express_TIER0_REPLAY_Run2_v1
   * promptrecoGlobalTag: ~124X_dataRun3_Prompt_v3~, then 124X_dataRun3_Prompt_TIER0_REPLAY_Run2_v1
   * alcap0GlobalTag: ~124X_dataRun3_Prompt_v3~, then 124X_dataRun3_Prompt_TIER0_REPLAY_Run2_v1
* Additional changes: Add new high granularity (HG) Tracker Alignment PCL (`PromptCalibProdSiPixelAliHG`) to the rest of express

**Purpose of the test**  

Test HG Tracker Alignment PCL

**T0 Operations cmsTalk thread**  
If necessary, provide a link to the cmsTalk thread announcing the test to the relevant groups. 
[Tier0 Operations cmsTalk Forum](https://cms-talk.web.cern.ch/c/offcomp/compops/tier0/210?)
