### PR TITLE
Prodoffline config to reprocess run 356719 only for ParkingSingleMuon1

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -25,6 +25,7 @@ from T0.RunConfig.Tier0Config import setInjectMaxRun
 from T0.RunConfig.Tier0Config import setStreamerPNN
 from T0.RunConfig.Tier0Config import addSiteConfig
 from T0.RunConfig.Tier0Config import setStorageSite
+from T0.RunConfig.Tier0Config import setInjectRuns
 
 # Create the Tier0 configuration object
 tier0Config = createTier0Config()
@@ -33,11 +34,13 @@ tier0Config = createTier0Config()
 setConfigVersion(tier0Config, "replace with real version")
 
 # Set the min run number:
-setInjectMinRun(tier0Config, 355794)
+#setInjectMinRun(tier0Config, 355794)
 
 # Set the max run number:
-setInjectMaxRun(tier0Config, 9999999)
+#setInjectMaxRun(tier0Config, 9999999)
 
+# Reprocess Run
+setInjectRuns(tier0Config, [356719])
 # Settings up sites
 processingSite = "T2_CH_CERN"
 storageSite = "T0_CH_CERN_Disk"
@@ -1705,6 +1708,46 @@ ignoreStream(tier0Config, "DQMOffline")
 ignoreStream(tier0Config, "streamHLTRates")
 ignoreStream(tier0Config, "streamL1Rates")
 ignoreStream(tier0Config, "streamDQMRates")
+
+# Ignored Streams for this reprocessing
+ignoreStream(tier0Config, "ALCALowPtJet")
+ignoreStream(tier0Config, "ALCALumiPixelsCountsExpress")
+ignoreStream(tier0Config, "ALCALumiPixelsCountsPrompt")
+ignoreStream(tier0Config, "ALCAP0")
+ignoreStream(tier0Config, "ALCAPHISYM")
+ignoreStream(tier0Config, "ALCAPPSExpress")
+ignoreStream(tier0Config, "ALCAPPSPrompt")
+ignoreStream(tier0Config, "Calibration")
+ignoreStream(tier0Config, "Express")
+ignoreStream(tier0Config, "ExpressAlignment")
+ignoreStream(tier0Config, "HLTMonitor")
+ignoreStream(tier0Config, "NanoDST")
+ignoreStream(tier0Config, "ParkingDoubleElectronLowMass0")
+ignoreStream(tier0Config, "ParkingDoubleElectronLowMass1")
+ignoreStream(tier0Config, "ParkingDoubleElectronLowMass2")
+ignoreStream(tier0Config, "ParkingDoubleMuonLowMass0")
+ignoreStream(tier0Config, "ParkingDoubleMuonLowMass1")
+ignoreStream(tier0Config, "ParkingDoubleMuonLowMass2")
+ignoreStream(tier0Config, "ParkingDoubleMuonLowMass3")
+ignoreStream(tier0Config, "ParkingSingleMuon0")
+ignoreStream(tier0Config, "ParkingSingleMuon2")
+ignoreStream(tier0Config, "PhysicsCommissioning")
+ignoreStream(tier0Config, "PhysicsEGamma")
+ignoreStream(tier0Config, "PhysicsHadronsTaus")
+ignoreStream(tier0Config, "PhysicsHLTPhysics0")
+ignoreStream(tier0Config, "PhysicsHLTPhysics1")
+ignoreStream(tier0Config, "PhysicsHLTPhysics2")
+ignoreStream(tier0Config, "PhysicsHLTPhysics3")
+ignoreStream(tier0Config, "PhysicsHLTPhysics4")
+ignoreStream(tier0Config, "PhysicsHLTPhysics5")
+ignoreStream(tier0Config, "PhysicsHLTPhysics6")
+ignoreStream(tier0Config, "PhysicsHLTPhysics7")
+ignoreStream(tier0Config, "PhysicsHLTPhysics8")
+ignoreStream(tier0Config, "PhysicsHLTPhysics9")
+ignoreStream(tier0Config, "PhysicsMuons")
+ignoreStream(tier0Config, "PhysicsScoutingPFMonitor")
+ignoreStream(tier0Config, "RPCMON")
+ignoreStream(tier0Config, "ScoutingPF")
 
 ###################################
 ### currently inactive settings ###

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -36,7 +36,7 @@ setConfigVersion(tier0Config, "replace with real version")
 # 355189 - 2022 cosmics
 # 355559 - 2022 pp at 13.6 TeV (1h long, 300 bunches)
 # 356005 - 2022 pp at 13.5 TeV (1h long, 600 bunches)
