### PR TITLE
replay configuration for `12_4_10_patch2`

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -104,7 +104,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_12_4_10"
+    'default': "CMSSW_12_4_10_patch2"
 }
 
 # Configure ScramArch
@@ -156,7 +156,9 @@ repackVersionOverride = {
     "CMSSW_12_4_7" : defaultCMSSWVersion['default'],
     "CMSSW_12_4_8" : defaultCMSSWVersion['default'],
     "CMSSW_12_4_9" : defaultCMSSWVersion['default'],
-    "CMSSW_12_4_9_patch1" : defaultCMSSWVersion['default']
+    "CMSSW_12_4_9_patch1" : defaultCMSSWVersion['default'],
+    "CMSSW_12_4_10" : defaultCMSSWVersion['default'],
+    "CMSSW_12_4_10_patch1" : defaultCMSSWVersion['default']
     }
 
 expressVersionOverride = {
@@ -167,7 +169,9 @@ expressVersionOverride = {
     "CMSSW_12_4_7" : defaultCMSSWVersion['default'],
     "CMSSW_12_4_8" : defaultCMSSWVersion['default'],
     "CMSSW_12_4_9" : defaultCMSSWVersion['default'],
-    "CMSSW_12_4_9_patch1" : defaultCMSSWVersion['default']
+    "CMSSW_12_4_9_patch1" : defaultCMSSWVersion['default'],
+    "CMSSW_12_4_10" : defaultCMSSWVersion['default'],
+    "CMSSW_12_4_10_patch1" : defaultCMSSWVersion['default']
     }
 
 #set default repack settings for bulk streams


### PR DESCRIPTION
# Replay Request

**Requestor**  
ORM 

**Describe the configuration**  
* Release: CMSSW_12_4_10_patch2
* Run: 359762 
* GTs (unchanged):
    * expressGlobalTag: 124X_dataRun3_Express_v5
    * promptrecoGlobalTag: 124X_dataRun3_Prompt_v4
    * alcap0GlobalTag: 124X_dataRun3_Prompt_v4
* Additional changes:

**Purpose of the test**  
 Test the new CMSSW_12_4_10_patch2 release in view of the change in the T0 configuration. 

**T0 Operations cmsTalk thread**  
Will post here when available.
