### PR TITLE
Production configuration for CRAFT and new processing version

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -94,11 +94,11 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_12_6_4"
+    'default': "CMSSW_13_0_0"
 }
 
 # Configure ScramArch
-setDefaultScramArch(tier0Config, "el8_amd64_gcc10")
+setDefaultScramArch(tier0Config, "el8_amd64_gcc11")
 
 # Configure scenarios
 ppScenario = "ppEra_Run3"
@@ -113,23 +113,22 @@ alcaPPSScenario = "AlCaPPS_Run3"
 hiTestppScenario = "ppEra_Run3"
 
 # Defaults for processing version
-defaultProcVersionRAW = 1
+defaultProcVersionRAW = 2
 alcarawProcVersion = {
-    'default': "1"
+    'default': "2"
 }
 
 defaultProcVersionReco = {
-    'default': "1"
+    'default': "2"
 }
 
 expressProcVersion = {
-    'default': "1"
+    'default': "2"
 }
 
 # Defaults for GlobalTag
-expressGlobalTag = "126X_dataRun3_Express_v3"
-promptrecoGlobalTag = "126X_dataRun3_Prompt_v3"
-alcap0GlobalTag = "126X_dataRun3_Prompt_v3"
+expressGlobalTag = "130X_dataRun3_Express_v1"
+promptrecoGlobalTag = "130X_dataRun3_Prompt_v1"
 
 # Mandatory for CondDBv2
 globalTagConnect = "frontier://PromptProd/CMS_CONDITIONS"
@@ -148,13 +147,15 @@ alcarawSplitting = 20000 * numberOfCores
 repackVersionOverride = {
     "CMSSW_12_6_1" : defaultCMSSWVersion['default'],
     "CMSSW_12_6_2" : defaultCMSSWVersion['default'],
-    "CMSSW_12_6_3" : defaultCMSSWVersion['default']
+    "CMSSW_12_6_3" : defaultCMSSWVersion['default'],
+    "CMSSW_12_6_4" : defaultCMSSWVersion['default']
 }
 
 expressVersionOverride = {
     "CMSSW_12_6_1" : defaultCMSSWVersion['default'],
     "CMSSW_12_6_2" : defaultCMSSWVersion['default'],
-    "CMSSW_12_6_3" : defaultCMSSWVersion['default']
+    "CMSSW_12_6_3" : defaultCMSSWVersion['default'],
+    "CMSSW_12_6_4" : defaultCMSSWVersion['default']
 }
 
 #set default repack settings for bulk streams
@@ -652,7 +653,7 @@ for dataset in DATASETS:
                dqm_sequences=["@common"],
                scenario=ppScenario)
 
-DATASETS = ["JetMET"]
+DATASETS = ["JetMET", "JetMET0", "JetMET1"]
 
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,
@@ -707,7 +708,7 @@ for dataset in DATASETS:
                physics_skims=["TopMuEG", "LogError", "LogErrorMonitor"],
                scenario=ppScenario)
 
-DATASETS = ["Muon"]
+DATASETS = ["Muon", "Muon0", "Muon1"]
 
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,
@@ -754,7 +755,7 @@ for dataset in DATASETS:
                physics_skims=["ZMu", "LogError", "LogErrorMonitor"],
                scenario=ppScenario)
 
-DATASETS = ["EGamma"]
+DATASETS = ["EGamma", "EGamma0", "EGamma1"]
 
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,
@@ -915,7 +916,7 @@ for dataset in DATASETS:
                tape_node=None,
                reco_split=alcarawSplitting,
                proc_version=alcarawProcVersion,
-               alca_producers = [ "AlCaPCCZeroBias", "RawPCCProducer" ],
+               alca_producers = [ "AlCaPCCZeroBias", "RawPCCProducer", "AlCaPCCRandom"],
                timePerEvent=0.02,
                sizePerEvent=38,
                scenario=alcaLumiPixelsScenario)

--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -145,17 +145,15 @@ alcarawSplitting = 20000 * numberOfCores
 # Setup repack and express mappings
 #
 repackVersionOverride = {
-    "CMSSW_12_6_1" : defaultCMSSWVersion['default'],
-    "CMSSW_12_6_2" : defaultCMSSWVersion['default'],
-    "CMSSW_12_6_3" : defaultCMSSWVersion['default'],
-    "CMSSW_12_6_4" : defaultCMSSWVersion['default']
+    "CMSSW_12_6_1" : "CMSSW_12_6_4",
+    "CMSSW_12_6_2" : "CMSSW_12_6_4",
+    "CMSSW_12_6_3" : "CMSSW_12_6_4"
 }
 
 expressVersionOverride = {
-    "CMSSW_12_6_1" : defaultCMSSWVersion['default'],
-    "CMSSW_12_6_2" : defaultCMSSWVersion['default'],
-    "CMSSW_12_6_3" : defaultCMSSWVersion['default'],
-    "CMSSW_12_6_4" : defaultCMSSWVersion['default']
+    "CMSSW_12_6_1" : "CMSSW_12_6_4",
+    "CMSSW_12_6_2" : "CMSSW_12_6_4",
+    "CMSSW_12_6_3" : "CMSSW_12_6_4"
 }
 
 #set default repack settings for bulk streams

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -8,6 +8,7 @@ from T0.RunConfig.Tier0Config import addDataset
 from T0.RunConfig.Tier0Config import createTier0Config
 from T0.RunConfig.Tier0Config import setAcquisitionEra
 from T0.RunConfig.Tier0Config import setDefaultScramArch
