### PR TITLE
Removing unused datasets from T0 config

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -589,60 +589,7 @@ for dataset in DATASETS:
                dqm_sequences=["@common"],
                scenario=ppScenario)
 
-DATASETS = ["FSQJet1", "FSQJet2"]
-
-DATASETS = ["FSQJets", "FSQJets1", "FSQJets2", "FSQJets3"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               dqm_sequences=["@common", "@jetmet"],
-               scenario=ppScenario)
-
-DATASETS = ["HINCaloJets", "HINPFJets"]
-
-DATASETS += ["HINCaloJet40", "HINPFJet100", "HINCaloJet100", "HINCaloJetsOther", "HINPFJetsOther"]
-
-DATASETS += ["HINMuon", "HINPhoton"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               dqm_sequences=["@common"],
-               scenario=ppScenario)
-
-DATASETS = ["HighMultiplicity"]
-
-DATASETS += ["HighMultiplicityEOF0", "HighMultiplicityEOF1", "HighMultiplicityEOF2",
-             "HighMultiplicityEOF3", "HighMultiplicityEOF4", "HighMultiplicityEOF5"]
-
-DATASETS += ["HighMultiplicity85", "HighMultiplicity85EOF"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_reco=False,
-               write_dqm=True,
-               dqm_sequences=["@common"],
-               scenario=ppScenario)
-
-# 05/07/2018 HighMultiplicityEOF needs to have 1sec per event
-DATASETS = ["HighMultiplicityEOF"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_reco=False,
-               write_dqm=True,
-               dqm_sequences=["@common"],
-               timePerEvent=1,
-               scenario=ppScenario)
-
 DATASETS = ["HighPtLowerPhotons", "HighPtPhoton30AndZ"]
-
-DATASETS += ["ppForward", "HighPtLowerJets", "MuPlusX"]
 
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,
@@ -834,15 +781,6 @@ for dataset in DATASETS:
                raw_to_disk=False,
                scenario=ppScenario)
 
-DATASETS = ["CosmicsForEventDisplay"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=False,
-               raw_to_disk=False,
-               write_miniaod=False,
-               scenario=cosmicsScenario)
-
 DATASETS = ["L1Accept", "L1Accepts"]
 
 for dataset in DATASETS:
@@ -1022,27 +960,6 @@ for dataset in DATASETS:
                physics_skims=["LogError", "LogErrorMonitor"],
                scenario=ppScenario)
 
-DATASETS = ["HLTPhysicsBunchTrains", "HLTPhysicsIsolatedBunch"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               raw_to_disk=True,
-               write_dqm=True,
-               alca_producers=["SiStripCalMinBias", "TkAlMinBias", "HcalCalIsoTrkFilter"],
-               physics_skims=["LogError", "LogErrorMonitor"],
-               scenario=ppScenario)
-
-DATASETS = ["HLTPhysicspart0", "HLTPhysicspart1",
-            "HLTPhysicspart2", "HLTPhysicspart3", "HLTPhysicspart4",
-            "HLTPhysicspart5", "HLTPhysicspart6", "HLTPhysicspart7"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=False,
-               raw_to_disk=True,
-               scenario=ppScenario)
-
 DATASETS = ["EphemeralHLTPhysics0","EphemeralHLTPhysics1", "EphemeralHLTPhysics2", "EphemeralHLTPhysics3",
             "EphemeralHLTPhysics4", "EphemeralHLTPhysics5", "EphemeralHLTPhysics6","EphemeralHLTPhysics7"
             "EphemeralHLTPhysics8", "EphemeralHLTPhysics9","EphemeralHLTPhysics10","EphemeralHLTPhysics11"
@@ -1061,18 +978,6 @@ for dataset in DATASETS:
                tape_node="T0_CH_CERN_MSS",
                disk_node="T2_CH_CERN",
                scenario=ppScenario)
-
-DATASETS = ["HLTPhysicsCosmics", "HLTPhysicsCosmics1", "HLTPhysicsCosmics2",
-            "HLTPhysicsCosmics3", "HLTPhysicsCosmics4", "HLTPhysicsCosmics5",
-            "HLTPhysicsCosmics6", "HLTPhysicsCosmics7", "HLTPhysicsCosmics8"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_miniaod=False,
-               raw_to_disk=True,
-               dqm_sequences=["@common"],
-               scenario=cosmicsScenario)
 
 ########################################################
 ### MinimumBias PDs                                  ###
@@ -1097,27 +1002,11 @@ for dataset in DATASETS:
                alca_producers=["SiStripCalZeroBias", "SiStripCalMinBias", "TkAlMinBias"],
                scenario=ppScenario)
 
-DATASETS = ["L1MinimumBias"]
-
-DATASETS += ["L1MinimumBiasHF1", "L1MinimumBiasHF2", "L1MinimumBiasHF3", "L1MinimumBiasHF4",
-             "L1MinimumBiasHF5", "L1MinimumBiasHF6", "L1MinimumBiasHF7", "L1MinimumBiasHF8"]
-
-DATASETS += ["L1MinimumBias0", "L1MinimumBias1", "L1MinimumBias2", "L1MinimumBias3", "L1MinimumBias4",
-             "L1MinimumBias5", "L1MinimumBias6", "L1MinimumBias7", "L1MinimumBias8", "L1MinimumBias9",
-             "L1MinimumBias10"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               dqm_sequences=["@common"],
-               scenario=ppScenario)
-
 ########################################################
 ### ZeroBias PDs                                     ###
 ########################################################
 
-DATASETS = ["ZeroBias"]
+DATASETS = ["ZeroBias", "ZeroBias0"]
 
 DATASETS += ["ZeroBias1", "ZeroBias2",
              "ZeroBias3", "ZeroBias4", "ZeroBias5", "ZeroBias6",
@@ -1168,24 +1057,6 @@ for dataset in DATASETS:
                alca_producers=["SiStripCalZeroBias", "TkAlMinBias", "SiStripCalMinBias", "HcalCalIsolatedBunchSelector"],
                physics_skims=["LogError", "LogErrorMonitor"],
                siteWhitelist = ["T2_CH_CERN_P5", "T2_CH_CERN"],
-               timePerEvent=3.5,
-               sizePerEvent=1500,
-               tape_node="T1_ES_PIC_MSS",
-               disk_node="T1_ES_PIC_Disk",
-               scenario=ppScenario)
-
-DATASETS = ["ZeroBias0"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               raw_to_disk=True,
-               write_reco=False,
-               write_dqm=True,
-               dqm_sequences=["@commonSiStripZeroBias", "@ecal", "@L1TMon", "@hcal", "@muon", "@jetmet", "@ctpps"],
-               alca_producers=["SiStripCalZeroBias", "TkAlMinBias", "SiStripCalMinBias"],
-               physics_skims=["LogError", "LogErrorMonitor"],
-               siteWhitelist = ["T2_CH_CERN_P5"],
                timePerEvent=3.5,
                sizePerEvent=1500,
                tape_node="T1_ES_PIC_MSS",
@@ -1246,59 +1117,6 @@ for dataset in DATASETS:
                disk_node="T2_CH_CERN",
                scenario=ppScenario)
 
