### PR TITLE
Extend express ALCARECOs lifetime on disk to 1 year

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -233,7 +233,7 @@ addExpressConfig(tier0Config, "Express",
                  timePerEvent=4,
                  sizePerEvent=1700,
                  maxMemoryperCore=2000,
-                 dataset_lifetime=3*30*24*3600,#lifetime for container rules. Default 3 months
+                 dataset_lifetime=12*30*24*3600,#lifetime for container rules. Default 12 months
                  versionOverride=expressVersionOverride)
 
 addExpressConfig(tier0Config, "ExpressCosmics",
@@ -260,7 +260,7 @@ addExpressConfig(tier0Config, "ExpressCosmics",
                  timePerEvent=4, #I have to get some stats to set this properly
                  sizePerEvent=1700, #I have to get some stats to set this properly
                  maxMemoryperCore=2000,
-                 dataset_lifetime=3*30*24*3600,#lifetime for container rules. Default 3 months
+                 dataset_lifetime=12*30*24*3600,#lifetime for container rules. Default 12 months
                  versionOverride=expressVersionOverride)
 
 addExpressConfig(tier0Config, "HLTMonitor",
@@ -336,7 +336,7 @@ addExpressConfig(tier0Config, "ExpressAlignment",
                  sizePerEvent=1700,
                  versionOverride=expressVersionOverride,
                  maxMemoryperCore=2000,
-                 dataset_lifetime=3*30*24*3600,#lifetime for container rules. Default 3 months
+                 dataset_lifetime=12*30*24*3600,#lifetime for container rules. Default 12 months
                  diskNode="T2_CH_CERN")
 
 addExpressConfig(tier0Config, "ALCALumiPixelsCountsExpress",
@@ -363,7 +363,7 @@ addExpressConfig(tier0Config, "ALCALumiPixelsCountsExpress",
                  maxMemoryperCore=2000,
                  archivalNode=None,
                  tapeNode=None,
-                 dataset_lifetime=3*30*24*3600,#lifetime for container rules. Default 3 months
+                 dataset_lifetime=12*30*24*3600,#lifetime for container rules. Default 12 months
                  diskNode="T2_CH_CERN")
 
 addExpressConfig(tier0Config, "ALCAPPSExpress",
@@ -390,7 +390,7 @@ addExpressConfig(tier0Config, "ALCAPPSExpress",
                  timePerEvent=4,
                  sizePerEvent=1700,
                  maxMemoryperCore=2000,
-                 dataset_lifetime=3*30*24*3600,#lifetime for container rules. Default 3 months
+                 dataset_lifetime=12*30*24*3600,#lifetime for container rules. Default 12 months
                  diskNode="T2_CH_CERN",
                  versionOverride=expressVersionOverride)
 


### PR DESCRIPTION
# Config Change Request

Not really a replay request, more just a config change. 

**Proposed Changes**
In https://github.com/dmwm/T0/pull/4642 a lifetime of 3 months was added to the express alcarecos. Since this means that when such lifetime expires these datasets (which are not custodial as the prompt ones) get deleted (not transferred to tape), we propose to increase the lifetime to 12 month so that they can be used, for example, for the derivation fo the re-reco conditions.
In this PR I increased the lifetime for:
 - "Express"
 - "ExpressCosmics"
 - "ExpressAlignment"
 - "ALCALumiPixelsCountsExpress"
 - "ALCAPPSExpress"

@drkovalskyi given your comment in https://github.com/dmwm/T0/pull/4642#issuecomment-1096936222 any feedback on this proposal is welcome (including possibly setting different `diskNode`s for storing these alcarecos).

**T0 Operations cmsTalk thread**
Will be provided soon