### PR TITLE
Tier0 Configuration for stable beams at injection energy

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -113,17 +113,17 @@ alcaPPSScenario = "AlCaPPS_Run3"
 hiTestppScenario = "ppEra_Run3"
 
 # Defaults for processing version
-defaultProcVersionRAW = 2
+defaultProcVersionRAW = 1
 alcarawProcVersion = {
-    'default': "2"
+    'default': "1"
 }
 
 defaultProcVersionReco = {
-    'default': "2"
+    'default': "1"
 }
 
 expressProcVersion = {
-    'default': "2"
+    'default': "1"
 }
 
 # Defaults for GlobalTag

--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -55,7 +55,7 @@ addSiteConfig(tier0Config, "T0_CH_CERN_Disk",
 #  Data type
 #  Processing site (where jobs run)
 #  PhEDEx locations
-setAcquisitionEra(tier0Config, "Commissioning2023")
+setAcquisitionEra(tier0Config, "Run2023A")
 setBaseRequestPriority(tier0Config, 251000)
 setBackfill(tier0Config, None)
 setBulkDataType(tier0Config, "data")
@@ -792,7 +792,7 @@ for dataset in DATASETS:
     addDataset(tier0Config, dataset,
                do_reco=True,
                write_dqm=True,
-               alca_producers=["TkAlMinBias", "SiStripCalMinBias", "HcalCalIsoTrk"],
+               alca_producers=["TkAlMinBias", "SiStripCalMinBias", "HcalCalIsoTrk", "HcalCalIsolatedBunchFilter"],
                dqm_sequences=["@common", "@L1TMon", "@hcal"],
                physics_skims=["EcalActivity", "LogError", "LogErrorMonitor"],
                timePerEvent=12,
@@ -1796,6 +1796,7 @@ ignoreStream(tier0Config, "DQMOffline")
 ignoreStream(tier0Config, "streamHLTRates")
 ignoreStream(tier0Config, "streamL1Rates")
 ignoreStream(tier0Config, "streamDQMRates")
+ignoreStream(tier0Config, "DQMPPSRandom")
 
 ###################################
 ### currently inactive settings ###

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -737,7 +737,7 @@ for dataset in DATASETS:
     addDataset(tier0Config, dataset,
                do_reco=True,
                write_dqm=True,
-               alca_producers=["TkAlMinBias", "SiStripCalMinBias", "HcalCalIsoTrk"],
+               alca_producers=["TkAlMinBias", "SiStripCalMinBias", "HcalCalIsoTrk", "HcalCalIsolatedBunchFilter"],
                dqm_sequences=["@common", "@L1TMon", "@hcal"],
                physics_skims=["EcalActivity", "LogError", "LogErrorMonitor"],
                timePerEvent=12,
@@ -1665,6 +1665,7 @@ ignoreStream(tier0Config, "DQMOffline")
 ignoreStream(tier0Config, "streamHLTRates")
 ignoreStream(tier0Config, "streamL1Rates")
 ignoreStream(tier0Config, "streamDQMRates")
+ignoreStream(tier0Config, "DQMPPSRandom")
 
 ###################################
 ### currently inactive settings ###


### PR DESCRIPTION
**Requestor**  
ORM ( @francescobrivio @saumyaphor4252 )

**Describe the configuration**  
* Release: CMSSW_13_0_0
* Run: 
* GTs:
   * expressGlobalTag: 130X_dataRun3_Express_v1
   * promptrecoGlobalTag: 130X_dataRun3_Prompt_v1
* Additional changes:

**Purpose of the test**  
Configuration for data taking with stable beams at 900 GeV. It includes the following updates:
   * New era → Run2023A
   * Add HCAL alcareco "HcalCalIsolatedBunchFilter" in the Commissioning PD
   * Add "DQMPPSRandom" to the ignored Streams
   * No update to GTs needed

**T0 Operations cmsTalk thread**  
https://cms-talk.web.cern.ch/t/t0-production-configuration-for-sb-at-900-gev/22319