-DATASETS = ["ParkingMonitor"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               dqm_sequences=["@common"],
-               write_reco=False, write_aod=False, write_miniaod=True, write_dqm=True,
-               tape_node="T1_US_FNAL_MSS",
-               disk_node=None,
-               scenario=ppScenario)
-
-DATASETS = ["ParkingScoutingMonitor"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               dqm_sequences=["@common"],
-               write_reco=False, write_aod=False, write_miniaod=True, write_dqm=True,
-               tape_node="T1_US_FNAL_MSS",
-               scenario=ppScenario)
-
-DATASETS = ["ParkingMuon", "ParkingHT"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=False,
-               archival_node="T0_CH_CERN_MSS",
-               tape_node=None,
-               disk_node=None,
-               scenario=ppScenario)
-
-DATASETS = ["ParkingBPH1", "ParkingBPH2", "ParkingBPH3", "ParkingBPH4", "ParkingBPH5", "ParkingBPH6"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=False,
-               archival_node="T0_CH_CERN_MSS",
-               tape_node=None,
-               disk_node=None,
-               scenario=ppScenario)
-
-# Parking PD to be PR'ed at CSCS
-DATASETS = ["ParkingBPHPromptCSCS"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=False,
-               siteWhitelist=["T0_CH_CSCS_HPC"],
-               archival_node="T0_CH_CERN_MSS",
-               tape_node=None,
-               disk_node=None,
-               scenario=ppScenario)
-
 DATASETS = ["RPCMonitor"]
 
 for dataset in DATASETS:
@@ -1336,43 +1154,7 @@ for dataset in DATASETS:
                do_reco=False,
                scenario=ppScenario)
 
-DATASETS = ["ParkingHT410to430", "ParkingHT500to550", "ParkingHT430to450", "ParkingHT470to500", "ParkingHT450to470"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=False,
-               tape_node="T1_US_FNAL_MSS",
-               disk_node=None,
-               scenario=ppScenario)
-
-DATASETS = ["ParkingHT550to650", "ParkingHT650"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=False,
-               tape_node="T1_US_FNAL_MSS",
-               disk_node=None,
-               scenario=ppScenario)
-
-DATASETS = ["ParkingHLTPhysics", "ParkingHLTPhysics0", "ParkingHLTPhysics1",
-            "ParkingHLTPhysics2", "ParkingHLTPhysics3", "ParkingHLTPhysics4",
-            "ParkingHLTPhysics5", "ParkingHLTPhysics6", "ParkingHLTPhysics7",
-            "ParkingHLTPhysics8", "ParkingHLTPhysics9", "ParkingHLTPhysics10",
-            "ParkingHLTPhysics11", "ParkingHLTPhysics12", "ParkingHLTPhysics13",
-            "ParkingHLTPhysics14", "ParkingHLTPhysics15", "ParkingHLTPhysics16",
-            "ParkingHLTPhysics17", "ParkingHLTPhysics18", "ParkingHLTPhysics19",
-            "ParkingHLTPhysics20"]
-
-DATASETS += ["ParkingZeroBias", "ParkingZeroBias0",
-             "ParkingZeroBias1", "ParkingZeroBias2", "ParkingZeroBias3",
-             "ParkingZeroBias4", "ParkingZeroBias5", "ParkingZeroBias6",
-             "ParkingZeroBias7", "ParkingZeroBias8", "ParkingZeroBias9",
-             "ParkingZeroBias10", "ParkingZeroBias11", "ParkingZeroBias12",
-             "ParkingZeroBias13", "ParkingZeroBias14", "ParkingZeroBias15",
-             "ParkingZeroBias16", "ParkingZeroBias17", "ParkingZeroBias18",
-             "ParkingZeroBias19", "ParkingZeroBias20"]
-
-DATASETS += ["AlCaElectron", "VRRandom", "VRRandom0", "VRRandom1", "VRRandom2", "VRRandom3",
+DATASETS = ["AlCaElectron", "VRRandom", "VRRandom0", "VRRandom1", "VRRandom2", "VRRandom3",
              "VRRandom4", "VRRandom5", "VRRandom6", "VRRandom7", "VRRandom8", "VRRandom9",
              "VRRandom10", "VRRandom11", "VRRandom12", "VRRandom13", "VRRandom14", "VRRandom15",
              "VRZeroBias", "VirginRaw"]
@@ -1380,124 +1162,6 @@ DATASETS += ["AlCaElectron", "VRRandom", "VRRandom0", "VRRandom1", "VRRandom2", 
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,
                do_reco=False,
-               scenario=ppScenario)
-
-
-#########################################
-### New PDs for pp Reference Run 2017 ###
-#########################################
-
-DATASETS = ["HighEGJet", "LowEGJet"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               dqm_sequences=["@common", "@ecal", "@egamma", "@L1TMon", "@hcal", "@jetmet"],
-               scenario=ppScenario)
-
-DATASETS = ["HeavyFlavor", "SingleTrack"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               dqm_sequences=["@common"],
-               scenario=ppScenario)
-
-DATASETS = ["HIZeroBias1", "HIZeroBias2", "HIZeroBias3", "HIZeroBias4",
-            "HIZeroBias5", "HIZeroBias6", "HIZeroBias7", "HIZeroBias8",
-            "HIZeroBias9", "HIZeroBias10", "HIZeroBias11", "HIZeroBias12"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               dqm_sequences=["@commonSiStripZeroBias", "@ecal", "@L1TMon", "@hcal", "@muon"],
-               alca_producers=["SiStripCalZeroBias", "TkAlMinBias", "LumiPixelsMinBias", "SiStripCalMinBias", "AlCaPCCZeroBiasFromRECO"],
-               timePerEvent=3.5,
-               sizePerEvent=1500,
-               scenario=ppScenario)
-
-DATASETS = ["Totem12", "Totem34"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               dqm_sequences=["@common"],
-               scenario=ppScenario)
-
-################################
-### Low PU collisions 13 TeV ###
-################################
-
-DATASETS = ["CastorJets", "EGMLowPU", "FullTrack"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               dqm_sequences=["@common"],
-               scenario=ppScenario)
-
-DATASETS = ["HcalHPDNoise"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               dqm_sequences=["@common"],
-               physics_skims=["LogError", "LogErrorMonitor"],
-               scenario=ppScenario)
-
-DATASETS = ["HINMuon_HFveto"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               dqm_sequences=["@common"],
-               scenario=ppScenario)
-
-################################
-### Special Totem runs       ###
-################################
-
-DATASETS = ["TOTEM_minBias", "TOTEM_romanPots", "ToTOTEM", "ToTOTEM_DoubleJet32_0", "ToTOTEM_DoubleJet32_1",
-            "ToTOTEM_DoubleJet32_2", "ToTOTEM_DoubleJet32_3", "TOTEM_zeroBias", "ZeroBiasTotem", "MinimumBiasTotem",
-            "TOTEM_minBias1", "TOTEM_minBias2", "TOTEM_romanPots1", "TOTEM_romanPots2", "TOTEM_romanPots2_0",
-            "TOTEM_romanPots2_1", "TOTEM_romanPots2_2", "TOTEM_romanPots2_3", "TOTEM_romanPots2_4",
-            "TOTEM_romanPots2_5", "TOTEM_romanPots2_6", "TOTEM_romanPots2_7", "TOTEM_romanPots3",
-            "TOTEM_romanPotsTTBB_0", "TOTEM_romanPotsTTBB_1", "TOTEM_romanPotsTTBB_2", "TOTEM_romanPotsTTBB_3",
-            "TOTEM_romanPotsTTBB_4", "TOTEM_romanPotsTTBB_5", "TOTEM_romanPotsTTBB_6", "TOTEM_romanPotsTTBB_7"]
-
-DATASETS += ["Totem1", "Totem2", "Totem3", "Totem4"]
-
-### TOTEM DATASETS for 90m and LowPileUp menu - 2018/06/22
-DATASETS += ["HFvetoTOTEM", "JetsTOTEM"]
-
-DATASETS += ["RandomTOTEM1", "RandomTOTEM2", "RandomTOTEM3", "RandomTOTEM4"]
-
-DATASETS += ["TOTEM10", "TOTEM11", "TOTEM12", "TOTEM13", "TOTEM20", "TOTEM21", "TOTEM22",
-             "TOTEM23", "TOTEM3", "TOTEM40", "TOTEM41", "TOTEM42", "TOTEM43"]
-
-DATASETS += ["ZeroBiasTOTEM1", "ZeroBiasTOTEM2", "ZeroBiasTOTEM3", "ZeroBiasTOTEM4"]
-### TOTEM DATASETS for 90m and LowPileUp menu - 2018/06/22
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_reco=False,
-               dqm_sequences=["@common"],
-               scenario=ppScenario)
-
-### TOTEM EGamma dataset for 90m and LowPileUp with egamma dqm sequence
-DATASETS = ["MuonEGammaTOTEM"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_reco=False,
-               write_dqm=True,
-               dqm_sequences=["@common", "@egamma"],
                scenario=ppScenario)
 
 # PPS 2022
