### PR TITLE
[RFC] Update ParkingDoubleElectronLowMass PD name

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -1090,7 +1090,7 @@ for dataset in DATASETS:
                disk_node="T1_UK_RAL_Disk",
                scenario=ppScenario)
 
-DATASETS = ["ParkingDoubleElectronLowMass0"]
+DATASETS = ["ParkingDoubleElectronLowMass","ParkingDoubleElectronLowMass0"]
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,
                do_reco=True,

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -998,7 +998,8 @@ for dataset in DATASETS:
 
 
 DATASETS = ["ParkingDoubleElectronLowMass0","ParkingDoubleElectronLowMass1","ParkingDoubleElectronLowMass2",
-            "ParkingDoubleElectronLowMass3","ParkingDoubleElectronLowMass4","ParkingDoubleElectronLowMass5"]
+            "ParkingDoubleElectronLowMass3","ParkingDoubleElectronLowMass4","ParkingDoubleElectronLowMass5",
+            "ParkingDoubleElectronLowMass"]
 
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,


### PR DESCRIPTION
## Config Update Request
Following [this comment](https://its.cern.ch/jira/browse/CMSHLT-2599?focusedCommentId=4802897&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-4802897) from @missirol regarding the preparations of the new collision menu at 13.6 TeV (expected tomorrow): for 2023 collisions the `ParkingDoubleElectronLowMass[0-5]` have been merged and renamed to `ParkingDoubleElectronLowMass`.

In this PR I'm simply adding the new dataset name (in both prod and replay configs) so that it can be Prompt-reconstructed correctly.

**Important Note:**
In the prod configuration there are actually 2 blocks to handle `ParkingDoubleElectronLowMass[0-5]` datasets:
1. the first block contains only the "0" dataset
2. the second block contains "1-5" datasets

The only difference of the two blocks is that the second one has `aod_to_disk=False`.
I added the the new dataset to the _first_ one: this means AOD will be sent to disk (IIUC) --> **Please confirm if this is ok or not!**

**T0 Operations cmsTalk thread**  
https://cms-talk.web.cern.ch/t/update-parkingdoubleelectronlowmass-pd-name/22966

Attn. @fabiocos @germanfgv @trtomei @mzarucki
