### PR TITLE
Change era to Run2022F

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -55,7 +55,7 @@ addSiteConfig(tier0Config, "T0_CH_CERN_Disk",
 #  Data type
 #  Processing site (where jobs run)
 #  PhEDEx locations
-setAcquisitionEra(tier0Config, "Run2022E")
+setAcquisitionEra(tier0Config, "Run2022F")
 setBaseRequestPriority(tier0Config, 251000)
 setBackfill(tier0Config, None)
 setBulkDataType(tier0Config, "data")


### PR DESCRIPTION
Era change to take place due to major changes in HCAL conditions: https://its.cern.ch/jira/browse/CMSALCA-184

CMS Talk thread: https://cms-talk.web.cern.ch/t/request-to-change-era-version-for-hcal-updates/15977
