### PR TITLE
Add specifyStreams function

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -17,6 +17,7 @@ from T0.RunConfig.Tier0Config import setDQMUploadUrl
 from T0.RunConfig.Tier0Config import setPromptCalibrationConfig
 from T0.RunConfig.Tier0Config import setConfigVersion
 from T0.RunConfig.Tier0Config import ignoreStream
+from T0.RunConfig.Tier0Config import specifyStreams
 from T0.RunConfig.Tier0Config import addRepackConfig
 from T0.RunConfig.Tier0Config import addExpressConfig
 from T0.RunConfig.Tier0Config import setInjectRuns

--- a/src/python/T0/RunConfig/RunConfigAPI.py
+++ b/src/python/T0/RunConfig/RunConfigAPI.py
@@ -210,6 +210,9 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
 
         # consistency check to make sure stream exists and has datasets defined
         # only run if we don't ignore the stream
+        if tier0Config.Global.SpecifiedStreamNames!=None:
+            if(not stream in tier0Config.Global.SpecifiedStreamNames:
+                streamConfig.ProcessingStyle = "Ignore"
         if streamConfig.ProcessingStyle != "Ignore":
             getStreamDatasetsDAO = daoFactory(classname = "RunConfig.GetStreamDatasets")
             datasets = getStreamDatasetsDAO.execute(run, stream, transaction = False)

--- a/src/python/T0/RunConfig/Tier0Config.py
+++ b/src/python/T0/RunConfig/Tier0Config.py
@@ -24,6 +24,8 @@ Tier0Configuration - Global configuration object
 | |       |
 | |       |--> InjectMaxRun - Highest run number to be injected into the system from the SM database (default is unlimited)
 | |       |
+| |       |--> SpecifiedStreamNames - Streamer names to be ran exclusivley(default is None)
+| |       |
 | |       |--> AcquisitionEra - The acquisition era for the run
 | |       |
 | |       |--> Backfill - The backfill mode, can be None, 1 or 2
@@ -258,6 +260,8 @@ def createTier0Config():
     tier0Config.Global.InjectRuns = None
     tier0Config.Global.InjectMinRun = None
     tier0Config.Global.InjectMaxRun = None
+    
+    tier0Config.Global.SpecifiedStreamNames = None
 
     tier0Config.Global.ScramArches = {}
     tier0Config.Global.Backfill = None
@@ -793,12 +797,15 @@ def specifyStreams(config, streamNames):
     adds ignore configurations for streams that
     not in specified streams
     """
+    config.Global.SpecifiedStreamNames = streamNames
+
     if(type(streamNames)!=list):
         streamNames=[streamNames]
     for stream in config.Streams.dictionary_().keys():
         if not stream in streamNames:
             streamConfig = retrieveStreamConfig(config, stream)
             streamConfig.ProcessingStyle = "Ignore"
+
     return
 
 def addRepackConfig(config, streamName, **options):

--- a/src/python/T0/RunConfig/Tier0Config.py
+++ b/src/python/T0/RunConfig/Tier0Config.py
@@ -786,6 +786,18 @@ def ignoreStream(config, streamName):
 
     return
 
+def specifyStream(config, streamName):
+    """
+    _specifyStream_
+    adds configurations for streams that
+    not specified it to be ignored
+    """
+    for stream in list(config.Streams.dictionary_().keys()):
+        if(stream != streamName):
+            streamConfig = retrieveStreamConfig(config, streamName)
+            streamConfig.ProcessingStyle = "Ignore"
+    return
+
 def addRepackConfig(config, streamName, **options):
     """
     _addRepackConfig_

--- a/src/python/T0/RunConfig/Tier0Config.py
+++ b/src/python/T0/RunConfig/Tier0Config.py
@@ -795,8 +795,7 @@ def specifyStreams(config, streamNames):
     """
     _specifyStreams_
     
-    adds ignore configurations for streams that
-    not in specified streams
+    Set the list of streamer names to be processed exclusively.
     """
     config.Global.SpecifiedStreamNames = streamNames
 

--- a/src/python/T0/RunConfig/Tier0Config.py
+++ b/src/python/T0/RunConfig/Tier0Config.py
@@ -786,15 +786,18 @@ def ignoreStream(config, streamName):
 
     return
 
-def specifyStream(config, streamName):
+def specifyStreams(config, streamNames):
     """
-    _specifyStream_
-    adds configurations for streams that
-    not specified it to be ignored
+    _specifyStreams_
+    
+    adds ignore configurations for streams that
+    not in specified streams
     """
-    for stream in list(config.Streams.dictionary_().keys()):
-        if(stream != streamName):
-            streamConfig = retrieveStreamConfig(config, streamName)
+    if(type(streamNames)!=list):
+        streamNames=[streamNames]
+    for stream in config.Streams.dictionary_().keys():
+        if not stream in streamNames:
+            streamConfig = retrieveStreamConfig(config, stream)
             streamConfig.ProcessingStyle = "Ignore"
     return
 

--- a/src/python/T0/RunConfig/Tier0Config.py
+++ b/src/python/T0/RunConfig/Tier0Config.py
@@ -24,7 +24,8 @@ Tier0Configuration - Global configuration object
 | |       |
 | |       |--> InjectMaxRun - Highest run number to be injected into the system from the SM database (default is unlimited)
 | |       |
-| |       |--> SpecifiedStreamNames - Streamer names to be ran exclusivley(default is None)
+| |       |--> SpecifiedStreamNames - Streamer names list to be ran exclusivley. (default is None)
+| |       |                           If it is None, all streamer will processed except which is set to be ignored.
 | |       |
 | |       |--> AcquisitionEra - The acquisition era for the run
 | |       |
@@ -798,13 +799,6 @@ def specifyStreams(config, streamNames):
     not in specified streams
     """
     config.Global.SpecifiedStreamNames = streamNames
-
-    if(type(streamNames)!=list):
-        streamNames=[streamNames]
-    for stream in config.Streams.dictionary_().keys():
-        if not stream in streamNames:
-            streamConfig = retrieveStreamConfig(config, stream)
-            streamConfig.ProcessingStyle = "Ignore"
 
     return
 


### PR DESCRIPTION
Add specifyStreams(config, streamNames) at Tier0Config.py

Add speicifyStreams at end of [ReplayOfflineConfiguration.py](https://github.com/dmwm/T0/blob/master/etc/ReplayOfflineConfiguration.py) to ignore every stream except specified streams.
for example,
specifyStreams(tier0Config, ["Calibration","LookArea"])

Replay at vocms0500
**Describe the configuration**

- Run: 356005,359060
- DeploymentID: 221012133000
- Additional changes: `specifyStreams(tier0Config, ["Calibration"])` at the end of [ReplayOfflineConfiguration.py](https://github.com/dmwm/T0/pull/4765/files#diff-4d2c96d3e15eb107f3aec15b5259355379fad0c475f704ed3a3cf8720cf94684)