### PR TITLE
Replay configuration for CMSSW_12_4_4

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -36,7 +36,7 @@ setConfigVersion(tier0Config, "replace with real version")
 # 355189 - 2022 cosmics
 # 355559 - 2022 pp at 13.6 TeV (1h long, 300 bunches)
 # 356005 - 2022 pp at 13.5 TeV (1h long, 600 bunches)
-setInjectRuns(tier0Config, [356005])
+setInjectRuns(tier0Config, [356005, 356069])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"
@@ -103,7 +103,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_12_4_3"
+    'default': "CMSSW_12_4_4"
 }
 
 # Configure ScramArch
@@ -157,7 +157,8 @@ repackVersionOverride = {
     "CMSSW_12_3_5_patch1" : defaultCMSSWVersion['default'],
     "CMSSW_12_3_6" : defaultCMSSWVersion['default'],
     "CMSSW_12_3_7" : defaultCMSSWVersion['default'],
-    "CMSSW_12_3_7_patch1" : defaultCMSSWVersion['default']
+    "CMSSW_12_3_7_patch1" : defaultCMSSWVersion['default'],
+    "CMSSW_12_4_4" : defaultCMSSWVersion['default']
     }
 
 expressVersionOverride = {
@@ -171,7 +172,8 @@ expressVersionOverride = {
     "CMSSW_12_3_5_patch1" : defaultCMSSWVersion['default'],
     "CMSSW_12_3_6" : defaultCMSSWVersion['default'],
     "CMSSW_12_3_7" : defaultCMSSWVersion['default'],
-    "CMSSW_12_3_7_patch1" : defaultCMSSWVersion['default']
+    "CMSSW_12_3_7_patch1" : defaultCMSSWVersion['default'],
+    "CMSSW_12_4_4" : defaultCMSSWVersion['default']
     }
 
 #set default repack settings for bulk streams
@@ -491,7 +493,7 @@ for dataset in DATASETS:
                dqm_sequences=["@common"],
                tape_node="T1_FR_CCIN2P3_MSS",
                disk_node="T1_FR_CCIN2P3_Disk",
-               physics_skims=["EXODisplacedJet", "EXODelayedJet", "EXODTCluster", "LogError", "LogErrorMonitor"],
+               physics_skims=["EXODisplacedJet", "EXODelayedJet", "EXODTCluster", "LogError", "LogErrorMonitor", "EXOCSCCluster"],
                # EXOCSCCluster needs to be added when 12_4_4 is introduced
                scenario=ppScenario)
 

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -158,7 +158,7 @@ repackVersionOverride = {
     "CMSSW_12_3_6" : defaultCMSSWVersion['default'],
     "CMSSW_12_3_7" : defaultCMSSWVersion['default'],
     "CMSSW_12_3_7_patch1" : defaultCMSSWVersion['default'],
-    "CMSSW_12_4_4" : defaultCMSSWVersion['default']
+    "CMSSW_12_4_3" : defaultCMSSWVersion['default']
     }
 
 expressVersionOverride = {
@@ -172,8 +172,8 @@ expressVersionOverride = {
     "CMSSW_12_3_5_patch1" : defaultCMSSWVersion['default'],
     "CMSSW_12_3_6" : defaultCMSSWVersion['default'],
     "CMSSW_12_3_7" : defaultCMSSWVersion['default'],
-    "CMSSW_12_3_7_patch1" : defaultCMSSWVersion['default'],
-    "CMSSW_12_4_4" : defaultCMSSWVersion['default']
+    "CMSSW_12_3_7_patch1" : defaultCMSSWVersion['default']
+    "CMSSW_12_4_3" : defaultCMSSWVersion['default']
     }
 
 #set default repack settings for bulk streams

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -172,7 +172,7 @@ expressVersionOverride = {
     "CMSSW_12_3_5_patch1" : defaultCMSSWVersion['default'],
     "CMSSW_12_3_6" : defaultCMSSWVersion['default'],
     "CMSSW_12_3_7" : defaultCMSSWVersion['default'],
-    "CMSSW_12_3_7_patch1" : defaultCMSSWVersion['default']
+    "CMSSW_12_3_7_patch1" : defaultCMSSWVersion['default'],
     "CMSSW_12_4_3" : defaultCMSSWVersion['default']
     }
 


### PR DESCRIPTION
# Replay Request

**Requestor**  
ORM

**Describe the configuration**  
* Release: CMSSW_12_4_4
* Run: 356005, 356069
* GTs:
   * expressGlobalTag: 124X_dataRun3_Express_v4
   * promptrecoGlobalTag: 124X_dataRun3_Prompt_v4
   * alcap0GlobalTag: 124X_dataRun3_Prompt_v4
* Additional changes: EXOCSCCluster added to physics_skim when 12_4_4 is introduced

**Purpose of the test**  
Testing for new release CMSSW_12_4_4 and Global Tag changes

