### PR TITLE
Add AlCaLumiPixelsCountsUngated dataset for VdM scans

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -907,6 +907,21 @@ for dataset in DATASETS:
                sizePerEvent=38,
                scenario=alcaLumiPixelsScenario)
 
+DATASETS = ["AlCaLumiPixelsCountsUngated"]
+
+for dataset in DATASETS:
+    addDataset(tier0Config, dataset,
+               do_reco=False,
+               write_reco=False, write_aod=False, write_miniaod=False, write_dqm=False,
+               disk_node=None,
+               tape_node=None,
+               reco_split=alcarawSplitting,
+               proc_version=alcarawProcVersion,
+               timePerEvent=0.02,
+               sizePerEvent=38,
+               scenario=alcaLumiPixelsScenario)
+
+
 DATASETS = ["AlCaPhiSym"]
 
 for dataset in DATASETS:

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -872,6 +872,20 @@ for dataset in DATASETS:
                sizePerEvent=38,
                scenario=alcaLumiPixelsScenario)
 
+DATASETS = ["AlCaLumiPixelsCountsUngated"]
+
+for dataset in DATASETS:
+    addDataset(tier0Config, dataset,
+               do_reco=False,
+               write_reco=False, write_aod=False, write_miniaod=False, write_dqm=False,
+               disk_node=None,
+               tape_node=None,
+               reco_split=alcarawSplitting,
+               proc_version=alcarawProcVersion,
+               timePerEvent=0.02,
+               sizePerEvent=38,
+               scenario=alcaLumiPixelsScenario)
+
 DATASETS = ["AlCaPhiSym"]
 
 for dataset in DATASETS:


### PR DESCRIPTION
**Requestor**  
Francesco Brivio for the LumiPOG

**Describe the configuration**  
* Release: unchanged from current prod
* Run: unchanged from current prod
* GTs:
   * expressGlobalTag: unchanged from current prod
   * promptrecoGlobalTag: unchanged from current prod
   * alcap0GlobalTag: unchanged from current prod
* Additional changes:
   * Added `AlCaLumiPixelsCountsUngated` dataset that will be produced during the upcoming VdM scans
      * Only RAW output will be produced

**Purpose of the test**  
This PR is intended to add the configuration for the `AlCaLumiPixelsCountsUngated` that will be produced during the upcoming VdM scans. No alca-producers or skims are added as only the RAW output dataset is expected.
This is a new dataset so there is no run to be used for a possible replay.
More details can be found in https://its.cern.ch/jira/browse/CMSHLT-2460.

**T0 Operations cmsTalk thread**  
https://cms-talk.web.cern.ch/t/add-configuration-for-alcalumipixelscountsungated-dataset/15328
