### PR TITLE
Increase TaskArchiver delay to 24 hours (replays)

### DIFF
--- a/bin/00_deploy_replay.sh
+++ b/bin/00_deploy_replay.sh
@@ -166,7 +166,6 @@ echo 'config.TaskArchiver.logLevel = "DEBUG"' >> ./config/tier0/config.py
 # Workflow archive delay
 #
 #echo 'config.TaskArchiver.archiveDelayHours = 1' >> ./config/tier0/config.py
-sed -i "s+config.TaskArchiver.archiveDelayHours = 24+config.TaskArchiver.archiveDelayHours = 24+" ./config/tier0/config.py
 
 #
 # Do not use WorkQueue

--- a/bin/00_deploy_replay.sh
+++ b/bin/00_deploy_replay.sh
@@ -166,7 +166,7 @@ echo 'config.TaskArchiver.logLevel = "DEBUG"' >> ./config/tier0/config.py
 # Workflow archive delay
 #
 #echo 'config.TaskArchiver.archiveDelayHours = 1' >> ./config/tier0/config.py
-sed -i "s+config.TaskArchiver.archiveDelayHours = 24+config.TaskArchiver.archiveDelayHours = 1+" ./config/tier0/config.py
+sed -i "s+config.TaskArchiver.archiveDelayHours = 24+config.TaskArchiver.archiveDelayHours = 24+" ./config/tier0/config.py
 
 #
 # Do not use WorkQueue


### PR DESCRIPTION
Increase TaskArchiver delay for replays from 1 to 24 hours, to keep the completed WFs in the database for further checking/diagnosis. This need to be increased after the reduction of the closing block delay.