### PR TITLE
Fix ErrorHandler's Max Fail time

### DIFF
--- a/bin/00_deploy_prod.sh
+++ b/bin/00_deploy_prod.sh
@@ -244,3 +244,6 @@ echo "config.RetryManager.PauseAlgo.section_('Processing')" >> ./config/tier0/co
 echo "config.RetryManager.PauseAlgo.Processing.retryErrorCodes = { 70: 0, 50513: 0, 50660: 0, 50661: 0, 50664: 0, 71304: 0 }" >> ./config/tier0/config.py
 echo "config.RetryManager.PauseAlgo.section_('Repack')" >> ./config/tier0/config.py
 echo "config.RetryManager.PauseAlgo.Repack.retryErrorCodes = { 70: 0, 50513: 0, 50660: 0, 50661: 0, 50664: 0, 71304: 0 }" >> ./config/tier0/config.py
+
+#Overwrite ErrorHandler to avoid jobs going to ensure T0 jobs can always be retried
+sed -i "s/config.ErrorHandler.maxFailTime.*/config.ErrorHandler.maxFailTime=601200/g" ./config/tier0/config.py

--- a/bin/00_deploy_replay.sh
+++ b/bin/00_deploy_replay.sh
@@ -240,4 +240,7 @@ echo "config.RetryManager.PauseAlgo.Repack.retryErrorCodes = { 70: 0, 50513: 0, 
 
 #Overwrite RetryManager to show Logcollect and CleanUp jobs paused instead of automatically fails
 sed -i "s/config.RetryManager.plugins.*/config.RetryManager.plugins={'default': 'PauseAlgo', 'Cleanup': 'PauseAlgo', 'LogCollect': 'PauseAlgo'}/g" ./config/tier0/config.py
+
+#Overwrite ErrorHandler to avoid jobs going to ensure T0 jobs can always be retried
+sed -i "s/config.ErrorHandler.maxFailTime.*/config.ErrorHandler.maxFailTime=601200/g" ./config/tier0/config.py
 sed -i "s/config.ErrorHandler.maxRetries.*/config.ErrorHandler.maxRetries={'default': 30, 'Cleanup': 30, 'LogCollect': 30}/g" ./config/tier0/config.py

--- a/bin/00_deploy_replay.sh
+++ b/bin/00_deploy_replay.sh
@@ -241,6 +241,6 @@ echo "config.RetryManager.PauseAlgo.Repack.retryErrorCodes = { 70: 0, 50513: 0, 
 #Overwrite RetryManager to show Logcollect and CleanUp jobs paused instead of automatically fails
 sed -i "s/config.RetryManager.plugins.*/config.RetryManager.plugins={'default': 'PauseAlgo', 'Cleanup': 'PauseAlgo', 'LogCollect': 'PauseAlgo'}/g" ./config/tier0/config.py
 
-#Overwrite ErrorHandler to avoid jobs going to ensure T0 jobs can always be retried
+#Overwrite ErrorHandler to ensure T0 jobs can always be retried
 sed -i "s/config.ErrorHandler.maxFailTime.*/config.ErrorHandler.maxFailTime=601200/g" ./config/tier0/config.py
 sed -i "s/config.ErrorHandler.maxRetries.*/config.ErrorHandler.maxRetries={'default': 30, 'Cleanup': 30, 'LogCollect': 30}/g" ./config/tier0/config.py


### PR DESCRIPTION
ErrorHandler.maxFailTime sets a maximum time a job can run to be retried. If a job takes longer than `maxFailTime`, it does not go to the retry logic and it is failed immediately.

This allows regular production agents to avoid retrying long executing jobs. Nonetheless, T0 never wants to skip the retry logic, as we want to be able to recover jobs using the [PauseAlgo plugin](https://github.com/dmwm/WMCore/blob/master/src/python/WMComponent/RetryManager/PlugIns/PauseAlgo.py).

The current configuration of `maxFailTime=12000` (33.3h) means that if a job fails after this long, it is directly exhausted and doesn't go to the usual pause state, causing issues like the one described here:
https://cms-talk.web.cern.ch/t/summary-of-failures-in-promptreco-jobs/16373/5

Here we are setting `maxFailTime=601200` (167h), effectively disabling this feature for T0 agents.