### PR TITLE
Replay test of CMSSW_12_4_5_patch1

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -103,7 +103,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_12_4_5"
+    'default': "CMSSW_12_4_5_patch1"
 }
 
 # Configure ScramArch
@@ -159,7 +159,8 @@ repackVersionOverride = {
     "CMSSW_12_3_7" : defaultCMSSWVersion['default'],
     "CMSSW_12_3_7_patch1" : defaultCMSSWVersion['default'],
     "CMSSW_12_4_3" : defaultCMSSWVersion['default'],
-    "CMSSW_12_4_4" : defaultCMSSWVersion['default']
+    "CMSSW_12_4_4" : defaultCMSSWVersion['default'],
+    "CMSSW_12_4_5" : defaultCMSSWVersion['default']
     }
 
 expressVersionOverride = {
@@ -175,7 +176,8 @@ expressVersionOverride = {
     "CMSSW_12_3_7" : defaultCMSSWVersion['default'],
     "CMSSW_12_3_7_patch1" : defaultCMSSWVersion['default'],
     "CMSSW_12_4_3" : defaultCMSSWVersion['default'],
-    "CMSSW_12_4_4" : defaultCMSSWVersion['default']
+    "CMSSW_12_4_4" : defaultCMSSWVersion['default'],
+    "CMSSW_12_4_5" : defaultCMSSWVersion['default']
     }
 
 #set default repack settings for bulk streams


### PR DESCRIPTION
# Replay Request

**Requestor**  
ORM

**Describe the configuration**  
* Release: CMSSW_12_4_5_patch1
* Run: 356433
* GTs:
   * expressGlobalTag: 124X_dataRun3_Express_v4
   * promptrecoGlobalTag: 124X_dataRun3_Prompt_v4
   * alcap0GlobalTag: 124X_dataRun3_Prompt_v4
* Additional changes:

**Purpose of the test**  
CMSSW_12_4_5_patch1 meant for HLT, T0 do not strictly need to updated, but testing to be prepared

**T0 Operations cmsTalk thread**
https://cms-talk.web.cern.ch/t/replay-testing-cmssw-12-4-5-patch1/13687