### PR TITLE
Replay for 12_4_11_patch1

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -105,7 +105,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_12_4_10"
+    'default': "CMSSW_12_4_11_patch1"
 }
 
 # Configure ScramArch
@@ -131,9 +131,9 @@ expressProcVersion = dt
 alcarawProcVersion = dt
 
 # Defaults for GlobalTag
-expressGlobalTag = "124X_dataRun3_Express_v5"
-promptrecoGlobalTag = "124X_dataRun3_Prompt_v4"
-alcap0GlobalTag = "124X_dataRun3_Prompt_v4"
+expressGlobalTag = "124X_dataRun3_Express_v9"
+promptrecoGlobalTag = "124X_dataRun3_Prompt_v10"
+alcap0GlobalTag = "124X_dataRun3_Prompt_v6"
 
 # Mandatory for CondDBv2
 globalTagConnect = "frontier://PromptProd/CMS_CONDITIONS"
@@ -157,7 +157,8 @@ repackVersionOverride = {
     "CMSSW_12_4_7" : defaultCMSSWVersion['default'],
     "CMSSW_12_4_8" : defaultCMSSWVersion['default'],
     "CMSSW_12_4_9" : defaultCMSSWVersion['default'],
-    "CMSSW_12_4_9_patch1" : defaultCMSSWVersion['default']
+    "CMSSW_12_4_9_patch1" : defaultCMSSWVersion['default'],
+    "CMSSW_12_4_11_patch1" : defaultCMSSWVersion['default']
     }
 
 expressVersionOverride = {
@@ -168,7 +169,8 @@ expressVersionOverride = {
     "CMSSW_12_4_7" : defaultCMSSWVersion['default'],
     "CMSSW_12_4_8" : defaultCMSSWVersion['default'],
     "CMSSW_12_4_9" : defaultCMSSWVersion['default'],
-    "CMSSW_12_4_9_patch1" : defaultCMSSWVersion['default']
+    "CMSSW_12_4_9_patch1" : defaultCMSSWVersion['default'],
+    "CMSSW_12_4_11_patch1" : defaultCMSSWVersion['default']
     }
 
 #set default repack settings for bulk streams

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -161,7 +161,7 @@ repackVersionOverride = {
     "CMSSW_12_4_8" : defaultCMSSWVersion['default'],
     "CMSSW_12_4_9" : defaultCMSSWVersion['default'],
     "CMSSW_12_4_9_patch1" : defaultCMSSWVersion['default'],
-    "CMSSW_12_4_11_patch1" : defaultCMSSWVersion['default']
+    "CMSSW_12_4_10" : defaultCMSSWVersion['default']
     }
 
 expressVersionOverride = {
@@ -173,7 +173,7 @@ expressVersionOverride = {
     "CMSSW_12_4_8" : defaultCMSSWVersion['default'],
     "CMSSW_12_4_9" : defaultCMSSWVersion['default'],
     "CMSSW_12_4_9_patch1" : defaultCMSSWVersion['default'],
-    "CMSSW_12_4_11_patch1" : defaultCMSSWVersion['default']
+    "CMSSW_12_4_10" : defaultCMSSWVersion['default']
     }
 
 #set default repack settings for bulk streams

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -133,7 +133,7 @@ alcarawProcVersion = dt
 # Defaults for GlobalTag
 expressGlobalTag = "124X_dataRun3_Express_v9"
 promptrecoGlobalTag = "124X_dataRun3_Prompt_v10"
-alcap0GlobalTag = "124X_dataRun3_Prompt_v6"
+alcap0GlobalTag = "124X_dataRun3_Prompt_v10"
 
 # Mandatory for CondDBv2
 globalTagConnect = "frontier://PromptProd/CMS_CONDITIONS"

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -38,7 +38,10 @@ setConfigVersion(tier0Config, "replace with real version")
 # 355559 - 2022 pp at 13.6 TeV (1h long, 300 bunches)
 # 356005 - 2022 pp at 13.6 TeV (1h long, 600 bunches - ALL detectors included)
 # 359060 - 2022 cosmics - Oberved failures in Express (https://cms-talk.web.cern.ch/t/paused-jobs-for-express-run359045-streamexpress/15232)
-setInjectRuns(tier0Config, [359762])
+# 359762 - 2022 pp at 13.6 TeV (2h long, 2400 bunches - ALL detectors included)
+# 361468 - 2022 pp at 13.6 TeV - Observed Abort Signal in Prompt (https://github.com/cms-sw/cmssw/issues/40032) 
+# 361971 - 2022 pp at 13.6 TeV - Observed GsfTracking Error (https://cms-talk.web.cern.ch/t/paused-job-in-run-361971-due-to-gsftraking-logic-error/17617) 
+setInjectRuns(tier0Config, [359762, 361468, 361971])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"


### PR DESCRIPTION
# Replay Request

**Requestor**  
Erica Brondolin (as ORM)

**Describe the configuration**  
* Release: 12_4_11_patch1
* Run: 359762, 361468, 361971
* GTs:
   * expressGlobalTag: 124X_dataRun3_Express_v9
   * promptrecoGlobalTag: 124X_dataRun3_Prompt_v10
   * alcap0GlobalTag: 124X_dataRun3_Prompt_v10
* Additional changes: None

**Purpose of the test**  
Test the new CMSSW_12_4_11_patch1 release in view of the change in the T0 configuration.

**T0 Operations cmsTalk thread**  
[CMS Talk](https://cms-talk.web.cern.ch/t/replay-testing-for-cmssw-12-4-11-patch1/17707)