@@ -1511,263 +1175,6 @@ for dataset in DATASETS:
                alca_producers=["PPSCalMaxTracks"],
                dqm_sequences=["@none"],
                scenario=alcaPPSScenario)
-
-################################
-### 50 ns Physics Menu       ###
-################################
-
-DATASETS = ["L1TechBPTXPlusOnly", "L1TechBPTXMinusOnly", "L1TechBPTXQuiet"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               dqm_sequences=["@common"],
-               scenario=ppScenario)
-
-DATASETS = ["SingleMu"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               dqm_sequences=["@common"],
-               scenario=ppScenario)
-
-DATASETS = ["DoubleMu"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               dqm_sequences=["@common"],
-               alca_producers=["TkAlZMuMu", "TkAlJpsiMuMu", "TkAlUpsilonMuMu", "MuAlCalIsolatedMu", "MuAlOverlaps", "MuAlZMuMu", "HcalCalIsoTrkFilter"],
-               physics_skims=["Onia"],
-               scenario=ppScenario)
-
-DATASETS = ["DoublePhoton"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               dqm_sequences=["@common", "@ecal", "@egamma"],
-               scenario=ppScenario)
-
-
-#########################################
-### New PDs for pp Reference Run 2015 ###
-#########################################
-
-# new PD with same name added for 2017 ppRef
-# keeping this config for reference
-# addDataset(tier0Config, "HeavyFlavor",
-#            do_reco=True,
-#            write_dqm=True,
-#            dqm_sequences=["@common"],
-#            physics_skims=["D0Meson"],
-#            scenario=ppScenario)
-
-addDataset(tier0Config, "HighPtJet80",
-           do_reco=True,
-           write_dqm=True,
-           dqm_sequences=["@common"],
-           physics_skims=["HighPtJet"],
-           scenario=ppScenario)
-
-addDataset(tier0Config, "SingleMuHighPt",
-           do_reco=True,
-           write_dqm=True,
-           alca_producers=["TkAlMuonIsolated", "HcalCalIterativePhiSym", "MuAlCalIsolatedMu", "MuAlOverlaps", "MuAlZMuMu"],
-           dqm_sequences=["@common"],
-           physics_skims=["ZMM"],
-           scenario=ppScenario)
-
-addDataset(tier0Config, "SingleMuLowPt",
-           do_reco=True,
-           write_dqm=True,
-           alca_producers=["TkAlMuonIsolated", "HcalCalIterativePhiSym", "MuAlCalIsolatedMu", "MuAlOverlaps", "MuAlZMuMu"],
-           dqm_sequences=["@common"],
-           scenario=ppScenario)
-
-###############################
-### ExpressPA configuration ###
-###############################
-
-addExpressConfig(tier0Config, "ExpressPA",
-                 scenario=hiScenario,
-                 data_tiers=["FEVT"],
-                 write_dqm=True,
-                 alca_producers=["SiStripCalZeroBias", "TkAlMinBias", "SiStripCalMinBias",
-                                 "SiStripCalMinBiasAfterAbortGap", "LumiPixelsMinBias", "PromptCalibProd",
-                                 "PromptCalibProdSiStrip", "PromptCalibProdSiPixelAli", "PromptCalibProdSiStripGains",
-                                 "PromptCalibProdSiStripGainsAfterAbortGap", "SiStripPCLHistos"],
-                 reco_version=defaultCMSSWVersion,
-                 multicore=numberOfCores,
-                 global_tag_connect=globalTagConnect,
-                 global_tag=expressGlobalTag,
-                 proc_ver=expressProcVersion,
-                 maxInputRate=23 * 1000,
-                 maxInputEvents=400,
-                 maxInputSize=2 * 1024 * 1024 * 1024,
-                 maxInputFiles=15,
-                 maxLatency=15 * 23,
-                 periodicHarvestInterval=20 * 60,
-                 blockCloseDelay=1200,
-                 timePerEvent=4,
-                 sizePerEvent=1700,
-                 diskNode="T2_CH_CERN",
-                 versionOverride=expressVersionOverride)
-
-addExpressConfig(tier0Config, "HLTMonitorPA",
-                 scenario=hiScenario,
-                 data_tiers=["FEVTHLTALL"],
-                 write_dqm=True,
-                 alca_producers=[],
-                 dqm_sequences=["@HLTMonPA"],
-                 reco_version=defaultCMSSWVersion,
-                 multicore=numberOfCores,
-                 global_tag_connect=globalTagConnect,
-                 global_tag=expressGlobalTag,
-                 proc_ver=expressProcVersion,
-                 maxInputRate=23 * 1000,
-                 maxInputEvents=400,
-                 maxInputSize=2 * 1024 * 1024 * 1024,
-                 maxInputFiles=15,
-                 maxLatency=15 * 23,
-                 periodicHarvestInterval=20 * 60,
-                 blockCloseDelay=1200,
-                 timePerEvent=4, #I have to get some stats to set this properly
-                 sizePerEvent=1700, #I have to get some stats to set this properly
-                 diskNode="T2_CH_CERN",
-                 versionOverride=expressVersionOverride)
-
-#########################################
-### New PDs for PARun 2016 ###
-#########################################
-
-DATASETS = ["PAHighMultiplicity0", "PAHighMultiplicity1", "PAHighMultiplicity2", "PAHighMultiplicity3",
-            "PAHighMultiplicity4", "PAHighMultiplicity5", "PAHighMultiplicity6", "PAHighMultiplicity7"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               dqm_sequences=["@common"],
-               scenario=hiScenario)
-
-addDataset(tier0Config, "PACastor",
-           do_reco=True,
-           write_dqm=True,
-           dqm_sequences=["@common"],
-           scenario=hiScenario)
-
-addDataset(tier0Config, "PAForward",
-           do_reco=True,
-           write_dqm=True,
-           dqm_sequences=["@common"],
-           scenario=hiScenario)
-
-addDataset(tier0Config, "PADoubleMuon",
-           do_reco=True,
-           write_dqm=True,
-           dqm_sequences=["@common", "@muon"],
-           alca_producers=["TkAlMuonIsolatedPA", "TkAlZMuMuPA", "TkAlUpsilonMuMuPA"],
-           scenario=hiScenario)
-
-addDataset(tier0Config, "PASingleMuon",
-           do_reco=True,
-           write_dqm=True,
-           dqm_sequences=["@common", "@muon"],
-           alca_producers=["TkAlMuonIsolatedPA"],
-           physics_skims=["PAZMM"],
-           scenario=hiScenario)
-
-DATASETS = ["PADTrack1", "PADTrack2"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               dqm_sequences=["@common"],
-               scenario=hiScenario)
-
-addDataset(tier0Config, "PAEGJet1",
-           do_reco=True,
-           write_dqm=True,
-           dqm_sequences=["@common", "@ecal", "@egamma", "@L1TMon", "@hcal", "@jetmet"],
-           physics_skims=["PAZEE"],
-           scenario=hiScenario)
-
-DATASETS = ["PAMinimumBias1", "PAMinimumBias2", "PAMinimumBias3", "PAMinimumBias4",
-            "PAMinimumBias5", "PAMinimumBias6", "PAMinimumBias7", "PAMinimumBias8",
-            "PAMinimumBias9", "PAMinimumBias10", "PAMinimumBias11", "PAMinimumBias12",
-            "PAMinimumBias13", "PAMinimumBias14", "PAMinimumBias15", "PAMinimumBias16",
-            "PAMinimumBias17", "PAMinimumBias18", "PAMinimumBias19", "PAMinimumBias20"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               dqm_sequences=["@common"],
-               alca_producers=["SiStripCalMinBias", "TkAlMinBias"],
-               scenario=hiScenario)
-
-addDataset(tier0Config, "PAMinimumBiasBkg",
-           do_reco=True,
-           write_dqm=True,
-           dqm_sequences=["@common"],
-           physics_skims=["PAMinBias"],
-           scenario=hiScenario)
-
-
-addDataset(tier0Config, "PAEmptyBX",
-           do_reco=True,
-           write_dqm=True,
-           dqm_sequences=["@common"],
-           scenario=hiScenario)
-
-#############################
-###   PDs pA VdM scan     ###
-#############################
-
-DATASETS = ["PAL1AlwaysTrue0", "PAL1AlwaysTrue1", "PAL1AlwaysTrue2", "PAL1AlwaysTrue3",
-            "PAL1AlwaysTrue4", "PAL1AlwaysTrue5", "PAL1AlwaysTrue6", "PAL1AlwaysTrue7",
-            "PAL1AlwaysTrue8", "PAL1AlwaysTrue9"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               alca_producers=["LumiPixelsMinBias"],
-               dqm_sequences=["@common"],
-               scenario=hiScenario)
-
-DATASETS = ["PAMinimumBiasHFOR0", "PAMinimumBiasHFOR1", "PAMinimumBiasHFOR2"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               alca_producers=["LumiPixelsMinBias"],
-               dqm_sequences=["@common"],
-               scenario=hiScenario)
-
-DATASETS = ["PAZeroBias0", "PAZeroBias1", "PAZeroBias2", "PAZeroBias3",
-            "PAZeroBias4", "PAZeroBias5", "PAZeroBias6", "PAZeroBias7",
-            "PAZeroBias8", "PAZeroBias9"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               alca_producers=["LumiPixelsMinBias"],
-               dqm_sequences=["@commonSiStripZeroBias", "@ecal", "@L1TMon", "@hcal", "@muon"],
-               scenario=hiScenario)
-
-addDataset(tier0Config, "PADoubleMuOpen",
-           do_reco=True,
-           write_dqm=True,
-           alca_producers=["LumiPixelsMinBias"],
-           dqm_sequences=["@common", "@muon"],
-           scenario=hiScenario)
 
 #####################
 ### HI TESTS 2018 ###

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -553,60 +553,7 @@ for dataset in DATASETS:
                dqm_sequences=["@common"],
                scenario=ppScenario)
 
