### PR TITLE
Replay testing CMSSW_12_5_1 with Run3 data

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -37,7 +37,7 @@ setConfigVersion(tier0Config, "replace with real version")
 # 355559 - 2022 pp at 13.6 TeV (1h long, 300 bunches)
 # 356005 - 2022 pp at 13.6 TeV (1h long, 600 bunches - ALL detectors included)
 # 359060 - 2022 cosmics - Oberved failures in Express (https://cms-talk.web.cern.ch/t/paused-jobs-for-express-run359045-streamexpress/15232)
-setInjectRuns(tier0Config, [359762])
+setInjectRuns(tier0Config, [360788])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"
@@ -62,7 +62,7 @@ addSiteConfig(tier0Config, "EOS_PILOT",
 #  Processing site (where jobs run)
 #  PhEDEx locations
 setAcquisitionEra(tier0Config, "Tier0_REPLAY_2022")
-setBaseRequestPriority(tier0Config, 240000)
+setBaseRequestPriority(tier0Config, 260000)
 setBackfill(tier0Config, 1)
 setBulkDataType(tier0Config, "data")
 setProcessingSite(tier0Config, processingSite)
@@ -104,7 +104,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_12_4_10"
+    'default': "CMSSW_12_5_1"
 }
 
 # Configure ScramArch

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -130,9 +130,9 @@ expressProcVersion = dt
 alcarawProcVersion = dt
 
 # Defaults for GlobalTag
-expressGlobalTag = "124X_dataRun3_Express_v5"
-promptrecoGlobalTag = "124X_dataRun3_Prompt_v4"
-alcap0GlobalTag = "124X_dataRun3_Prompt_v4"
+expressGlobalTag = "124X_dataRun3_Express_v6"
+promptrecoGlobalTag = "124X_dataRun3_Prompt_v5"
+alcap0GlobalTag = "124X_dataRun3_Prompt_v5"
 
 # Mandatory for CondDBv2
 globalTagConnect = "frontier://PromptProd/CMS_CONDITIONS"


### PR DESCRIPTION
# Replay Request

**Requestor**  
Team or person that requests this replay

**Describe the configuration**  
* Release: CMSSW_12_5_1
* Run: 360788
* GTs:
   * expressGlobalTag: 124X_dataRun3_Express_v6
   * promptrecoGlobalTag: 124X_dataRun3_Prompt_v5
   * alcap0GlobalTag:
* Additional changes:

**Purpose of the test**  
Test 12_5_1 in preparation for HI tests

**T0 Operations cmsTalk thread**  
[Preparation of Tier0 replay on 2018 HI data](https://cms-talk.web.cern.ch/t/feedback-needed-preparation-of-tier0-replay-on-2018-hi-data/16678)
