### PR TITLE
Keep ECAL and Lumi RAW on DISK

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -913,7 +913,8 @@ for dataset in DATASETS:
     addDataset(tier0Config, dataset,
                do_reco=False,
                write_reco=False, write_aod=False, write_miniaod=False, write_dqm=False,
-               disk_node=None,
+               raw_to_disk=True,
+               disk_node="T2_CH_CERN",
                tape_node=None,
                reco_split=alcarawSplitting,
                proc_version=alcarawProcVersion,
@@ -927,6 +928,8 @@ DATASETS = ["AlCaPhiSym"]
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,
                do_reco=False,
+               raw_to_disk=True,
+               disk_node="T2_CH_CERN",
                alca_producers=["EcalCalPhiSym"],
                scenario=ppScenario)
 
@@ -935,6 +938,8 @@ DATASETS = ["AlCaP0"]
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,
                do_reco=False,
+               raw_to_disk=True,
+               disk_node="T2_CH_CERN",
                alca_producers=["EcalCalPi0Calib", "EcalCalEtaCalib"],
                scenario=ppScenario)
 

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -124,7 +124,7 @@ hiTestppScenario = "ppEra_Run3"
 
 # Procesing version number replays
 # Taking Replay processing ID from the last 8 digits of the DeploymentID
-dt = int(open("DeploymentID.txt","r").read()[4:]) 
+dt = int(open("DeploymentID.txt","r").read()[4:])
 defaultProcVersion = dt
 expressProcVersion = dt
 alcarawProcVersion = dt


### PR DESCRIPTION
# Replay Request

**Requestor**  

AlCa on behalf of ECAL DPD and Lumi POG

**Describe the configuration**  
* Release: N/A
* Run: N/A
* GTs:
   * expressGlobalTag: N/A
   * promptrecoGlobalTag: N/A
   * alcap0GlobalTag: N/A
* Additional changes:

**Purpose of the test**  

Not really a test, more just a config change. ECAL + Lumi needs their RAW on DISK. 
Besides that I cleaned the unused PDs out of the config.

**T0 Operations cmsTalk thread**  

https://cms-talk.web.cern.ch/t/config-change-request-for-keeping-some-raw-on-disk/15635