-DATASETS = ["FSQJet1", "FSQJet2"]
-
-DATASETS = ["FSQJets", "FSQJets1", "FSQJets2", "FSQJets3"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               dqm_sequences=["@common", "@jetmet"],
-               scenario=ppScenario)
-
-DATASETS = ["HINCaloJets", "HINPFJets"]
-
-DATASETS += ["HINCaloJet40", "HINPFJet100", "HINCaloJet100", "HINCaloJetsOther", "HINPFJetsOther"]
-
-DATASETS += ["HINMuon", "HINPhoton"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               dqm_sequences=["@common"],
-               scenario=ppScenario)
-
-DATASETS = ["HighMultiplicity"]
-
-DATASETS += ["HighMultiplicityEOF0", "HighMultiplicityEOF1", "HighMultiplicityEOF2",
-             "HighMultiplicityEOF3", "HighMultiplicityEOF4", "HighMultiplicityEOF5"]
-
-DATASETS += ["HighMultiplicity85", "HighMultiplicity85EOF"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_reco=False,
-               write_dqm=True,
-               dqm_sequences=["@common"],
-               scenario=ppScenario)
-
-# 05/07/2018 HighMultiplicityEOF needs to have 1sec per event
-DATASETS = ["HighMultiplicityEOF"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_reco=False,
-               write_dqm=True,
-               dqm_sequences=["@common"],
-               timePerEvent=1,
-               scenario=ppScenario)
-
 DATASETS = ["HighPtLowerPhotons", "HighPtPhoton30AndZ"]
