### PR TITLE
Replay for PPS Sampic PCL workflow and Prompt ALCARECO

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -104,7 +104,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_12_4_5"
+    'default': "CMSSW_12_4_6"
 }
 
 # Configure ScramArch
@@ -160,7 +160,8 @@ repackVersionOverride = {
     "CMSSW_12_3_7" : defaultCMSSWVersion['default'],
     "CMSSW_12_3_7_patch1" : defaultCMSSWVersion['default'],
     "CMSSW_12_4_3" : defaultCMSSWVersion['default'],
-    "CMSSW_12_4_4" : defaultCMSSWVersion['default']
+    "CMSSW_12_4_4" : defaultCMSSWVersion['default'],
+    "CMSSW_12_4_5" : defaultCMSSWVersion['default']
     }
 
 expressVersionOverride = {
@@ -176,7 +177,8 @@ expressVersionOverride = {
     "CMSSW_12_3_7" : defaultCMSSWVersion['default'],
     "CMSSW_12_3_7_patch1" : defaultCMSSWVersion['default'],
     "CMSSW_12_4_3" : defaultCMSSWVersion['default'],
-    "CMSSW_12_4_4" : defaultCMSSWVersion['default']
+    "CMSSW_12_4_4" : defaultCMSSWVersion['default'],
+    "CMSSW_12_4_5" : defaultCMSSWVersion['default']
     }
 
 #set default repack settings for bulk streams

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -35,8 +35,9 @@ setConfigVersion(tier0Config, "replace with real version")
 # 352929 - 2022 pp at 900 GeV
 # 355189 - 2022 cosmics
 # 355559 - 2022 pp at 13.6 TeV (1h long, 300 bunches)
-# 356005 - 2022 pp at 13.5 TeV (1h long, 600 bunches)
-setInjectRuns(tier0Config, [356005, 356069])
+# 356005 - 2022 pp at 13.6 TeV (1h long, 600 bunches)
+# 356433 - 2022 pp at 13.6 TeV (2h long, 1200 bunches, HLT menu v1.3)
+setInjectRuns(tier0Config, [356433])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"
@@ -118,7 +119,7 @@ hiScenario = "ppEra_Run3"
 alcaTrackingOnlyScenario = "trackingOnlyEra_Run3"
 alcaTestEnableScenario = "AlCaTestEnable"
 alcaLumiPixelsScenario = "AlCaLumiPixels_Run3"
-alcaPPSScenario = "AlCaLumiPixels_Run3"
+alcaPPSScenario = "AlCaPPS_Run3"
 hiTestppScenario = "ppEra_Run3"
 
 # Procesing version number replays
@@ -380,7 +381,9 @@ addExpressConfig(tier0Config, "ALCAPPSExpress",
                  dqm_sequences=["@none"],
                  write_dqm=True,
                  do_reco=False,
-                 alca_producers=["PPSCalMaxTracks", "PromptCalibProdPPSTimingCalib", "PromptCalibProdPPSAlignment"],
+                 alca_producers=["PPSCalMaxTracks", "PromptCalibProdPPSTimingCalib", "PromptCalibProdPPSAlignment",
+                                 "PromptCalibProdPPSDiamondSampic"
+                                ],
                  reco_version=defaultCMSSWVersion,
                  multicore=numberOfCores,
                  global_tag_connect=globalTagConnect,
@@ -1349,7 +1352,8 @@ DATASETS = ["AlCaPPSPrompt"]
 
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,
-               do_reco=False,
+               do_reco=True,
+               write_reco=False, write_aod=False, write_miniaod=False,
                write_dqm=True,
                alca_producers=["PPSCalMaxTracks"],
                dqm_sequences=["@none"],
@@ -1641,6 +1645,43 @@ ignoreStream(tier0Config, "DQMOffline")
 ignoreStream(tier0Config, "streamHLTRates")
 ignoreStream(tier0Config, "streamL1Rates")
 ignoreStream(tier0Config, "streamDQMRates")
+
+# Ingore following streams only for this replay
+ignoreStream(tier0Config, "ALCALowPtJet")
+ignoreStream(tier0Config, "ALCALumiPixelsCountsExpress")
+ignoreStream(tier0Config, "ALCALumiPixelsCountsPrompt")
+ignoreStream(tier0Config, "ALCAP0")
+ignoreStream(tier0Config, "ALCAPHISYM")
+ignoreStream(tier0Config, "Calibration")
+ignoreStream(tier0Config, "Express")
+ignoreStream(tier0Config, "ExpressAlignment")
+ignoreStream(tier0Config, "HLTMonitor")
+ignoreStream(tier0Config, "NanoDST")
+ignoreStream(tier0Config, "ParkingDoubleElectronLowMass0")
+ignoreStream(tier0Config, "ParkingDoubleElectronLowMass1")
+ignoreStream(tier0Config, "ParkingDoubleElectronLowMass2")
+ignoreStream(tier0Config, "ParkingDoubleMuonLowMass0")
+ignoreStream(tier0Config, "ParkingDoubleMuonLowMass1")
+ignoreStream(tier0Config, "ParkingDoubleMuonLowMass2")
+ignoreStream(tier0Config, "ParkingDoubleMuonLowMass3")
+ignoreStream(tier0Config, "ParkingSingleMuon")
+ignoreStream(tier0Config, "PhysicsCommissioning")
+ignoreStream(tier0Config, "PhysicsEGamma")
+ignoreStream(tier0Config, "PhysicsHLTPhysics0")
+ignoreStream(tier0Config, "PhysicsHLTPhysics1")
+ignoreStream(tier0Config, "PhysicsHLTPhysics2")
+ignoreStream(tier0Config, "PhysicsHLTPhysics3")
+ignoreStream(tier0Config, "PhysicsHLTPhysics4")
+ignoreStream(tier0Config, "PhysicsHLTPhysics5")
+ignoreStream(tier0Config, "PhysicsHLTPhysics6")
+ignoreStream(tier0Config, "PhysicsHLTPhysics7")
+ignoreStream(tier0Config, "PhysicsHLTPhysics8")
+ignoreStream(tier0Config, "PhysicsHLTPhysics9")
+ignoreStream(tier0Config, "PhysicsHadronsTaus")
+ignoreStream(tier0Config, "PhysicsMuons")
+ignoreStream(tier0Config, "PhysicsScoutingPFMonitor")
+ignoreStream(tier0Config, "RPCMON")
+ignoreStream(tier0Config, "ScoutingPF")
 
 ###################################
 ### currently inactive settings ###

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -104,7 +104,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_12_4_4"
+    'default': "CMSSW_12_4_5"
 }
 
 # Configure ScramArch
@@ -159,7 +159,8 @@ repackVersionOverride = {
     "CMSSW_12_3_6" : defaultCMSSWVersion['default'],
     "CMSSW_12_3_7" : defaultCMSSWVersion['default'],
     "CMSSW_12_3_7_patch1" : defaultCMSSWVersion['default'],
-    "CMSSW_12_4_3" : defaultCMSSWVersion['default']
+    "CMSSW_12_4_3" : defaultCMSSWVersion['default'],
+    "CMSSW_12_4_4" : defaultCMSSWVersion['default']
     }
 
 expressVersionOverride = {
@@ -174,7 +175,8 @@ expressVersionOverride = {
     "CMSSW_12_3_6" : defaultCMSSWVersion['default'],
     "CMSSW_12_3_7" : defaultCMSSWVersion['default'],
     "CMSSW_12_3_7_patch1" : defaultCMSSWVersion['default'],
-    "CMSSW_12_4_3" : defaultCMSSWVersion['default']
+    "CMSSW_12_4_3" : defaultCMSSWVersion['default'],
+    "CMSSW_12_4_4" : defaultCMSSWVersion['default']
     }
 
 #set default repack settings for bulk streams

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -129,7 +129,7 @@ expressProcVersion = dt
 alcarawProcVersion = dt
 
 # Defaults for GlobalTag
-expressGlobalTag = "124X_dataRun3_Express_v4"
+expressGlobalTag = "124X_dataRun3_Express_Candidate_2022_08_05_17_14_24"
 promptrecoGlobalTag = "124X_dataRun3_Prompt_v4"
 alcap0GlobalTag = "124X_dataRun3_Prompt_v4"
 


### PR DESCRIPTION
# Replay Request

**Requestor**  
Francesco Brivio for AlCaDB/PPS

**Describe the configuration**  
* Release: ~CMSSW_12_4_4~ ~CMSSW_12_4_5~ CMSSW_12_4_6
* Run: 356433
* GTs:
   * expressGlobalTag: ~124X_dataRun3_Express_v4~ 124X_dataRun3_Express_Candidate_2022_08_05_17_14_24
   * promptrecoGlobalTag: 124X_dataRun3_Prompt_v4
   * alcap0GlobalTag: 124X_dataRun3_Prompt_v4
* Additional changes:
   * Set the `alcaPPSScenario` to be `"AlCaPPS_Run3"`
   * Added the PPS PCL workflow `PromptCalibProdPPSDiamondSampic`
   * Set the options `do_reco=True, write_reco=False, write_aod=False, write_miniaod=False` for the `AlCaPPSPrompt` dataset in order to produce as output only RAW and the `PPSCalMaxTracks` ALCARECO at Prompt level
   * Ignored all streams except `ALCAPPSExpress` and `ALCAPPSPrompt`

**Purpose of the test**  
Now that with the hlt menu v1.3 we have two different PPS streams for Express and Prompt we want to test the full PPS chain, including PCL and RAW/Prompt-reco.

**T0 Operations cmsTalk thread**  
N/A

FYI @malbouis @tvami @saumyaphor4252 @vavati