### PR TITLE
Replay testing CMSSW_12_4_9

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -105,7 +105,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_12_4_8"
+    'default': "CMSSW_12_4_9"
 }
 
 # Configure ScramArch
@@ -154,7 +154,8 @@ repackVersionOverride = {
     "CMSSW_12_4_4" : defaultCMSSWVersion['default'],
     "CMSSW_12_4_5" : defaultCMSSWVersion['default'],
     "CMSSW_12_4_6" : defaultCMSSWVersion['default'],
-    "CMSSW_12_4_7" : defaultCMSSWVersion['default']
+    "CMSSW_12_4_7" : defaultCMSSWVersion['default'],
+    "CMSSW_12_4_8" : defaultCMSSWVersion['default']
     }
 
 expressVersionOverride = {
@@ -162,7 +163,8 @@ expressVersionOverride = {
     "CMSSW_12_4_4" : defaultCMSSWVersion['default'],
     "CMSSW_12_4_5" : defaultCMSSWVersion['default'],
     "CMSSW_12_4_6" : defaultCMSSWVersion['default'],
-    "CMSSW_12_4_7" : defaultCMSSWVersion['default']
+    "CMSSW_12_4_7" : defaultCMSSWVersion['default'],
+    "CMSSW_12_4_8" : defaultCMSSWVersion['default']
     }
 
 #set default repack settings for bulk streams

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -215,7 +215,7 @@ addExpressConfig(tier0Config, "Express",
                  data_tiers=["FEVT"],
                  write_dqm=True,
                  alca_producers=["SiStripPCLHistos", "SiStripCalZeroBias", "SiStripCalMinBias", "SiStripCalMinBiasAAG",
-                                 "TkAlMinBias", "SiPixelCalZeroBias", "SiPixelCalSingleMuon",
+                                 "TkAlMinBias", "SiPixelCalZeroBias", "SiPixelCalSingleMuon", "SiPixelCalSingleMuonTight",
                                  "PromptCalibProd", "PromptCalibProdSiStrip", "PromptCalibProdSiPixelAli",
                                  "PromptCalibProdSiStripGains", "PromptCalibProdSiStripGainsAAG", "PromptCalibProdSiPixel",
                                  "PromptCalibProdSiPixelLA", "PromptCalibProdSiStripHitEff", "PromptCalibProdSiPixelAliHG"


### PR DESCRIPTION
# Replay Request

**Requestor**  
ORM

**Describe the configuration**  
* Release: CMSSW_12_4_9
* Run: [356824](https://cmsoms.cern.ch/cms/runs/report?cms_run=356824)
* GTs:
   * expressGlobalTag: 124X_dataRun3_Express_v5
   * promptrecoGlobalTag: 124X_dataRun3_Prompt_v4
   * alcap0GlobalTag: 124X_dataRun3_Prompt_v4
* Additional changes:

**Purpose of the test**  
Test release to be used in Run2022E

**T0 Operations cmsTalk thread**  
https://cms-talk.web.cern.ch/t/replay-to-test-cmssw-12-4-9/15168
