### PR TITLE
Replay for CMSSW_13_0_3

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -35,7 +35,9 @@ setConfigVersion(tier0Config, "replace with real version")
 
 # Set run number to replay
 # Cosmics from cruzet, splashes, and 2022 collisions
-setInjectRuns(tier0Config, [364158,350966,359691])
+# 365118 - CRAFT 2023
+# 359691 - Collisions 2022
+setInjectRuns(tier0Config, [365118,359691])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"
@@ -102,7 +104,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_13_0_0"
+    'default': "CMSSW_13_0_3"
 }
 
 # Configure ScramArch
@@ -130,8 +132,8 @@ expressProcVersion = dt
 alcarawProcVersion = dt
 
 # Defaults for GlobalTag
-expressGlobalTag = "130X_dataRun3_Express_v1"
-promptrecoGlobalTag = "130X_dataRun3_Prompt_v1"
+expressGlobalTag = "130X_dataRun3_Express_v2"
+promptrecoGlobalTag = "130X_dataRun3_Prompt_Candidate_2023_03_09_09_47_16"
 
 # Mandatory for CondDBv2
 globalTagConnect = "frontier://PromptProd/CMS_CONDITIONS"
@@ -148,15 +150,13 @@ alcarawSplitting = 20000 * numberOfCores
 # Setup repack and express mappings
 #
 repackVersionOverride = {
-    "CMSSW_12_6_1" : defaultCMSSWVersion['default'],
-    "CMSSW_12_6_2" : defaultCMSSWVersion['default'],
-    "CMSSW_12_6_3" : defaultCMSSWVersion['default']
+    "CMSSW_13_0_0" : defaultCMSSWVersion['default'],
+    "CMSSW_12_6_3" : "CMSSW_12_6_4"
 }
 
 expressVersionOverride = {
-    "CMSSW_12_6_1" : defaultCMSSWVersion['default'],
-    "CMSSW_12_6_2" : defaultCMSSWVersion['default'],
-    "CMSSW_12_6_3" : defaultCMSSWVersion['default']
+    "CMSSW_13_0_0" : defaultCMSSWVersion['default'],
+    "CMSSW_12_6_3" : "CMSSW_12_6_4"
 }
 
 #set default repack settings for bulk streams
@@ -737,7 +737,7 @@ for dataset in DATASETS:
     addDataset(tier0Config, dataset,
                do_reco=True,
                write_dqm=True,
-               alca_producers=["TkAlMinBias", "SiStripCalMinBias", "HcalCalIsoTrk"],
+               alca_producers=["TkAlMinBias", "SiStripCalMinBias", "HcalCalIsoTrk", "HcalCalIsolatedBunchFilter"],
                dqm_sequences=["@common", "@L1TMon", "@hcal"],
                physics_skims=["EcalActivity", "LogError", "LogErrorMonitor"],
                timePerEvent=12,
@@ -1665,6 +1665,7 @@ ignoreStream(tier0Config, "DQMOffline")
 ignoreStream(tier0Config, "streamHLTRates")
 ignoreStream(tier0Config, "streamL1Rates")
 ignoreStream(tier0Config, "streamDQMRates")
+ignoreStream(tier0Config, "DQMPPSRandom")
 
 ###################################
 ### currently inactive settings ###

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -108,8 +108,8 @@ defaultCMSSWVersion = {
 }
 
 # Configure ScramArch
-setDefaultScramArch(tier0Config, "el8_amd64_gcc10")
-setScramArch(tier0Config, defaultCMSSWVersion['default'], "el8_amd64_gcc11")
+setDefaultScramArch(tier0Config, "el8_amd64_gcc11")
+setScramArch(tier0Config, "CMSSW_12_4_9", "el8_amd64_gcc10")
 setScramArch(tier0Config, "CMSSW_12_3_0", "cs8_amd64_gcc10")
 
 # Configure scenarios
@@ -150,12 +150,10 @@ alcarawSplitting = 20000 * numberOfCores
 # Setup repack and express mappings
 #
 repackVersionOverride = {
-    "CMSSW_13_0_0" : defaultCMSSWVersion['default'],
     "CMSSW_12_6_3" : "CMSSW_12_6_4"
 }
 
 expressVersionOverride = {
-    "CMSSW_13_0_0" : defaultCMSSWVersion['default'],
     "CMSSW_12_6_3" : "CMSSW_12_6_4"
 }
 


### PR DESCRIPTION
# Replay Request

**Requestor**  
ORMs (@malbouis @saumyaphor4252)

**Describe the configuration**  
* Release: CMSSW_13_0_3
* Runs: 
   * 365118 - CRAFT 2023
   * 359691 - Collisions 2022
* GTs:
   * expressGlobalTag: 130X_dataRun3_Express_v2
   * promptrecoGlobalTag: 130X_dataRun3_Prompt_Candidate_2023_03_09_09_47_16
       * Identical to `130X_dataRun3_Prompt_v2` but with correct triggerbits to run on 2022 data 
* Additional changes:
   * Added`HcalCalIsolatedBunchFilter` alcareco to Commissioning PD (already tested in previous replays but not yet deployed)
   * Added `ignoreStream(tier0Config, "DQMPPSRandom")`

**Purpose of the test**  
Test new CMSSW_13_0_3 release.

**T0 Operations cmsTalk thread**  
https://cms-talk.web.cern.ch/t/replay-testing-cmssw-13-0-3/22363