### PR TITLE
test CMSSW_12_3_7_patch1

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -35,7 +35,7 @@ setConfigVersion(tier0Config, "replace with real version")
 # 352929 - 2022 pp with tracker
 # 353737 - 2022 circulating
 # 353739 - 2022 cosmics
-setInjectRuns(tier0Config, [352929,353737,353739])
+setInjectRuns(tier0Config, [352929])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"
@@ -102,7 +102,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_12_3_7"
+    'default': "CMSSW_12_3_7_patch1"
 }
 
 # Configure ScramArch
@@ -179,7 +179,8 @@ repackVersionOverride = {
     "CMSSW_12_3_4_patch2" : defaultCMSSWVersion['default'],
     "CMSSW_12_3_5" : defaultCMSSWVersion['default'],
     "CMSSW_12_3_5_patch1" : defaultCMSSWVersion['default'],
-    "CMSSW_12_3_6" : defaultCMSSWVersion['default']
+    "CMSSW_12_3_6" : defaultCMSSWVersion['default'],
+    "CMSSW_12_3_7" : defaultCMSSWVersion['default']
     }
 
 expressVersionOverride = {
@@ -216,7 +217,8 @@ expressVersionOverride = {
     "CMSSW_12_3_4_patch2" : defaultCMSSWVersion['default'],
     "CMSSW_12_3_5" : defaultCMSSWVersion['default'],
     "CMSSW_12_3_5_patch1" : defaultCMSSWVersion['default'],
-    "CMSSW_12_3_6" : defaultCMSSWVersion['default']
+    "CMSSW_12_3_6" : defaultCMSSWVersion['default'],
+    "CMSSW_12_3_7" : defaultCMSSWVersion['default']
     }
 
 #set default repack settings for bulk streams


### PR DESCRIPTION
# Replay Request

**Requestor**  
Giovanni Petrucciani (ORM) on request from Sal Rappoccio (PPD) on request from GEMs and CTPPS

**Describe the configuration**  
* Release:  [CMSSW_12_3_7_patch1](https://github.com/cms-sw/cmssw/releases/CMSSW_12_3_7_patch1)
* Run: [355205](https://cmsoms.cern.ch/cms/runs/report?cms_run=355205&cms_run_sequence=GLOBAL-RUN)
* GTs: _same as currently being used_
   * expressGlobalTag:  `123X_dataRun3_Express_v10`
   * promptrecoGlobalTag: `123X_dataRun3_Prompt_v12`
   * alcap0GlobalTag: `123X_dataRun3_Prompt_v12`
* Additional changes: none

**Purpose of the test**  
Requested to fix an config issue tath causes GEM rechits to be missing in the event content (and possibly CTPPS as well), corresponding to the fix from the CMSSW PR https://github.com/cms-sw/cmssw/pull/38622

**T0 Operations cmsTalk thread**  
No cms-talk thread yet, it was discussed only on the mattermost https://mattermost.web.cern.ch/cms-exp/channels/orm--t0
