### PR TITLE
Add raise conditions when run/stream can't be configured

### DIFF
--- a/bin/00_patches.sh
+++ b/bin/00_patches.sh
@@ -15,4 +15,5 @@ DEPLOY_DIR=$BASE_DIR/srv/wmagent
 #wget -nv https://github.com/dmwm/T0/pull/4596.patch -O - | patch -f -d $DEPLOY_DIR/current/apps/t0/lib/python*/site-packages/ -p 3
 #wget -nv https://github.com/dmwm/T0/pull/4597.patch -O - | patch -f -d $DEPLOY_DIR/current/apps/t0/lib/python*/site-packages/ -p 3
 
-#Patches on top of 3.0.1
+#Patches on top of 3.0.5
+wget -nv https://github.com/dmwm/T0/pull/4729.patch -O - | patch -f -d $DEPLOY_DIR/current/apps/t0/lib/python*/site-packages/ -p 3

--- a/src/python/T0Component/Tier0Feeder/Tier0FeederPoller.py
+++ b/src/python/T0Component/Tier0Feeder/Tier0FeederPoller.py
@@ -207,6 +207,7 @@ class Tier0FeederPoller(BaseWorkerThread):
                     RunConfigAPI.configureRun(tier0Config, run, hltConfig)
                 except:
                     logging.exception("Can't configure for run %d" % (run))
+                    raise
 
             #
             # find unconfigured run/stream with data
@@ -222,6 +223,7 @@ class Tier0FeederPoller(BaseWorkerThread):
                                                         self.dqmUploadProxy)
                     except:
                         logging.exception("Can't configure for run %d and stream %s" % (run, stream))
+                        raise
 
         #
         # stop and close runs based on RunSummary and StorageManager records


### PR DESCRIPTION
Added 2 raise conditions when a run and/or stream can't be configured. Such errors are severe and should be spotted by the T0 team. These raise conditions will shut down the T0Feeder component.

It follows from the discussion here: https://its.cern.ch/jira/projects/CMSTZ/issues/CMSTZ-995.