### PR TITLE
Replay testing CMSSW_12_4_2

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -158,7 +158,7 @@ repackVersionOverride = {
     "CMSSW_11_3_2" : defaultCMSSWVersion['default'],
     "CMSSW_11_3_3" : defaultCMSSWVersion['default'],
     "CMSSW_11_3_4" : defaultCMSSWVersion['default'],
-    "CMSSW_12_0_0" : defaultCMSSWVersion['default'], produces
+    "CMSSW_12_0_0" : defaultCMSSWVersion['default'],
     "CMSSW_12_0_1" : defaultCMSSWVersion['default'],
     "CMSSW_12_0_2" : defaultCMSSWVersion['default'],
     "CMSSW_12_0_2_patch1" : defaultCMSSWVersion['default'],


### PR DESCRIPTION
# Replay Request

**Requestor**  
ORM

**Describe the configuration**  
* Release: CMSSW_12_4_2
* Run: 352929
* GTs:
   * expressGlobalTag: 124X_dataRun3_Express_v3
   * promptrecoGlobalTag: 124X_dataRun3_Prompt_v3
   * alcap0GlobalTag: 124X_dataRun3_Prompt_v3
* Additional changes:

**Purpose of the test**  
Test configuration for use in production

**T0 Operations cmsTalk thread**  
We'll create the ticket once the replay starts
[Tier0 Operations cmsTalk Forum](https://cms-talk.web.cern.ch/c/offcomp/compops/tier0/210?)
