### PR TITLE
Replay to test new FPIX LA PCL

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -42,7 +42,7 @@ streamerPNN = "T0_CH_CERN_Disk"
 
 addSiteConfig(tier0Config, "T0_CH_CERN_Disk",
                 siteLocalConfig="/cvmfs/cms.cern.ch/SITECONF/T0_CH_CERN/JobConfig/site-local-config.xml",
-                overrideCatalog="T2_CH_CERN,,T0_CH_CERN,CERN_EOS_T0,XRootD"
+                overrideCatalog="trivialcatalog_file:/cvmfs/cms.cern.ch/SITECONF/T0_CH_CERN/PhEDEx/storage.xml?protocol=eos"
                 )
 
 addSiteConfig(tier0Config, "EOS_PILOT",
@@ -232,9 +232,7 @@ addExpressConfig(tier0Config, "ExpressCosmics",
                  diskNode="T0_CH_CERN_Disk",
                  data_tiers=["FEVT"],
                  write_dqm=True,
-                 alca_producers=["SiPixelCalCosmics",
-                                 "PromptCalibProdSiPixelLAMCS"
-                                ],
+                 alca_producers=["SiPixelCalCosmics", "PromptCalibProdSiPixelLAMCS"],
                  reco_version=defaultCMSSWVersion,
                  multicore=numberOfCores,
                  global_tag_connect=globalTagConnect,

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -33,7 +33,7 @@ tier0Config = createTier0Config()
 setConfigVersion(tier0Config, "replace with real version")
 
 # Set run number to replay
-setInjectRuns(tier0Config, [359473])
+setInjectRuns(tier0Config, [359688]) # 2022 1.3h cosmic 2022 w/ tracker HV ON for 143 LS
 
 # Settings up sites
 processingSite = "T2_CH_CERN"
@@ -42,7 +42,7 @@ streamerPNN = "T0_CH_CERN_Disk"
 
 addSiteConfig(tier0Config, "T0_CH_CERN_Disk",
                 siteLocalConfig="/cvmfs/cms.cern.ch/SITECONF/T0_CH_CERN/JobConfig/site-local-config.xml",
-                overrideCatalog="trivialcatalog_file:/cvmfs/cms.cern.ch/SITECONF/T0_CH_CERN/PhEDEx/storage.xml?protocol=eos"
+                overrideCatalog="T2_CH_CERN,,T0_CH_CERN,CERN_EOS_T0,XRootD"
                 )
 
 addSiteConfig(tier0Config, "EOS_PILOT",
@@ -58,7 +58,7 @@ addSiteConfig(tier0Config, "EOS_PILOT",
 #  Processing site (where jobs run)
 #  PhEDEx locations
 setAcquisitionEra(tier0Config, "Tier0_REPLAY_2023")
-setBaseRequestPriority(tier0Config, 240000)
+setBaseRequestPriority(tier0Config, 260000)
 setBackfill(tier0Config, 1)
 setBulkDataType(tier0Config, "data")
 setProcessingSite(tier0Config, processingSite)
@@ -100,7 +100,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_12_6_3"
+    'default': "CMSSW_12_6_4"
 }
 
 # Configure ScramArch
@@ -126,9 +126,9 @@ expressProcVersion = dt
 alcarawProcVersion = dt
 
 # Defaults for GlobalTag
-expressGlobalTag = "126X_dataRun3_Express_v2"
-promptrecoGlobalTag = "126X_dataRun3_Prompt_v2"
-alcap0GlobalTag = "126X_dataRun3_Prompt_v2"
+expressGlobalTag = "126X_dataRun3_Express_Candidate_2023_02_16_13_39_00"
+promptrecoGlobalTag = "126X_dataRun3_Prompt_Candidate_2023_02_16_13_40_28"
+alcap0GlobalTag = "126X_dataRun3_Prompt_Candidate_2023_02_16_13_40_28"
 
 # Mandatory for CondDBv2
 globalTagConnect = "frontier://PromptProd/CMS_CONDITIONS"
@@ -144,9 +144,17 @@ alcarawSplitting = 20000 * numberOfCores
 #
 # Setup repack and express mappings
 #
-repackVersionOverride = {}
+repackVersionOverride = {
+    "CMSSW_12_6_1" : defaultCMSSWVersion['default'],
+    "CMSSW_12_6_2" : defaultCMSSWVersion['default'],
+    "CMSSW_12_6_3" : defaultCMSSWVersion['default']
+}
 
-expressVersionOverride = {}
+expressVersionOverride = {
+    "CMSSW_12_6_1" : defaultCMSSWVersion['default'],
+    "CMSSW_12_6_2" : defaultCMSSWVersion['default'],
+    "CMSSW_12_6_3" : defaultCMSSWVersion['default']
+}
 
 #set default repack settings for bulk streams
 addRepackConfig(tier0Config, "Default",
@@ -224,9 +232,8 @@ addExpressConfig(tier0Config, "ExpressCosmics",
                  diskNode="T0_CH_CERN_Disk",
                  data_tiers=["FEVT"],
                  write_dqm=True,
-                 alca_producers=["SiStripPCLHistos", "SiStripCalZeroBias", "TkAlCosmics0T",
-                                 "SiPixelCalZeroBias",
-                                 "PromptCalibProdSiStrip"
+                 alca_producers=["SiPixelCalCosmics",
+                                 "PromptCalibProdSiPixelLAMCS"
                                 ],
                  reco_version=defaultCMSSWVersion,
                  multicore=numberOfCores,
@@ -1654,6 +1661,14 @@ ignoreStream(tier0Config, "DQMOffline")
 ignoreStream(tier0Config, "streamHLTRates")
 ignoreStream(tier0Config, "streamL1Rates")
 ignoreStream(tier0Config, "streamDQMRates")
+
+############################################
+### ignored streams for the current test ###
+############################################
+ignoreStream(tier0Config, "RPCMON")
+ignoreStream(tier0Config, "Physics")
+ignoreStream(tier0Config, "NanoDST")
+ignoreStream(tier0Config, "Calibration")
 
 ###################################
 ### currently inactive settings ###


### PR DESCRIPTION
# Replay Request

**Requestor**  
AlCaDB

**Describe the configuration**  
* Release: CMSSW_12_6_4
* Run: 359688 (2022 cosmic run with tracker HV ON)
* GTs:
   * expressGlobalTag: 126X_dataRun3_Express_Candidate_2023_02_16_13_39_00
   * promptrecoGlobalTag: 126X_dataRun3_Prompt_Candidate_2023_02_16_13_40_28
   * alcap0GlobalTag: 126X_dataRun3_Prompt_Candidate_2023_02_16_13_40_28
* Additional changes:
   * Added `SiPixelCalCosmics` ALCARECO to `ExpressCosmic` configuration
   * Added `PromptCalibProdSiPixelLAMCS` PCL workflow to `ExpressCosmic` configuration
   * Ignored all the other streams for this run (`RPCMON`, `Calibration`, `Physics`, `NanoDST`)
   * Config changes to run CMSSW_12_6_4 are copied from #4792

**Purpose of the test**  
The purpose of this replay is to test a new PCL workflow (FPIX LorentzAngle) which was introduced in CMSSW_12_6_X
in PR [#40734](https://github.com/cms-sw/cmssw/pull/40734).
The GT candidates have been udpated to included a new DropboxMetadata tag containing the destination tags for
the new PCL worflow.

**T0 Operations cmsTalk thread**  
https://cms-talk.web.cern.ch/t/replay-test-of-cmssw-12-6-4/20428