### PR TITLE
Replay in preparation for Heavy Ion test 2022

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -37,7 +37,7 @@ setConfigVersion(tier0Config, "replace with real version")
 # 355559 - 2022 pp at 13.6 TeV (1h long, 300 bunches)
 # 356005 - 2022 pp at 13.6 TeV (1h long, 600 bunches - ALL detectors included)
 # 359060 - 2022 cosmics - Oberved failures in Express (https://cms-talk.web.cern.ch/t/paused-jobs-for-express-run359045-streamexpress/15232)
-setInjectRuns(tier0Config, [359762])
+setInjectRuns(tier0Config, [325174, 327527])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"
@@ -62,7 +62,7 @@ addSiteConfig(tier0Config, "EOS_PILOT",
 #  Processing site (where jobs run)
 #  PhEDEx locations
 setAcquisitionEra(tier0Config, "Tier0_REPLAY_2022")
-setBaseRequestPriority(tier0Config, 240000)
+setBaseRequestPriority(tier0Config, 260000)
 setBackfill(tier0Config, 1)
 setBulkDataType(tier0Config, "data")
 setProcessingSite(tier0Config, processingSite)
@@ -104,23 +104,24 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_12_4_10"
+    'default': "CMSSW_12_5_1"
 }
 
 # Configure ScramArch
 setDefaultScramArch(tier0Config, "el8_amd64_gcc10")
 
 # Configure scenarios
-ppScenario = "ppEra_Run3"
-ppScenarioB0T = "ppEra_Run3"
+ppScenario = "ppEra_Run3_pp_on_PbPb"
+ppScenarioB0T = "ppEra_Run3_pp_on_PbPb"
 cosmicsScenario = "cosmicsEra_Run3"
-hcalnzsScenario = "hcalnzsEra_Run3"
-hiScenario = "ppEra_Run3"
+hcalnzsScenario = "hcalnzsEra_Run3_pp_on_PbPb"
+hiScenario = "ppEra_Run3_pp_on_PbPb"
 alcaTrackingOnlyScenario = "trackingOnlyEra_Run3"
+HIalcaTrackingOnlyScenario = "trackingOnlyEra_Run3_pp_on_PbPb"
 alcaTestEnableScenario = "AlCaTestEnable"
 alcaLumiPixelsScenario = "AlCaLumiPixels_Run3"
 alcaPPSScenario = "AlCaPPS_Run3"
-hiTestppScenario = "ppEra_Run3"
+hiTestppScenario = "ppEra_Run3_pp_on_PbPb"
 
 # Procesing version number replays
 # Taking Replay processing ID from the last 8 digits of the DeploymentID
@@ -130,9 +131,9 @@ expressProcVersion = dt
 alcarawProcVersion = dt
 
 # Defaults for GlobalTag
-expressGlobalTag = "124X_dataRun3_Express_v5"
-promptrecoGlobalTag = "124X_dataRun3_Prompt_v4"
-alcap0GlobalTag = "124X_dataRun3_Prompt_v4"
+expressGlobalTag = "124X_dataRun3_Express_TIER0_REPLAY_Run2_v3"
+promptrecoGlobalTag = "124X_dataRun3_Prompt_TIER0_REPLAY_Run2_v3"
+alcap0GlobalTag = "124X_dataRun3_Prompt_TIER0_REPLAY_Run2_v3"
 
 # Mandatory for CondDBv2
 globalTagConnect = "frontier://PromptProd/CMS_CONDITIONS"