-
-DATASETS += ["ppForward", "HighPtLowerJets", "MuPlusX"]
 
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,
@@ -777,15 +724,6 @@ for dataset in DATASETS:
                raw_to_disk=False,
                scenario=ppScenario)
 
-DATASETS = ["CosmicsForEventDisplay"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=False,
-               raw_to_disk=False,
-               write_miniaod=False,
-               scenario=cosmicsScenario)
-
 DATASETS = ["L1Accept", "L1Accepts"]
 
 for dataset in DATASETS:
@@ -943,27 +881,6 @@ for dataset in DATASETS:
                physics_skims=["LogError", "LogErrorMonitor"],
                scenario=ppScenario)
 
-DATASETS = ["HLTPhysicsBunchTrains", "HLTPhysicsIsolatedBunch"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               raw_to_disk=True,
-               write_dqm=True,
-               alca_producers=["SiStripCalMinBias", "TkAlMinBias", "HcalCalIsoTrkFilter"],
-               physics_skims=["LogError", "LogErrorMonitor"],
-               scenario=ppScenario)
-
-DATASETS = ["HLTPhysicspart0", "HLTPhysicspart1",
-            "HLTPhysicspart2", "HLTPhysicspart3", "HLTPhysicspart4",
-            "HLTPhysicspart5", "HLTPhysicspart6", "HLTPhysicspart7"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=False,
-               raw_to_disk=True,
-               scenario=ppScenario)
-
 DATASETS = ["EphemeralHLTPhysics0","EphemeralHLTPhysics1", "EphemeralHLTPhysics2", "EphemeralHLTPhysics3",
             "EphemeralHLTPhysics4", "EphemeralHLTPhysics5", "EphemeralHLTPhysics6","EphemeralHLTPhysics7"
             "EphemeralHLTPhysics8", "EphemeralHLTPhysics9","EphemeralHLTPhysics10","EphemeralHLTPhysics11"
@@ -977,18 +894,6 @@ for dataset in DATASETS:
                dqm_sequences=["@none"],
                write_dqm=False,
                scenario=ppScenario)
-
-DATASETS = ["HLTPhysicsCosmics", "HLTPhysicsCosmics1", "HLTPhysicsCosmics2",
-            "HLTPhysicsCosmics3", "HLTPhysicsCosmics4", "HLTPhysicsCosmics5",
-            "HLTPhysicsCosmics6", "HLTPhysicsCosmics7", "HLTPhysicsCosmics8"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_miniaod=False,
-               raw_to_disk=True,
-               dqm_sequences=["@common"],
-               scenario=cosmicsScenario)
 
 ########################################################
 ### MinimumBias PDs                                  ###
@@ -1011,27 +916,11 @@ for dataset in DATASETS:
                alca_producers=["SiStripCalZeroBias", "SiStripCalMinBias", "TkAlMinBias"],
                scenario=ppScenario)
 
-DATASETS = ["L1MinimumBias"]
-
-DATASETS += ["L1MinimumBiasHF1", "L1MinimumBiasHF2", "L1MinimumBiasHF3", "L1MinimumBiasHF4",
-             "L1MinimumBiasHF5", "L1MinimumBiasHF6", "L1MinimumBiasHF7", "L1MinimumBiasHF8"]
-
-DATASETS += ["L1MinimumBias0", "L1MinimumBias1", "L1MinimumBias2", "L1MinimumBias3", "L1MinimumBias4",
-             "L1MinimumBias5", "L1MinimumBias6", "L1MinimumBias7", "L1MinimumBias8", "L1MinimumBias9",
-             "L1MinimumBias10"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               dqm_sequences=["@common"],
-               scenario=ppScenario)
-
 ########################################################
 ### ZeroBias PDs                                     ###
 ########################################################
 
-DATASETS = ["ZeroBias"]
+DATASETS = ["ZeroBias", "ZeroBias0"]
 
 DATASETS += ["ZeroBias1", "ZeroBias2",
              "ZeroBias3", "ZeroBias4", "ZeroBias5", "ZeroBias6",
@@ -1085,21 +974,6 @@ for dataset in DATASETS:
                sizePerEvent=1500,
                scenario=ppScenario)
 
-DATASETS = ["ZeroBias0"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               raw_to_disk=True,
-               write_reco=False,
-               write_dqm=True,
-               dqm_sequences=["@commonSiStripZeroBias", "@ecal", "@L1TMon", "@hcal", "@muon", "@jetmet", "@ctpps"],
-               alca_producers=["SiStripCalZeroBias", "TkAlMinBias", "SiStripCalMinBias"],
-               physics_skims=["LogError", "LogErrorMonitor"],
-               timePerEvent=3.5,
-               sizePerEvent=1500,
-               scenario=ppScenario)
-
 DATASETS = ["EphemeralZeroBias0", "EphemeralZeroBias1", "EphemeralZeroBias2", "EphemeralZeroBias3",
             "EphemeralZeroBias4", "EphemeralZeroBias5", "EphemeralZeroBias6", "EphemeralZeroBias7",
             "EphemeralZeroBias8", "EphemeralZeroBias9", "EphemeralZeroBias10", "EphemeralZeroBias11",
@@ -1132,46 +1006,6 @@ for dataset in DATASETS:
     addDataset(tier0Config, dataset,
                do_reco=True,
                tape_node=None,
-               scenario=ppScenario)
-
-DATASETS = ["ParkingMonitor"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               dqm_sequences=["@common"],
-               write_reco=False, write_aod=False, write_miniaod=True, write_dqm=True,
-               scenario=ppScenario)
-
-DATASETS = ["ParkingScoutingMonitor"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               dqm_sequences=["@common"],
-               write_reco=False, write_aod=False, write_miniaod=True, write_dqm=True,
-               scenario=ppScenario)
-
-DATASETS = ["ParkingMuon", "ParkingHT"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=False,
-               scenario=ppScenario)
-
-DATASETS = ["ParkingBPH1", "ParkingBPH2", "ParkingBPH3", "ParkingBPH4", "ParkingBPH5", "ParkingBPH6"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=False,
-               scenario=ppScenario)
-
-# Parking PD to be PR'ed at CSCS
-DATASETS = ["ParkingBPHPromptCSCS"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=False,
                scenario=ppScenario)
 
 DATASETS = ["RPCMonitor"]
@@ -1207,39 +1041,7 @@ for dataset in DATASETS:
                do_reco=False,
                scenario=ppScenario)
 
