### PR TITLE
Add SpecialHLTPhysics* datasets

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -950,6 +950,14 @@ DATASETS = ["HLTPhysics", "HLTPhysics0", "HLTPhysics1",
             "HLTPhysics14", "HLTPhysics15", "HLTPhysics16",
             "HLTPhysics17", "HLTPhysics18", "HLTPhysics19"]
 
+DATASETS += ["SpecialHLTPhysics", "SpecialHLTPhysics0", "SpecialHLTPhysics1",
+            "SpecialHLTPhysics2", "SpecialHLTPhysics3", "SpecialHLTPhysics4",
+            "SpecialHLTPhysics5", "SpecialHLTPhysics6", "SpecialHLTPhysics7",
+            "SpecialHLTPhysics8", "SpecialHLTPhysics9", "SpecialHLTPhysics10",
+            "SpecialHLTPhysics11", "SpecialHLTPhysics12", "SpecialHLTPhysics13",
+            "SpecialHLTPhysics14", "SpecialHLTPhysics15", "SpecialHLTPhysics16",
+            "SpecialHLTPhysics17", "SpecialHLTPhysics18", "SpecialHLTPhysics19"]
+
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,
                do_reco=True,

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -912,6 +912,14 @@ DATASETS = ["HLTPhysics", "HLTPhysics0", "HLTPhysics1",
             "HLTPhysics14", "HLTPhysics15", "HLTPhysics16",
             "HLTPhysics17", "HLTPhysics18", "HLTPhysics19"]
 
+DATASETS += ["SpecialHLTPhysics", "SpecialHLTPhysics0", "SpecialHLTPhysics1",
+            "SpecialHLTPhysics2", "SpecialHLTPhysics3", "SpecialHLTPhysics4",
+            "SpecialHLTPhysics5", "SpecialHLTPhysics6", "SpecialHLTPhysics7",
+            "SpecialHLTPhysics8", "SpecialHLTPhysics9", "SpecialHLTPhysics10",
+            "SpecialHLTPhysics11", "SpecialHLTPhysics12", "SpecialHLTPhysics13",
+            "SpecialHLTPhysics14", "SpecialHLTPhysics15", "SpecialHLTPhysics16",
+            "SpecialHLTPhysics17", "SpecialHLTPhysics18", "SpecialHLTPhysics19"]
+
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,
                do_reco=True,


### PR DESCRIPTION
The datasets are added to handle the SpecialHLTPhysics menu, which will be used for tests like BSRT test,  the ECAL FullReadout, or the ECAL timing scan.

Requested by HLT in https://cms-talk.web.cern.ch/t/new-datasets-specialhltphysics-0-19/14187