@@ -401,7 +402,7 @@ addExpressConfig(tier0Config, "ALCAPPSExpress",
 #####################
 
 addExpressConfig(tier0Config, "HIExpress",
-                 scenario=hiTestppScenario,
+                 scenario=HIalcaTrackingOnlyScenario,
                  diskNode="T0_CH_CERN_Disk",
                  data_tiers=["FEVT"],
                  write_dqm=True,
@@ -453,6 +454,29 @@ addExpressConfig(tier0Config, "HIExpressAlignment",
                  maxMemoryperCore=2000,
                  dataset_lifetime=14*24*3600,#lifetime for container rules. Default 14 days
                  diskNode="T0_CH_CERN_Disk")
+
+addExpressConfig(tier0Config, "HIHLTMonitor",
+                 scenario=hiTestppScenario,
+                 diskNode="T2_CH_CERN",
+                 data_tiers=["FEVTHLTALL"],
+                 write_dqm=True,
+                 alca_producers=[],
+                 dqm_sequences=["@HLTMon"],
+                 reco_version=defaultCMSSWVersion,
+                 multicore=numberOfCores,
+                 global_tag_connect=globalTagConnect,
+                 global_tag=expressGlobalTag,
+                 proc_ver=expressProcVersion,
+                 maxInputRate=23 * 1000,
+                 maxInputEvents=400,
+                 maxInputSize=2 * 1024 * 1024 * 1024,
+                 maxInputFiles=15,
+                 maxLatency=15 * 23,
+                 periodicHarvestInterval=20 * 60,
+                 blockCloseDelay=1200,
+                 timePerEvent=4,
+                 sizePerEvent=1700,
+                 versionOverride=expressVersionOverride)
                  
 ###################################
 ### Standard Physics PDs (2022) ###
@@ -852,7 +876,7 @@ for dataset in DATASETS:
                tape_node=None,
                reco_split=alcarawSplitting,
                proc_version=alcarawProcVersion,
-               alca_producers = [ "AlCaPCCZeroBias", "RawPCCProducer" ],
+               alca_producers = ["AlCaPCCZeroBias", "RawPCCProducer"],
                timePerEvent=0.02,
                sizePerEvent=38,
                scenario=alcaLumiPixelsScenario)
@@ -1647,7 +1671,7 @@ addDataset(tier0Config, "PADoubleMuOpen",
            scenario=hiScenario)
 
 #####################
-### HI TESTS 2018 ###
+### HI TESTS 2022 ###
 #####################
 
 DATASETS = ["HITestFull", "HITestReduced"]
@@ -1655,8 +1679,196 @@ DATASETS = ["HITestFull", "HITestReduced"]
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,
                do_reco=True,
+               raw_to_disk=True,
                write_dqm=True,
                dqm_sequences=["@common"],
+               scenario=hiTestppScenario)
+
+DATASETS = ["HIHardProbesPrescaled", "HIHardProbesPeripheral", "HICommissioning",
+             "HICastor"]
+
+for dataset in DATASETS:
+    addDataset(tier0Config, dataset,
+               write_miniaod=False,
+               do_reco=True,
+               raw_to_disk=True,
+               write_dqm=True,
+               dqm_sequences=["@common"],
+               scenario=hiTestppScenario)
+
+DATASETS = ["HIHeavyFlavor", "HIHighMultiplicityETTAsym"]
+
+for dataset in DATASETS:
+    addDataset(tier0Config, dataset,
+               write_miniaod=False,
+               do_reco=True,
+               write_dqm=True,
+               reco_split=hiRecoSplitting,
+               dqm_sequences=["@common"],
+               scenario=hiTestppScenario)
+
+DATASETS = ["HIMinimumBiasReducedFormat0", "HILowMultiplicityReducedFormat", "HILowMultiplicity"]
+
+for dataset in DATASETS:
+    addDataset(tier0Config, dataset,
+               write_miniaod=False,
+               do_reco=True,
+               raw_to_disk=True,
+               write_dqm=True,
+               dqm_sequences=["@common"],
+               scenario=hiTestppScenario)
+
+# CMS VdM scan PDs
+DATASETS = ["HICentralityVetoReducedFormat0", "HICentralityVetoReducedFormat1", "HICentralityVetoReducedFormat2",
+             "HICentralityVetoReducedFormat3", "HICentralityVetoReducedFormat4", "HICentralityVetoReducedFormat5",
+             "HICentralityVetoReducedFormat6", "HICentralityVetoReducedFormat7", "HICentralityVetoReducedFormat8",
+             "HICentralityVetoReducedFormat9", "HICentralityVetoReducedFormat10", "HICentralityVetoReducedFormat11"]
+
+for dataset in DATASETS:
+    addDataset(tier0Config, dataset,
+               write_miniaod=False,
+               do_reco=True,
+               write_dqm=True,
+               dqm_sequences=["@common"],
+               scenario=hiTestppScenario)
+
+DATASETS = ["HIMinimumBiasReducedFormat1", "HIMinimumBiasReducedFormat10", "HIMinimumBiasReducedFormat11", 
+             "HIMinimumBiasReducedFormat2", "HIMinimumBiasReducedFormat3", "HIMinimumBiasReducedFormat4", 
+             "HIMinimumBiasReducedFormat5", "HIMinimumBiasReducedFormat6", "HIMinimumBiasReducedFormat7", 
+             "HIMinimumBiasReducedFormat8", "HIMinimumBiasReducedFormat9"]
+
+for dataset in DATASETS:
+    addDataset(tier0Config, dataset,
+               write_miniaod=False,
+               do_reco=True,
+               raw_to_disk=True,
+               write_dqm=False,
+               dqm_sequences=["@none"],
+               scenario=hiTestppScenario)
+
+DATASETS = ["HIForward"]
+
+for dataset in DATASETS:
+    addDataset(tier0Config, dataset,
+               write_miniaod=False,
+               do_reco=True,
+               raw_to_disk=True,
+               write_dqm=True,
+               dqm_sequences=["@commonSiStripZeroBias"],
+               scenario=hiTestppScenario)
+
+DATASETS = ["HIMinimumBias0", "HIMinimumBias1"]
+
+for dataset in DATASETS:
+    addDataset(tier0Config, dataset,
+               write_miniaod=False,
+               do_reco=True,
+               write_dqm=True,
+               dqm_sequences=["@commonSiStripZeroBias", "@hcal"],
+               scenario=hiTestppScenario)
+
+DATASETS = ["HIMinimumBias2",
+             "HIMinimumBias3", "HIMinimumBias4", "HIMinimumBias5",
+             "HIMinimumBias6", "HIMinimumBias7", "HIMinimumBias8",
+             "HIMinimumBias9", "HIMinimumBias10", "HIMinimumBias11",
+             "HIMinimumBias12", "HIMinimumBias13", "HIMinimumBias14",
+             "HIMinimumBias15", "HIMinimumBias16", "HIMinimumBias17",
+             "HIMinimumBias18","HIMinimumBias19"]
+
+for dataset in DATASETS:
+    addDataset(tier0Config, dataset,
+               write_miniaod=False,
+               do_reco=True,
+               raw_to_disk=True,
+               write_dqm=False,
+               dqm_sequences=["@none"],
+               scenario=hiTestppScenario)
+
+DATASETS = ["HIHcalNZS"]
+
+for dataset in DATASETS:
+    addDataset(tier0Config, dataset,
+               write_miniaod=False,
+               do_reco=True,
+               raw_to_disk=True,
+               write_dqm=True,
+               alca_producers=["HcalCalMinBias"],
+               dqm_sequences=["@common", "@hcal"],
+               scenario=hcalnzsScenario)
+
+DATASETS = ["HIHLTPhysics"]
+
+for dataset in DATASETS:
+    addDataset(tier0Config, dataset,
+               write_miniaod=False,
+               do_reco=True,
+               raw_to_disk=True,
+               write_dqm=True,
+               alca_producers=["TkAlMinBias"],
+               dqm_sequences=["@common"],
+               scenario=hiTestppScenario)
+
+DATASETS = ["HIHardProbesLower"]
+
+for dataset in DATASETS:
+    addDataset(tier0Config, dataset,
+               write_miniaod=False,
+               do_reco=True,
+               raw_to_disk=True,
+               write_dqm=True,
+               reco_split=hiRecoSplitting,
+               dqm_sequences=["@common", "@ecal", "@egamma"],
+               scenario=hiTestppScenario)
+
+DATASETS = ["HIHardProbes"]
+
+for dataset in DATASETS:
+    addDataset(tier0Config, dataset,
+               write_miniaod=False,
+               do_reco=True,
+               raw_to_disk=True,
+               write_dqm=True,
+               reco_split=hiRecoSplitting,
+               alca_producers=["TkAlMinBias", "HcalCalIterativePhiSym", "SiStripCalSmallBiasScan"],
+               dqm_sequences=["@common", "@ecal", "@hcal", "@jetmet", "@egamma"],
+               physics_skims=["PbPbEMu", "PbPbZEE"],
+               scenario=hiTestppScenario)
+
+DATASETS = ["HISingleMuon"]
+
+for dataset in DATASETS:
+    addDataset(tier0Config, dataset,
+               do_reco=True,
+               write_dqm=True,
+               raw_to_disk=True,
+               write_miniaod=False,
+               reco_split=hiRecoSplitting,
+               alca_producers=["TkAlZMuMu", "TkAlMuonIsolated", "DtCalib", "HcalCalIterativePhiSym"],
+               dqm_sequences=["@common", "@muon", "@lumi"],
+               physics_skims=["PbPbZMu"],
+               scenario=hiTestppScenario)
+
+DATASETS = ["HIDoubleMuon", "HIDoubleMuonPsiPeri"]
+
+for dataset in DATASETS:
+    addDataset(tier0Config, dataset,
+               do_reco=True,
+               write_reco=False,
+               raw_to_disk=True,
+               write_miniaod=False,
+               write_dqm=True,
+               reco_split=hiRecoSplitting,
+               alca_producers=["TkAlJpsiMuMu", "TkAlUpsilonMuMu"],
+               dqm_sequences=["@common", "@muon", "@lumi"],
+               physics_skims=["PbPbZMM"],
+               scenario=hiTestppScenario)
+
+DATASETS = ["HIOnlineMonitor", "HITrackerNZS"]
+
+for dataset in DATASETS:
+    addDataset(tier0Config, dataset,
+               do_reco=False,
+               raw_to_disk=True,
                scenario=hiTestppScenario)
 
 #######################

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -111,8 +111,8 @@ defaultCMSSWVersion = {
 setDefaultScramArch(tier0Config, "el8_amd64_gcc10")
 
 # Configure scenarios
-ppScenario = "ppEra_Run3_pp_on_PbPb"
-ppScenarioB0T = "ppEra_Run3_pp_on_PbPb"
+ppScenario = "ppEra_Run3"
+ppScenarioB0T = "ppEra_Run3"
 cosmicsScenario = "cosmicsEra_Run3"
 hcalnzsScenario = "hcalnzsEra_Run3_pp_on_PbPb"
 hiScenario = "ppEra_Run3_pp_on_PbPb"

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -407,7 +407,7 @@ addExpressConfig(tier0Config, "HIExpress",
                  data_tiers=["FEVT"],
                  write_dqm=True,
                  alca_producers=["SiStripPCLHistos", "SiStripCalZeroBias", "SiStripCalMinBias", "SiStripCalMinBiasAAG",
-                                 "TkAlMinBias", "SiPixelCalZeroBias","PromptCalibProdSiPixelLA", "PromptCalibProdSiStripHitEff",
+                                 "TkAlMinBias", "SiPixelCalZeroBias","SiPixelCalSingleMuon", "SiPixelCalSingleMuonTight",
                                  "PromptCalibProd", "PromptCalibProdSiStrip", "PromptCalibProdSiPixelAli",
                                  "PromptCalibProdSiStripGains", "PromptCalibProdSiStripGainsAAG", "PromptCalibProdSiPixel",
                                  "PromptCalibProdSiPixelLorentzAngle", "PromptCalibProdSiPixelAliHG"

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -410,7 +410,7 @@ addExpressConfig(tier0Config, "HIExpress",
                                  "TkAlMinBias", "SiPixelCalZeroBias","SiPixelCalSingleMuon", "SiPixelCalSingleMuonTight",
                                  "PromptCalibProd", "PromptCalibProdSiStrip", "PromptCalibProdSiPixelAli",
                                  "PromptCalibProdSiStripGains", "PromptCalibProdSiStripGainsAAG", "PromptCalibProdSiPixel",
-                                 "PromptCalibProdSiPixelLorentzAngle", "PromptCalibProdSiPixelAliHG"
+                                 "PromptCalibProdSiPixelLA", "PromptCalibProdSiStripHitEff", "PromptCalibProdSiPixelAliHG"
                                 ],
                  reco_version=defaultCMSSWVersion,
                  multicore=numberOfCores,

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -37,7 +37,7 @@ setConfigVersion(tier0Config, "replace with real version")
 # 355559 - 2022 pp at 13.6 TeV (1h long, 300 bunches)
 # 356005 - 2022 pp at 13.6 TeV (1h long, 600 bunches - ALL detectors included)
 # 359060 - 2022 cosmics - Oberved failures in Express (https://cms-talk.web.cern.ch/t/paused-jobs-for-express-run359045-streamexpress/15232)
-setInjectRuns(tier0Config, [325174, 360886])
+setInjectRuns(tier0Config, [325174])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -37,7 +37,7 @@ setConfigVersion(tier0Config, "replace with real version")
 # 355559 - 2022 pp at 13.6 TeV (1h long, 300 bunches)
 # 356005 - 2022 pp at 13.6 TeV (1h long, 600 bunches - ALL detectors included)
 # 359060 - 2022 cosmics - Oberved failures in Express (https://cms-talk.web.cern.ch/t/paused-jobs-for-express-run359045-streamexpress/15232)
-setInjectRuns(tier0Config, [325174, 327527])
+setInjectRuns(tier0Config, [325174, 360886])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"
@@ -402,14 +402,15 @@ addExpressConfig(tier0Config, "ALCAPPSExpress",
 #####################
 
 addExpressConfig(tier0Config, "HIExpress",
-                 scenario=HIalcaTrackingOnlyScenario,
+                 scenario=hiTestppScenario,
                  diskNode="T0_CH_CERN_Disk",
                  data_tiers=["FEVT"],
                  write_dqm=True,
                  alca_producers=["SiStripPCLHistos", "SiStripCalZeroBias", "SiStripCalMinBias", "SiStripCalMinBiasAAG",
-                                 "TkAlMinBias", "LumiPixelsMinBias", "SiPixelCalZeroBias",
+                                 "TkAlMinBias", "SiPixelCalZeroBias","PromptCalibProdSiPixelLA", "PromptCalibProdSiStripHitEff",
                                  "PromptCalibProd", "PromptCalibProdSiStrip", "PromptCalibProdSiPixelAli",
-                                 "PromptCalibProdSiStripGains", "PromptCalibProdSiStripGainsAAG", "PromptCalibProdSiPixel"
+                                 "PromptCalibProdSiStripGains", "PromptCalibProdSiStripGainsAAG", "PromptCalibProdSiPixel",
+                                 "PromptCalibProdSiPixelLorentzAngle", "PromptCalibProdSiPixelAliHG"
                                 ],
                  reco_version=defaultCMSSWVersion,
                  multicore=numberOfCores,
@@ -430,10 +431,10 @@ addExpressConfig(tier0Config, "HIExpress",
                  versionOverride=expressVersionOverride)
 
 addExpressConfig(tier0Config, "HIExpressAlignment",
-                 scenario=hiTestppScenario,
+                 scenario=HIalcaTrackingOnlyScenario,
                  data_tiers=["ALCARECO", "RAW"],
                  write_dqm=True,
-                 alca_producers=["TkAlMinBias"],
+                 alca_producers=["TkAlMinBias", "PromptCalibProdBeamSpotHP"],
                  dqm_sequences=["@trackingOnlyDQM"],
                  reco_version=defaultCMSSWVersion,
                  raw_to_disk=True,
@@ -1684,8 +1685,7 @@ for dataset in DATASETS:
                dqm_sequences=["@common"],
                scenario=hiTestppScenario)
 
-DATASETS = ["HIHardProbesPrescaled", "HIHardProbesPeripheral", "HICommissioning",
-             "HICastor"]
+DATASETS = ["HIHardProbesPrescaled", "HIHardProbesPeripheral", "HICommissioning"]
 
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,
@@ -1843,7 +1843,7 @@ for dataset in DATASETS:
                raw_to_disk=True,
                write_miniaod=False,
                reco_split=hiRecoSplitting,
-               alca_producers=["TkAlZMuMu", "TkAlMuonIsolated", "DtCalib", "HcalCalIterativePhiSym"],
+               alca_producers=["TkAlZMuMu", "TkAlMuonIsolated", "HcalCalIterativePhiSym"],
                dqm_sequences=["@common", "@muon", "@lumi"],
                physics_skims=["PbPbZMu"],
                scenario=hiTestppScenario)

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -8,6 +8,7 @@ from T0.RunConfig.Tier0Config import addDataset
 from T0.RunConfig.Tier0Config import createTier0Config
 from T0.RunConfig.Tier0Config import setAcquisitionEra
 from T0.RunConfig.Tier0Config import setDefaultScramArch
+from T0.RunConfig.Tier0Config import setScramArch
 from T0.RunConfig.Tier0Config import setBaseRequestPriority
 from T0.RunConfig.Tier0Config import setBackfill
 from T0.RunConfig.Tier0Config import setBulkDataType
@@ -108,7 +109,8 @@ defaultCMSSWVersion = {
 }
 
 # Configure ScramArch
-setDefaultScramArch(tier0Config, "el8_amd64_gcc10")
+setDefaultScramArch(tier0Config, "slc7_amd64_gcc700")
+setScramArch(tier0Config, defaultCMSSWVersion['default'], "el8_amd64_gcc10")
 
 # Configure scenarios
 ppScenario = "ppEra_Run3"
@@ -157,7 +159,8 @@ repackVersionOverride = {
     "CMSSW_12_4_7" : defaultCMSSWVersion['default'],
     "CMSSW_12_4_8" : defaultCMSSWVersion['default'],
     "CMSSW_12_4_9" : defaultCMSSWVersion['default'],
-    "CMSSW_12_4_9_patch1" : defaultCMSSWVersion['default']
+    "CMSSW_12_4_9_patch1" : defaultCMSSWVersion['default'],
+    "CMSSW_12_4_10" : defaultCMSSWVersion['default']
     }
 
 expressVersionOverride = {
@@ -168,7 +171,8 @@ expressVersionOverride = {
     "CMSSW_12_4_7" : defaultCMSSWVersion['default'],
     "CMSSW_12_4_8" : defaultCMSSWVersion['default'],
     "CMSSW_12_4_9" : defaultCMSSWVersion['default'],
-    "CMSSW_12_4_9_patch1" : defaultCMSSWVersion['default']
+    "CMSSW_12_4_9_patch1" : defaultCMSSWVersion['default'],
+    "CMSSW_12_4_10" : defaultCMSSWVersion['default']
     }
 
 #set default repack settings for bulk streams

--- a/src/python/T0/WMBS/Oracle/Create.py
+++ b/src/python/T0/WMBS/Oracle/Create.py
@@ -932,8 +932,8 @@ class Create(DBCreator):
                            42 : "AlCaPhiSymEcal_Nano",
                            43 : "AlCaPPS_Run3",
                            44 : "trackingOnlyEra_Run3_pp_on_PbPb",
-                           44 : "ppEra_Run3_pp_on_PbPb",
-                           44 : "hcalnzsEra_Run3_pp_on_PbPb" }
+                           45 : "ppEra_Run3_pp_on_PbPb",
+                           46 : "hcalnzsEra_Run3_pp_on_PbPb" }
         for id, name in list(eventScenarios.items()):
             sql = """INSERT INTO event_scenario
                      (ID, NAME)

--- a/src/python/T0/WMBS/Oracle/Create.py
+++ b/src/python/T0/WMBS/Oracle/Create.py
@@ -930,7 +930,10 @@ class Create(DBCreator):
                            40 : "trackingOnlyEra_Run3",
                            41 : "AlCaLumiPixels_Run3",
                            42 : "AlCaPhiSymEcal_Nano",
-                           43 : "AlCaPPS_Run3" }
+                           43 : "AlCaPPS_Run3",
+                           44 : "trackingOnlyEra_Run3_pp_on_PbPb",
+                           44 : "ppEra_Run3_pp_on_PbPb",
+                           44 : "hcalnzsEra_Run3_pp_on_PbPb" }
         for id, name in list(eventScenarios.items()):
             sql = """INSERT INTO event_scenario
                      (ID, NAME)


### PR DESCRIPTION
# Replay Request

**Requestor**  
Team or person that requests this replay

**Describe the configuration**  
* Release: CMSSW_12_5_1
* Run: 325174, 327527
* GTs:
   * expressGlobalTag: 124X_dataRun3_Express_TIER0_REPLAY_Run2_v3
   * promptrecoGlobalTag: 124X_dataRun3_Prompt_TIER0_REPLAY_Run2_v3
   * alcap0GlobalTag: 124X_dataRun3_Prompt_TIER0_REPLAY_Run2_v3
* Additional changes:

**Purpose of the test**  
We need to try HI configuration for the HI test scheduled for Nov 18

**T0 Operations cmsTalk thread**  
[Preparation of Tier0 replay on 2018 HI data](https://cms-talk.web.cern.ch/t/feedback-needed-preparation-of-tier0-replay-on-2018-hi-data/16678)
