### PR TITLE
Replay test of CMSSW_12_4_7

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -37,7 +37,8 @@ setConfigVersion(tier0Config, "replace with real version")
 # 355559 - 2022 pp at 13.6 TeV (1h long, 300 bunches)
 # 356005 - 2022 pp at 13.6 TeV (1h long, 600 bunches)
 # 356824 - 2022 pp at 13.6 TeV (30' long, 1900 bunches)
-setInjectRuns(tier0Config, [356824])
+# 356948 - 2022 pp at 13.6 TeV (30' long, 1900 bunches)
+setInjectRuns(tier0Config, [356824,356948])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -35,7 +35,8 @@ setConfigVersion(tier0Config, "replace with real version")
 # 352929 - 2022 pp at 900 GeV
 # 355189 - 2022 cosmics
 # 355559 - 2022 pp at 13.6 TeV (1h long, 300 bunches)
-# 356005 - 2022 pp at 13.5 TeV (1h long, 600 bunches)
+# 356005 - 2022 pp at 13.6 TeV (1h long, 600 bunches)
+# 356824 - 2022 pp at 13.6 TeV (30' long, 1900 bunches)
 setInjectRuns(tier0Config, [356824])
 
 # Settings up sites
@@ -103,7 +104,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_12_4_6"
+    'default': "CMSSW_12_4_7"
 }
 
 # Configure ScramArch
@@ -160,7 +161,8 @@ repackVersionOverride = {
     "CMSSW_12_3_7_patch1" : defaultCMSSWVersion['default'],
     "CMSSW_12_4_3" : defaultCMSSWVersion['default'],
     "CMSSW_12_4_4" : defaultCMSSWVersion['default'],
-    "CMSSW_12_4_5" : defaultCMSSWVersion['default']
+    "CMSSW_12_4_5" : defaultCMSSWVersion['default'],
+    "CMSSW_12_4_6" : defaultCMSSWVersion['default'],
     }
 
 expressVersionOverride = {
@@ -177,7 +179,8 @@ expressVersionOverride = {
     "CMSSW_12_3_7_patch1" : defaultCMSSWVersion['default'],
     "CMSSW_12_4_3" : defaultCMSSWVersion['default'],
     "CMSSW_12_4_4" : defaultCMSSWVersion['default'],
-    "CMSSW_12_4_5" : defaultCMSSWVersion['default']
+    "CMSSW_12_4_5" : defaultCMSSWVersion['default'],
+    "CMSSW_12_4_6" : defaultCMSSWVersion['default'],
     }
 
 #set default repack settings for bulk streams


### PR DESCRIPTION
# Replay Request

**Requestor**  
ORM 

**Describe the configuration**  
* Release: CMSSW_12_4_7
* Run: [356824](https://cmsoms.cern.ch/cms/runs/report?cms_run=356824), standard candle run used for previous replays (to cross-check e.g. output of PCL, etc.) [356948](https://cmsoms.cern.ch/cms/runs/report?cms_run=356948) to test solution failure of detailed at https://github.com/cms-sw/cmssw/issues/39026
* GTs:
   * expressGlobalTag: 124X_dataRun3_Express_v5
   * promptrecoGlobalTag: 124X_dataRun3_Prompt_v4
   * alcap0GlobalTag: 124X_dataRun3_Prompt_v4
* Additional changes:
None

**Purpose of the test**  
Test new release that includes bug fixes for the data taking, and some major updates for the local Tracker and for the Tracking code.

**T0 Operations cmsTalk thread**  

https://cms-talk.web.cern.ch/t/replay-testing-cmssw-12-4-7/14062