### PR TITLE
start branch for 13_0_0 replay

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -33,7 +33,8 @@ tier0Config = createTier0Config()
 setConfigVersion(tier0Config, "replace with real version")
 
 # Set run number to replay
-setInjectRuns(tier0Config, [363534])
+# Cosmics from cruzet, splashes, and 2022 collisions
+setInjectRuns(tier0Config, [364158,350966,359691])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"
@@ -100,7 +101,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_12_6_4"
+    'default': "CMSSW_13_0_0"
 }
 
 # Configure ScramArch

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -127,9 +127,9 @@ expressProcVersion = dt
 alcarawProcVersion = dt
 
 # Defaults for GlobalTag
-expressGlobalTag = "126X_dataRun3_Express_v3"
-promptrecoGlobalTag = "126X_dataRun3_Prompt_v3"
-alcap0GlobalTag = "126X_dataRun3_Prompt_v3"
+expressGlobalTag = "130X_dataRun3_Express_Candidate_2023_03_07_09_53_07"
+promptrecoGlobalTag = "130X_dataRun3_Prompt_Candidate_2023_03_07_09_53_07"
+alcap0GlobalTag = "130X_dataRun3_Prompt_Candidate_2023_03_07_09_53_07"
 
 # Mandatory for CondDBv2
 globalTagConnect = "frontier://PromptProd/CMS_CONDITIONS"
@@ -613,7 +613,7 @@ for dataset in DATASETS:
                dqm_sequences=["@common"],
                scenario=ppScenario)
 
-DATASETS = ["JetMET"]
+DATASETS = ["JetMET", "JetMET0", "JetMET1"]
 
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,
@@ -660,7 +660,7 @@ for dataset in DATASETS:
                physics_skims=["TopMuEG", "LogError", "LogErrorMonitor"],
                scenario=ppScenario)
 
-DATASETS = ["Muon"]
+DATASETS = ["Muon", "Muon0", "Muon1"]
 
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,
@@ -700,7 +700,7 @@ for dataset in DATASETS:
                physics_skims=["ZMu", "LogError", "LogErrorMonitor"],
                scenario=ppScenario)
 
-DATASETS = ["EGamma"]
+DATASETS = ["EGamma", "EGamma0", "EGamma1"]
 
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,
@@ -839,7 +839,7 @@ for dataset in DATASETS:
                tape_node=None,
                reco_split=alcarawSplitting,
                proc_version=alcarawProcVersion,
-               alca_producers = [ "AlCaPCCZeroBias", "RawPCCProducer" ],
+               alca_producers = [ "AlCaPCCZeroBias", "RawPCCProducer", "AlCaPCCRandom"],
                timePerEvent=0.02,
                sizePerEvent=38,
                scenario=alcaLumiPixelsScenario)

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -106,6 +106,7 @@ defaultCMSSWVersion = {
 
 # Configure ScramArch
 setDefaultScramArch(tier0Config, "el8_amd64_gcc10")
+setScramArch(tier0Config, defaultCMSSWVersion['default'], "el8_amd64_gcc11")
 
 # Configure scenarios
 ppScenario = "ppEra_Run3"


### PR DESCRIPTION
# Replay Request

**Requestor**  
ORM

**Describe the configuration**  
* Release:  CMSSW_13_0_0
* Run: 364158, 350966, 359691
* GTs:
   * expressGlobalTag:  130X_dataRun3_Express_Candidate_2023_03_07_09_53_07
   * promptrecoGlobalTag: 130X_dataRun3_Prompt_Candidate_2023_03_09_09_47_16
* Additional changes: still need to incorporate an alca matrix update

**Purpose of the test**  
First test of CMSSW_13_0_0