-setInjectRuns(tier0Config, [356433])
+setInjectRuns(tier0Config, [356719])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"
@@ -535,7 +535,7 @@ DATASETS = ["ParkingSingleMuon","ParkingSingleMuon0","ParkingSingleMuon1","Parki
 
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,
-               do_reco=False,
+               do_reco=True,
                scenario=ppScenario)
 
 DATASETS = ["ParkingDoubleMuonLowMass0","ParkingDoubleMuonLowMass1","ParkingDoubleMuonLowMass2",
@@ -1643,6 +1643,46 @@ ignoreStream(tier0Config, "DQMOffline")
 ignoreStream(tier0Config, "streamHLTRates")
 ignoreStream(tier0Config, "streamL1Rates")
 ignoreStream(tier0Config, "streamDQMRates")
+
+# Ignored Streams for this reprocessing
+ignoreStream(tier0Config, "ALCALowPtJet")
+ignoreStream(tier0Config, "ALCALumiPixelsCountsExpress")
+ignoreStream(tier0Config, "ALCALumiPixelsCountsPrompt")
+ignoreStream(tier0Config, "ALCAP0")
+ignoreStream(tier0Config, "ALCAPHISYM")
+ignoreStream(tier0Config, "ALCAPPSExpress")
+ignoreStream(tier0Config, "ALCAPPSPrompt")
+ignoreStream(tier0Config, "Calibration")
+ignoreStream(tier0Config, "Express")
+ignoreStream(tier0Config, "ExpressAlignment")
+ignoreStream(tier0Config, "HLTMonitor")
+ignoreStream(tier0Config, "NanoDST")
+ignoreStream(tier0Config, "ParkingDoubleElectronLowMass0")
+ignoreStream(tier0Config, "ParkingDoubleElectronLowMass1")
+ignoreStream(tier0Config, "ParkingDoubleElectronLowMass2")
+ignoreStream(tier0Config, "ParkingDoubleMuonLowMass0")
+ignoreStream(tier0Config, "ParkingDoubleMuonLowMass1")
+ignoreStream(tier0Config, "ParkingDoubleMuonLowMass2")
+ignoreStream(tier0Config, "ParkingDoubleMuonLowMass3")
+ignoreStream(tier0Config, "ParkingSingleMuon0")
+ignoreStream(tier0Config, "ParkingSingleMuon2")
+ignoreStream(tier0Config, "PhysicsCommissioning")
+ignoreStream(tier0Config, "PhysicsEGamma")
+ignoreStream(tier0Config, "PhysicsHadronsTaus")
+ignoreStream(tier0Config, "PhysicsHLTPhysics0")
+ignoreStream(tier0Config, "PhysicsHLTPhysics1")
+ignoreStream(tier0Config, "PhysicsHLTPhysics2")
+ignoreStream(tier0Config, "PhysicsHLTPhysics3")
+ignoreStream(tier0Config, "PhysicsHLTPhysics4")
+ignoreStream(tier0Config, "PhysicsHLTPhysics5")
+ignoreStream(tier0Config, "PhysicsHLTPhysics6")
+ignoreStream(tier0Config, "PhysicsHLTPhysics7")
+ignoreStream(tier0Config, "PhysicsHLTPhysics8")
+ignoreStream(tier0Config, "PhysicsHLTPhysics9")
+ignoreStream(tier0Config, "PhysicsMuons")
+ignoreStream(tier0Config, "PhysicsScoutingPFMonitor")
+ignoreStream(tier0Config, "RPCMON")
+ignoreStream(tier0Config, "ScoutingPF")
 
 ###################################
 ### currently inactive settings ###


### PR DESCRIPTION
Properly tested with a replay. [GrafanaIDMonitoring](https://monit-grafana.cern.ch/d/t_jr45h7k/cms-tier0-replayid-monitoring?orgId=11&var-Bin=5m&var-ReplayID=220809014300&var-JobType=All&var-WorkflowType=All) 
The files to invalidate are in the following list.
`/afs/cern.ch/user/c/cmst0/public/Files2Invalidate/Run2022C_356719_ParkingSingleMuon1.txt`
Production vm for this reprocessing will be vocms0314
[CMSTalk](https://cms-talk.web.cern.ch/t/promptreco-crash-in-run-356719/13691) thread 
FYI @jeyserma 