-DATASETS = ["ParkingHT410to430", "ParkingHT500to550", "ParkingHT430to450", "ParkingHT470to500", "ParkingHT450to470"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=False,
-               scenario=ppScenario)
-
-DATASETS = ["ParkingHT550to650", "ParkingHT650"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=False,
-               scenario=ppScenario)
-
-DATASETS = ["ParkingHLTPhysics", "ParkingHLTPhysics0", "ParkingHLTPhysics1",
-            "ParkingHLTPhysics2", "ParkingHLTPhysics3", "ParkingHLTPhysics4",
-            "ParkingHLTPhysics5", "ParkingHLTPhysics6", "ParkingHLTPhysics7",
-            "ParkingHLTPhysics8", "ParkingHLTPhysics9", "ParkingHLTPhysics10",
-            "ParkingHLTPhysics11", "ParkingHLTPhysics12", "ParkingHLTPhysics13",
-            "ParkingHLTPhysics14", "ParkingHLTPhysics15", "ParkingHLTPhysics16",
-            "ParkingHLTPhysics17", "ParkingHLTPhysics18", "ParkingHLTPhysics19",
-            "ParkingHLTPhysics20"]
-
-DATASETS += ["ParkingZeroBias", "ParkingZeroBias0",
-             "ParkingZeroBias1", "ParkingZeroBias2", "ParkingZeroBias3",
-             "ParkingZeroBias4", "ParkingZeroBias5", "ParkingZeroBias6",
-             "ParkingZeroBias7", "ParkingZeroBias8", "ParkingZeroBias9",
-             "ParkingZeroBias10", "ParkingZeroBias11", "ParkingZeroBias12",
-             "ParkingZeroBias13", "ParkingZeroBias14", "ParkingZeroBias15",
-             "ParkingZeroBias16", "ParkingZeroBias17", "ParkingZeroBias18",
-             "ParkingZeroBias19", "ParkingZeroBias20"]
-
-DATASETS += ["AlCaElectron", "VRRandom", "VRRandom0", "VRRandom1", "VRRandom2", "VRRandom3",
+DATASETS = ["AlCaElectron", "VRRandom", "VRRandom0", "VRRandom1", "VRRandom2", "VRRandom3",
              "VRRandom4", "VRRandom5", "VRRandom6", "VRRandom7", "VRRandom8", "VRRandom9",
              "VRRandom10", "VRRandom11", "VRRandom12", "VRRandom13", "VRRandom14", "VRRandom15",
              "VRZeroBias", "VirginRaw"]
@@ -1247,124 +1049,6 @@ DATASETS += ["AlCaElectron", "VRRandom", "VRRandom0", "VRRandom1", "VRRandom2", 
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,
                do_reco=False,
-               scenario=ppScenario)
-
-
-#########################################
-### New PDs for pp Reference Run 2017 ###
-#########################################
-
-DATASETS = ["HighEGJet", "LowEGJet"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               dqm_sequences=["@common", "@ecal", "@egamma", "@L1TMon", "@hcal", "@jetmet"],
-               scenario=ppScenario)
-
-DATASETS = ["HeavyFlavor", "SingleTrack"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               dqm_sequences=["@common"],
-               scenario=ppScenario)
-
-DATASETS = ["HIZeroBias1", "HIZeroBias2", "HIZeroBias3", "HIZeroBias4",
-            "HIZeroBias5", "HIZeroBias6", "HIZeroBias7", "HIZeroBias8",
-            "HIZeroBias9", "HIZeroBias10", "HIZeroBias11", "HIZeroBias12"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               dqm_sequences=["@commonSiStripZeroBias", "@ecal", "@L1TMon", "@hcal", "@muon"],
-               alca_producers=["SiStripCalZeroBias", "TkAlMinBias", "LumiPixelsMinBias", "SiStripCalMinBias", "AlCaPCCZeroBiasFromRECO"],
-               timePerEvent=3.5,
-               sizePerEvent=1500,
-               scenario=ppScenario)
-
-DATASETS = ["Totem12", "Totem34"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               dqm_sequences=["@common"],
-               scenario=ppScenario)
-
-################################
-### Low PU collisions 13 TeV ###
-################################
-
-DATASETS = ["CastorJets", "EGMLowPU", "FullTrack"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               dqm_sequences=["@common"],
-               scenario=ppScenario)
-
-DATASETS = ["HcalHPDNoise"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               dqm_sequences=["@common"],
-               physics_skims=["LogError", "LogErrorMonitor"],
-               scenario=ppScenario)
-
-DATASETS = ["HINMuon_HFveto"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               dqm_sequences=["@common"],
-               scenario=ppScenario)
-
-################################
-### Special Totem runs       ###
-################################
-
-DATASETS = ["TOTEM_minBias", "TOTEM_romanPots", "ToTOTEM", "ToTOTEM_DoubleJet32_0", "ToTOTEM_DoubleJet32_1",
-            "ToTOTEM_DoubleJet32_2", "ToTOTEM_DoubleJet32_3", "TOTEM_zeroBias", "ZeroBiasTotem", "MinimumBiasTotem",
-            "TOTEM_minBias1", "TOTEM_minBias2", "TOTEM_romanPots1", "TOTEM_romanPots2", "TOTEM_romanPots2_0",
-            "TOTEM_romanPots2_1", "TOTEM_romanPots2_2", "TOTEM_romanPots2_3", "TOTEM_romanPots2_4",
-            "TOTEM_romanPots2_5", "TOTEM_romanPots2_6", "TOTEM_romanPots2_7", "TOTEM_romanPots3",
-            "TOTEM_romanPotsTTBB_0", "TOTEM_romanPotsTTBB_1", "TOTEM_romanPotsTTBB_2", "TOTEM_romanPotsTTBB_3",
-            "TOTEM_romanPotsTTBB_4", "TOTEM_romanPotsTTBB_5", "TOTEM_romanPotsTTBB_6", "TOTEM_romanPotsTTBB_7"]
-
-DATASETS += ["Totem1", "Totem2", "Totem3", "Totem4"]
-
-### TOTEM DATASETS for 90m and LowPileUp menu - 2018/06/22
-DATASETS += ["HFvetoTOTEM", "JetsTOTEM"]
-
-DATASETS += ["RandomTOTEM1", "RandomTOTEM2", "RandomTOTEM3", "RandomTOTEM4"]
-
-DATASETS += ["TOTEM10", "TOTEM11", "TOTEM12", "TOTEM13", "TOTEM20", "TOTEM21", "TOTEM22",
-             "TOTEM23", "TOTEM3", "TOTEM40", "TOTEM41", "TOTEM42", "TOTEM43"]
-
-DATASETS += ["ZeroBiasTOTEM1", "ZeroBiasTOTEM2", "ZeroBiasTOTEM3", "ZeroBiasTOTEM4"]
-### TOTEM DATASETS for 90m and LowPileUp menu - 2018/06/22
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_reco=False,
-               dqm_sequences=["@common"],
-               scenario=ppScenario)
-
-### TOTEM EGamma dataset for 90m and LowPileUp with egamma dqm sequence
-DATASETS = ["MuonEGammaTOTEM"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_reco=False,
-               write_dqm=True,
-               dqm_sequences=["@common", "@egamma"],
                scenario=ppScenario)
 
 # PPS 2022
