### PR TITLE
Adding SITECONFIG_PATH var to WN environment

### DIFF
--- a/src/python/T0/RunConfig/RunConfigAPI.py
+++ b/src/python/T0/RunConfig/RunConfigAPI.py
@@ -1107,7 +1107,7 @@ def releasePromptReco(tier0Config, specDirectory, dqmUploadProxy):
 
 def setStorageSite(tier0Config, wmSpec, storagesite):
     site = retrieveSiteConfig(tier0Config, storagesite)
-    wmSpec.setTaskEnvironmentVariables({'WMAGENT_SITE_CONFIG_OVERRIDE':site.SiteLocalConfig})
+    wmSpec.setTaskEnvironmentVariables({'WMAGENT_SITE_CONFIG_OVERRIDE':site.SiteLocalConfig,'SITECONFIG_PATH':site.SiteLocalConfig.split("JobConfig")[0]})
     wmSpec.setOverrideCatalog(site.OverrideCatalog)
     for task in wmSpec.getAllTasks():
         for stepName in task.listAllStepNames():


### PR DESCRIPTION
Fix to the issues with CMSSW override catalog reported here:
https://cms-talk.web.cern.ch/t/invalid-override-string-overriding-tfc-in-cmssw-12-6-2/19904/5