### PR TITLE
Change era to Run2022E and release to CMSSW_12_4_9

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -55,7 +55,7 @@ addSiteConfig(tier0Config, "T0_CH_CERN_Disk",
 #  Data type
 #  Processing site (where jobs run)
 #  PhEDEx locations
-setAcquisitionEra(tier0Config, "Run2022D")
+setAcquisitionEra(tier0Config, "Run2022E")
 setBaseRequestPriority(tier0Config, 251000)
 setBackfill(tier0Config, None)
 setBulkDataType(tier0Config, "data")
@@ -94,7 +94,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_12_4_8"
+    'default': "CMSSW_12_4_9"
 }
 
 # Configure ScramArch
@@ -150,7 +150,8 @@ repackVersionOverride = {
     "CMSSW_12_4_4" : defaultCMSSWVersion['default'],
     "CMSSW_12_4_5" : defaultCMSSWVersion['default'],
     "CMSSW_12_4_6" : defaultCMSSWVersion['default'],
-    "CMSSW_12_4_7" : defaultCMSSWVersion['default']
+    "CMSSW_12_4_7" : defaultCMSSWVersion['default'],
+    "CMSSW_12_4_8" : defaultCMSSWVersion['default']
     }
 
 expressVersionOverride = {
@@ -158,7 +159,8 @@ expressVersionOverride = {
     "CMSSW_12_4_4" : defaultCMSSWVersion['default'],
     "CMSSW_12_4_5" : defaultCMSSWVersion['default'],
     "CMSSW_12_4_6" : defaultCMSSWVersion['default'],
-    "CMSSW_12_4_7" : defaultCMSSWVersion['default']
+    "CMSSW_12_4_7" : defaultCMSSWVersion['default'],
+    "CMSSW_12_4_8" : defaultCMSSWVersion['default']
     }
 
 #set default repack settings for bulk streams
@@ -209,7 +211,7 @@ addExpressConfig(tier0Config, "Express",
                  data_tiers=["FEVT"],
                  write_dqm=True,
                  alca_producers=["SiStripPCLHistos", "SiStripCalZeroBias", "SiStripCalMinBias", "SiStripCalMinBiasAAG",
-                                 "TkAlMinBias", "SiPixelCalZeroBias", "SiPixelCalSingleMuon",
+                                 "TkAlMinBias", "SiPixelCalZeroBias", "SiPixelCalSingleMuon", "SiPixelCalSingleMuonTight",
                                  "PromptCalibProd", "PromptCalibProdSiStrip", "PromptCalibProdSiPixelAli",
                                  "PromptCalibProdSiStripGains", "PromptCalibProdSiStripGainsAAG", "PromptCalibProdSiPixel",
                                  "PromptCalibProdSiPixelLA", "PromptCalibProdSiStripHitEff", "PromptCalibProdSiPixelAliHG"

--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -115,15 +115,15 @@ hiTestppScenario = "ppEra_Run3"
 # Defaults for processing version
 defaultProcVersionRAW = 1
 alcarawProcVersion = {
-    'default': "3"
+    'default': "1"
 }
 
 defaultProcVersionReco = {
-    'default': "3"
+    'default': "1"
 }
 
 expressProcVersion = {
-    'default': "3"
+    'default': "1"
 }
 
 # Defaults for GlobalTag


### PR DESCRIPTION
Update Production and Replay configuration to CMSSW_12_4_9 after successful replay in https://github.com/dmwm/T0/pull/4753
Adds `SiPixelCalSingleMuonTight` to Express configuration.

Change era to Run2022E