@@ -1378,265 +1062,6 @@ for dataset in DATASETS:
                alca_producers=["PPSCalMaxTracks"],
                dqm_sequences=["@none"],
                scenario=alcaPPSScenario)
-
-################################
-### 50 ns Physics Menu       ###
-################################
-
-DATASETS = ["L1TechBPTXPlusOnly", "L1TechBPTXMinusOnly", "L1TechBPTXQuiet"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               dqm_sequences=["@common"],
-               scenario=ppScenario)
-
-DATASETS = ["SingleMu"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               dqm_sequences=["@common"],
-               scenario=ppScenario)
-
-DATASETS = ["DoubleMu"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               dqm_sequences=["@common"],
-               alca_producers=["TkAlZMuMu", "TkAlJpsiMuMu", "TkAlUpsilonMuMu", "MuAlCalIsolatedMu", "MuAlOverlaps", "MuAlZMuMu", "HcalCalIsoTrkFilter"],
-               physics_skims=["Onia"],
-               scenario=ppScenario)
-
-DATASETS = ["DoublePhoton"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               dqm_sequences=["@common", "@ecal", "@egamma"],
-               scenario=ppScenario)
-
-
-#########################################
-### New PDs for pp Reference Run 2015 ###
-#########################################
-
-# new PD with same name added for 2017 ppRef
-# keeping this config for reference
-# addDataset(tier0Config, "HeavyFlavor",
-#            do_reco=True,
-#            write_dqm=True,
-#            dqm_sequences=["@common"],
-#            physics_skims=["D0Meson"],
-#            scenario=ppScenario)
-
-addDataset(tier0Config, "HighPtJet80",
-           do_reco=True,
-           write_dqm=True,
-           dqm_sequences=["@common"],
-           physics_skims=["HighPtJet"],
-           scenario=ppScenario)
-
-addDataset(tier0Config, "SingleMuHighPt",
-           do_reco=True,
-           write_dqm=True,
-           alca_producers=["TkAlMuonIsolated", "HcalCalIterativePhiSym", "MuAlCalIsolatedMu", "MuAlOverlaps", "MuAlZMuMu"],
-           dqm_sequences=["@common"],
-           physics_skims=["ZMM"],
-           scenario=ppScenario)
-
-addDataset(tier0Config, "SingleMuLowPt",
-           do_reco=True,
-           write_dqm=True,
-           alca_producers=["TkAlMuonIsolated", "HcalCalIterativePhiSym", "MuAlCalIsolatedMu", "MuAlOverlaps", "MuAlZMuMu"],
-           dqm_sequences=["@common"],
-           scenario=ppScenario)
-
-###############################
-### ExpressPA configuration ###
-###############################
-
-addExpressConfig(tier0Config, "ExpressPA",
-                 scenario=hiScenario,
-                 data_tiers=["FEVT"],
-                 write_dqm=True,
-                 alca_producers=["SiStripCalZeroBias", "TkAlMinBias", "SiStripCalMinBias",
-                                 "SiStripCalMinBiasAfterAbortGap", "LumiPixelsMinBias", "PromptCalibProd",
-                                 "PromptCalibProdSiStrip", "PromptCalibProdSiPixelAli", "PromptCalibProdSiStripGains",
-                                 "PromptCalibProdSiStripGainsAfterAbortGap", "SiStripPCLHistos"],
-                 reco_version=defaultCMSSWVersion,
-                 multicore=numberOfCores,
-                 global_tag_connect=globalTagConnect,
-                 global_tag=expressGlobalTag,
-                 proc_ver=expressProcVersion,
-                 maxInputRate=23 * 1000,
-                 maxInputEvents=400,
-                 maxInputSize=2 * 1024 * 1024 * 1024,
-                 maxInputFiles=15,
-                 maxLatency=15 * 23,
-                 periodicHarvestInterval=20 * 60,
-                 blockCloseDelay=1200,
-                 timePerEvent=4,
-                 sizePerEvent=1700,
-                 diskNode="T0_CH_CERN_Disk",
-                 dataset_lifetime=14*24*3600,#lifetime for container rules. Default 14 days
-                 versionOverride=expressVersionOverride)
-
-addExpressConfig(tier0Config, "HLTMonitorPA",
-                 scenario=hiScenario,
-                 data_tiers=["FEVTHLTALL"],
-                 write_dqm=True,
-                 alca_producers=[],
-                 dqm_sequences=["@HLTMonPA"],
-                 reco_version=defaultCMSSWVersion,
-                 multicore=numberOfCores,
-                 global_tag_connect=globalTagConnect,
-                 global_tag=expressGlobalTag,
-                 proc_ver=expressProcVersion,
-                 maxInputRate=23 * 1000,
-                 maxInputEvents=400,
-                 maxInputSize=2 * 1024 * 1024 * 1024,
-                 maxInputFiles=15,
-                 maxLatency=15 * 23,
-                 periodicHarvestInterval=20 * 60,
-                 blockCloseDelay=1200,
-                 timePerEvent=4, #I have to get some stats to set this properly
-                 sizePerEvent=1700, #I have to get some stats to set this properly
-                 diskNode="T0_CH_CERN_Disk",
-                 dataset_lifetime=14*24*3600,#lifetime for container rules. Default 14 days
-                 versionOverride=expressVersionOverride)
-
-#########################################
-### New PDs for PARun 2016 ###
-#########################################
-
-DATASETS = ["PAHighMultiplicity0", "PAHighMultiplicity1", "PAHighMultiplicity2", "PAHighMultiplicity3",
-            "PAHighMultiplicity4", "PAHighMultiplicity5", "PAHighMultiplicity6", "PAHighMultiplicity7"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               dqm_sequences=["@common"],
-               scenario=hiScenario)
-
-addDataset(tier0Config, "PACastor",
-           do_reco=True,
-           write_dqm=True,
-           dqm_sequences=["@common"],
-           scenario=hiScenario)
-
-addDataset(tier0Config, "PAForward",
-           do_reco=True,
-           write_dqm=True,
-           dqm_sequences=["@common"],
-           scenario=hiScenario)
-
-addDataset(tier0Config, "PADoubleMuon",
-           do_reco=True,
-           write_dqm=True,
-           dqm_sequences=["@common", "@muon"],
-           alca_producers=["TkAlMuonIsolatedPA", "TkAlZMuMuPA", "TkAlUpsilonMuMuPA"],
-           scenario=hiScenario)
-
-addDataset(tier0Config, "PASingleMuon",
-           do_reco=True,
-           write_dqm=True,
-           dqm_sequences=["@common", "@muon"],
-           alca_producers=["TkAlMuonIsolatedPA"],
-           physics_skims=["PAZMM"],
-           scenario=hiScenario)
-
-DATASETS = ["PADTrack1", "PADTrack2"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               dqm_sequences=["@common"],
-               scenario=hiScenario)
-
-addDataset(tier0Config, "PAEGJet1",
-           do_reco=True,
-           write_dqm=True,
-           dqm_sequences=["@common", "@ecal", "@egamma", "@L1TMon", "@hcal", "@jetmet"],
-           physics_skims=["PAZEE"],
-           scenario=hiScenario)
-
-DATASETS = ["PAMinimumBias1", "PAMinimumBias2", "PAMinimumBias3", "PAMinimumBias4",
-            "PAMinimumBias5", "PAMinimumBias6", "PAMinimumBias7", "PAMinimumBias8",
-            "PAMinimumBias9", "PAMinimumBias10", "PAMinimumBias11", "PAMinimumBias12",
-            "PAMinimumBias13", "PAMinimumBias14", "PAMinimumBias15", "PAMinimumBias16",
-            "PAMinimumBias17", "PAMinimumBias18", "PAMinimumBias19", "PAMinimumBias20"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               dqm_sequences=["@common"],
-               alca_producers=["SiStripCalMinBias", "TkAlMinBias"],
-               scenario=hiScenario)
-
-addDataset(tier0Config, "PAMinimumBiasBkg",
-           do_reco=True,
-           write_dqm=True,
-           dqm_sequences=["@common"],
-           physics_skims=["PAMinBias"],
-           scenario=hiScenario)
-
-
-addDataset(tier0Config, "PAEmptyBX",
-           do_reco=True,
-           write_dqm=True,
-           dqm_sequences=["@common"],
-           scenario=hiScenario)
-
-#############################
-###   PDs pA VdM scan     ###
-#############################
-
-DATASETS = ["PAL1AlwaysTrue0", "PAL1AlwaysTrue1", "PAL1AlwaysTrue2", "PAL1AlwaysTrue3",
-            "PAL1AlwaysTrue4", "PAL1AlwaysTrue5", "PAL1AlwaysTrue6", "PAL1AlwaysTrue7",
-            "PAL1AlwaysTrue8", "PAL1AlwaysTrue9"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               alca_producers=["LumiPixelsMinBias"],
-               dqm_sequences=["@common"],
-               scenario=hiScenario)
-
-DATASETS = ["PAMinimumBiasHFOR0", "PAMinimumBiasHFOR1", "PAMinimumBiasHFOR2"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               alca_producers=["LumiPixelsMinBias"],
-               dqm_sequences=["@common"],
-               scenario=hiScenario)
-
-DATASETS = ["PAZeroBias0", "PAZeroBias1", "PAZeroBias2", "PAZeroBias3",
-            "PAZeroBias4", "PAZeroBias5", "PAZeroBias6", "PAZeroBias7",
-            "PAZeroBias8", "PAZeroBias9"]
-
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_dqm=True,
-               alca_producers=["LumiPixelsMinBias"],
-               dqm_sequences=["@commonSiStripZeroBias", "@ecal", "@L1TMon", "@hcal", "@muon"],
-               scenario=hiScenario)
-
-addDataset(tier0Config, "PADoubleMuOpen",
-           do_reco=True,
-           write_dqm=True,
-           alca_producers=["LumiPixelsMinBias"],
-           dqm_sequences=["@common", "@muon"],
-           scenario=hiScenario)
 
 #####################
 ### HI TESTS 2018 ###