+from T0.RunConfig.Tier0Config import setScramArch
 from T0.RunConfig.Tier0Config import setBaseRequestPriority
 from T0.RunConfig.Tier0Config import setBackfill
 from T0.RunConfig.Tier0Config import setBulkDataType
@@ -107,6 +108,7 @@ defaultCMSSWVersion = {
 # Configure ScramArch
 setDefaultScramArch(tier0Config, "el8_amd64_gcc10")
 setScramArch(tier0Config, defaultCMSSWVersion['default'], "el8_amd64_gcc11")
+setScramArch(tier0Config, "CMSSW_12_3_0", "cs8_amd64_gcc10")
 
 # Configure scenarios
 ppScenario = "ppEra_Run3"
@@ -128,9 +130,8 @@ expressProcVersion = dt
 alcarawProcVersion = dt
 
 # Defaults for GlobalTag
-expressGlobalTag = "130X_dataRun3_Express_Candidate_2023_03_07_09_53_07"
-promptrecoGlobalTag = "130X_dataRun3_Prompt_Candidate_2023_03_07_09_53_07"
-alcap0GlobalTag = "130X_dataRun3_Prompt_Candidate_2023_03_07_09_53_07"
+expressGlobalTag = "130X_dataRun3_Express_v1"
+promptrecoGlobalTag = "130X_dataRun3_Prompt_v1"
 
 # Mandatory for CondDBv2
 globalTagConnect = "frontier://PromptProd/CMS_CONDITIONS"

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -33,7 +33,8 @@ tier0Config = createTier0Config()
 setConfigVersion(tier0Config, "replace with real version")
 
 # Set run number to replay
-setInjectRuns(tier0Config, [363534])
+# Cosmics from cruzet, splashes, and 2022 collisions
+setInjectRuns(tier0Config, [364158,350966,359691])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"
@@ -100,11 +101,12 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_12_6_4"
+    'default': "CMSSW_13_0_0"
 }
 
 # Configure ScramArch
 setDefaultScramArch(tier0Config, "el8_amd64_gcc10")
+setScramArch(tier0Config, defaultCMSSWVersion['default'], "el8_amd64_gcc11")
 
 # Configure scenarios
 ppScenario = "ppEra_Run3"
@@ -126,9 +128,9 @@ expressProcVersion = dt
 alcarawProcVersion = dt
 
 # Defaults for GlobalTag
-expressGlobalTag = "126X_dataRun3_Express_v3"
-promptrecoGlobalTag = "126X_dataRun3_Prompt_v3"
-alcap0GlobalTag = "126X_dataRun3_Prompt_v3"
+expressGlobalTag = "130X_dataRun3_Express_Candidate_2023_03_07_09_53_07"
+promptrecoGlobalTag = "130X_dataRun3_Prompt_Candidate_2023_03_07_09_53_07"
+alcap0GlobalTag = "130X_dataRun3_Prompt_Candidate_2023_03_07_09_53_07"
 
 # Mandatory for CondDBv2
 globalTagConnect = "frontier://PromptProd/CMS_CONDITIONS"
@@ -612,7 +614,7 @@ for dataset in DATASETS:
                dqm_sequences=["@common"],
                scenario=ppScenario)
 
-DATASETS = ["JetMET"]
+DATASETS = ["JetMET", "JetMET0", "JetMET1"]
 
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,
@@ -659,7 +661,7 @@ for dataset in DATASETS:
                physics_skims=["TopMuEG", "LogError", "LogErrorMonitor"],
                scenario=ppScenario)
 
-DATASETS = ["Muon"]
+DATASETS = ["Muon", "Muon0", "Muon1"]
 
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,
@@ -699,7 +701,7 @@ for dataset in DATASETS:
                physics_skims=["ZMu", "LogError", "LogErrorMonitor"],
                scenario=ppScenario)
 
-DATASETS = ["EGamma"]
+DATASETS = ["EGamma", "EGamma0", "EGamma1"]
 
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,
@@ -838,7 +840,7 @@ for dataset in DATASETS:
                tape_node=None,
                reco_split=alcarawSplitting,
                proc_version=alcarawProcVersion,
-               alca_producers = [ "AlCaPCCZeroBias", "RawPCCProducer" ],
+               alca_producers = [ "AlCaPCCZeroBias", "RawPCCProducer", "AlCaPCCRandom"],
                timePerEvent=0.02,
                sizePerEvent=38,
                scenario=alcaLumiPixelsScenario)


### PR DESCRIPTION
Production configuration for CRAFT and CMSSW 13_X release cycle.
Includes:

- Processing version moving from 1 to 2 (due to major CMSSW version change)
- Splitting of EGamma, JetMET, and Muon datasets
- Inclusion of "AlCaPCCRandom" for "AlCaLumiPixelsCountsPrompt0"

This configuration was tested in #4795 