### PR TITLE
Replay test of CMSSW_10_4_6

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -103,7 +103,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_12_4_5"
+    'default': "CMSSW_12_4_6"
 }
 
 # Configure ScramArch
@@ -159,7 +159,8 @@ repackVersionOverride = {
     "CMSSW_12_3_7" : defaultCMSSWVersion['default'],
     "CMSSW_12_3_7_patch1" : defaultCMSSWVersion['default'],
     "CMSSW_12_4_3" : defaultCMSSWVersion['default'],
-    "CMSSW_12_4_4" : defaultCMSSWVersion['default']
+    "CMSSW_12_4_4" : defaultCMSSWVersion['default'],
+    "CMSSW_12_4_5" : defaultCMSSWVersion['default']
     }
 
 expressVersionOverride = {
@@ -175,7 +176,8 @@ expressVersionOverride = {
     "CMSSW_12_3_7" : defaultCMSSWVersion['default'],
     "CMSSW_12_3_7_patch1" : defaultCMSSWVersion['default'],
     "CMSSW_12_4_3" : defaultCMSSWVersion['default'],
-    "CMSSW_12_4_4" : defaultCMSSWVersion['default']
+    "CMSSW_12_4_4" : defaultCMSSWVersion['default'],
+    "CMSSW_12_4_5" : defaultCMSSWVersion['default']
     }
 
 #set default repack settings for bulk streams


### PR DESCRIPTION
# Replay Request

**Requestor**  
ORM

**Describe the configuration**  
* Release: CMSSW_12_4_6
* Run: 356824
* GTs:
   * expressGlobalTag: 124X_dataRun3_Express_v4
   * promptrecoGlobalTag: 124X_dataRun3_Prompt_v4
   * alcap0GlobalTag: 124X_dataRun3_Prompt_v4
* Additional changes:

**Purpose of the test**  
This release contains the [fix](https://github.com/cms-sw/cmssw/pull/38989) to be deployed on HLT.

**T0 Operations cmsTalk thread**  