### PR DESCRIPTION
We are trying to reduce the number of unnecesary PD described in T0 config files. We can use this PR to discuss which PDs to remove.

I went throug the list and found several datasets that have not been used in the past 5 years. They are unlikely to return, or would need a different configuration if they do. Of course, we can always check the repo history to retrieve the configurations for the PDs.

This PR removes the following PDs:
  - FSQJet*, FSQJets*
  - HINCaloJets, HINCaloJet*, HINPFJets*, HINMuon, HINPhoton, HIZeroBias*, HINMuon_HFveto
  - HighMultiplicity*, HighMultiplicityEOF*
  - ppForward
  - HighPtLowerJets
  - MuPlus*
  - CosmicsForEventDisplay
  - HLTPhysicsBunchTrains, HLTPhysicsIsolatedBunch, HLTPhysicspart*, HLTPhysicsCosmics*
  - L1MinimumBias*
  - ParkingMonitor, ParkingScoutingMonitor
  - ParkingMuon, ParkingHT, ParkingHT\*to\*, ParkingBPH*, ParkingHLTPhysics*, ParkingZeroBias*
  - HighEGJet, LowEGJet
  - HeavyFlavor
  - SingleTrack
  - CastorJets, EGMLowPU, FullTrack
  - HcalHPDNoise, HcalCalIterativePhiSym
  - Totem*, TOTEM*, TOTEM_minBias*, MinimumBiasTotem, ToTOTEM, ToTOTEM_DoubleJet32_*, TOTEM_zeroBias, ZeroBiasTOTEM*, TOTEM_romanPots*, RandomTOTEM*, HFvetoTOTEM, JetsTOTEM
  - L1TechBPTX*
  - SingleMu, SingleMuHighPt, SingleMuLowPt
  - DoubleMu, DoublePhoton
  - HighPtJet80
  - MuAlCalIsolatedMu, MuAlOverlaps, MuAlZMuMu
  - kAlMuonIsolated, TkAlMuonIsolated
  - ExpressPA, HLTMonitorPA, PAHighMultiplicity*, PACastor, PAForward, PADoubleMuon, PASingleMuon, PADTrack*, PAEGJet1, PAMinimumBias*, PAZeroBias*, PAEmptyBX, PAL1AlwaysTrue*, PADoubleMuOpen
  