### PR TITLE
Replay test for 12_4_8

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -38,7 +38,7 @@ setConfigVersion(tier0Config, "replace with real version")
 # 356005 - 2022 pp at 13.6 TeV (1h long, 600 bunches)
 # 356824 - 2022 pp at 13.6 TeV (30' long, 1900 bunches)
 # 356948 - 2022 pp at 13.6 TeV (30' long, 1900 bunches)
-setInjectRuns(tier0Config, [356824,356948])
+setInjectRuns(tier0Config, [356824])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -153,7 +153,7 @@ repackVersionOverride = {
     "CMSSW_12_4_3" : defaultCMSSWVersion['default'],
     "CMSSW_12_4_4" : defaultCMSSWVersion['default'],
     "CMSSW_12_4_5" : defaultCMSSWVersion['default'],
-    "CMSSW_12_4_6" : defaultCMSSWVersion['default']
+    "CMSSW_12_4_6" : defaultCMSSWVersion['default'],
     "CMSSW_12_4_7" : defaultCMSSWVersion['default']
     }
 
@@ -161,7 +161,7 @@ expressVersionOverride = {
     "CMSSW_12_4_3" : defaultCMSSWVersion['default'],
     "CMSSW_12_4_4" : defaultCMSSWVersion['default'],
     "CMSSW_12_4_5" : defaultCMSSWVersion['default'],
-    "CMSSW_12_4_6" : defaultCMSSWVersion['default']
+    "CMSSW_12_4_6" : defaultCMSSWVersion['default'],
     "CMSSW_12_4_7" : defaultCMSSWVersion['default']
     }
 

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -105,7 +105,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_12_4_7"
+    'default': "CMSSW_12_4_8"
 }
 
 # Configure ScramArch
@@ -154,6 +154,7 @@ repackVersionOverride = {
     "CMSSW_12_4_4" : defaultCMSSWVersion['default'],
     "CMSSW_12_4_5" : defaultCMSSWVersion['default'],
     "CMSSW_12_4_6" : defaultCMSSWVersion['default']
+    "CMSSW_12_4_7" : defaultCMSSWVersion['default']
     }
 
 expressVersionOverride = {
@@ -161,6 +162,7 @@ expressVersionOverride = {
     "CMSSW_12_4_4" : defaultCMSSWVersion['default'],
     "CMSSW_12_4_5" : defaultCMSSWVersion['default'],
     "CMSSW_12_4_6" : defaultCMSSWVersion['default']
+    "CMSSW_12_4_7" : defaultCMSSWVersion['default']
     }
 
 #set default repack settings for bulk streams


### PR DESCRIPTION
# Replay Request

**Requestor**  
ORM

**Describe the configuration**  
* Release: CMSSW_12_4_8
* Run: [356824](https://cmsoms.cern.ch/cms/runs/report?cms_run=356824), [356948](https://cmsoms.cern.ch/cms/runs/report?cms_run=356948) (same as for the [CMSSW_12_4_7 replay](https://github.com/dmwm/T0/pull/4745))
* GTs:
   * expressGlobalTag: 124X_dataRun3_Express_v5
   * promptrecoGlobalTag: 124X_dataRun3_Prompt_v4
   * alcap0GlobalTag: 124X_dataRun3_Prompt_v4
* Additional changes: None

**Purpose of the test**  
Test the new release that will be used for the ReReco of the first part of 2022 data and for data-taking, for which a few fixes are included.

**T0 Operations cmsTalk thread**  
https://cms-talk.web.cern.ch/t/replay-testing-for-cmssw-12-4-8/14321