### PR TITLE
Use deployment ID as processing version

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -120,7 +120,7 @@ alcaLumiPixelsScenario = "AlCaLumiPixels_Run3"
 hiTestppScenario = "ppEra_Run3"
 
 # Procesing version number replays
-dt = 434
+dt = int(open("DeploymentID.txt","r").read())
 defaultProcVersion = dt
 expressProcVersion = dt
 alcarawProcVersion = dt

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -120,7 +120,7 @@ alcaLumiPixelsScenario = "AlCaLumiPixels_Run3"
 hiTestppScenario = "ppEra_Run3"
 
 # Procesing version number replays
-dt = int(open("DeploymentID.txt","r").read())
+dt = int(open("DeploymentID.txt","r").read()[4:-1])
 defaultProcVersion = dt
 expressProcVersion = dt
 alcarawProcVersion = dt

--- a/src/python/T0Component/Tier0Feeder/Tier0FeederPoller.py
+++ b/src/python/T0Component/Tier0Feeder/Tier0FeederPoller.py
@@ -111,6 +111,7 @@ class Tier0FeederPoller(BaseWorkerThread):
             if self.deployID == 0:
                 self.deployID = int(datetime.datetime.now().strftime("%y%m%d%H%M%S"))
                 SetDeploymentIdDAO.execute(self.deployID)
+                open("DeploymentID.txt","a").write("%d" % self.deployID)
 
         except:
             logging.exception("Something went wrong with setting deployment ID")


### PR DESCRIPTION
This PR need to be deployed alongside #4690. Otherwise, workflow names will likely be too long for DBS.
