### PR TITLE
Replay configuration for 13_0_1

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -127,8 +127,8 @@ expressProcVersion = {
 }
 
 # Defaults for GlobalTag
-expressGlobalTag = "130X_dataRun3_Express_v1"
-promptrecoGlobalTag = "130X_dataRun3_Prompt_v1"
+expressGlobalTag = "130X_dataRun3_Express_v2"
+promptrecoGlobalTag = "130X_dataRun3_Prompt_v2"
 
 # Mandatory for CondDBv2
 globalTagConnect = "frontier://PromptProd/CMS_CONDITIONS"

--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -94,7 +94,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_13_0_0"
+    'default': "CMSSW_13_0_1"
 }
 
 # Configure ScramArch

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -102,7 +102,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_13_0_0"
+    'default': "CMSSW_13_0_1"
 }
 
 # Configure ScramArch

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -148,14 +148,12 @@ alcarawSplitting = 20000 * numberOfCores
 # Setup repack and express mappings
 #
 repackVersionOverride = {
-    "CMSSW_12_6_1" : defaultCMSSWVersion['default'],
-    "CMSSW_12_6_2" : defaultCMSSWVersion['default'],
+    "CMSSW_13_0_0" : defaultCMSSWVersion['default'],
     "CMSSW_12_6_3" : "CMSSW_12_6_4"
 }
 
 expressVersionOverride = {
-    "CMSSW_12_6_1" : defaultCMSSWVersion['default'],
-    "CMSSW_12_6_2" : defaultCMSSWVersion['default'],
+    "CMSSW_13_0_0" : defaultCMSSWVersion['default'],
     "CMSSW_12_6_3" : "CMSSW_12_6_4"
 }
 

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -35,7 +35,7 @@ setConfigVersion(tier0Config, "replace with real version")
 
 # Set run number to replay
 # Cosmics from cruzet, splashes, and 2022 collisions
-setInjectRuns(tier0Config, [364158,350966,359691])
+setInjectRuns(tier0Config, [365118,350966,359691])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"
@@ -150,13 +150,13 @@ alcarawSplitting = 20000 * numberOfCores
 repackVersionOverride = {
     "CMSSW_12_6_1" : defaultCMSSWVersion['default'],
     "CMSSW_12_6_2" : defaultCMSSWVersion['default'],
-    "CMSSW_12_6_3" : defaultCMSSWVersion['default']
+    "CMSSW_12_6_3" : "CMSSW_12_6_4"
 }
 
 expressVersionOverride = {
     "CMSSW_12_6_1" : defaultCMSSWVersion['default'],
     "CMSSW_12_6_2" : defaultCMSSWVersion['default'],
-    "CMSSW_12_6_3" : defaultCMSSWVersion['default']
+    "CMSSW_12_6_3" : "CMSSW_12_6_4"
 }
 
 #set default repack settings for bulk streams

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -130,8 +130,8 @@ expressProcVersion = dt
 alcarawProcVersion = dt
 
 # Defaults for GlobalTag
-expressGlobalTag = "130X_dataRun3_Express_v1"
-promptrecoGlobalTag = "130X_dataRun3_Prompt_v1"
+expressGlobalTag = "130X_dataRun3_Express_v2"
+promptrecoGlobalTag = "130X_dataRun3_Prompt_v2"
 
 # Mandatory for CondDBv2
 globalTagConnect = "frontier://PromptProd/CMS_CONDITIONS"


### PR DESCRIPTION
# Replay Request

**Requestor**  
ORM

**Describe the configuration**  
* Release: CMSSW_13_0_1
* Run: 364158,350966,359691
* GTs:
   * expressGlobalTag: 130X_dataRun3_Express_v1
   * promptrecoGlobalTag: 130X_dataRun3_Prompt_v1
* Additional changes:

**Purpose of the test**  
Testing for new release 13_0_1

