### PR TITLE
Update of configuration for Era 2023B

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -1090,7 +1090,7 @@ for dataset in DATASETS:
                disk_node="T1_UK_RAL_Disk",
                scenario=ppScenario)
 
-DATASETS = ["ParkingDoubleElectronLowMass0"]
+DATASETS = ["ParkingDoubleElectronLowMass","ParkingDoubleElectronLowMass0"]
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,
                do_reco=True,

--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -55,7 +55,7 @@ addSiteConfig(tier0Config, "T0_CH_CERN_Disk",
 #  Data type
 #  Processing site (where jobs run)
 #  PhEDEx locations
-setAcquisitionEra(tier0Config, "Run2023A")
+setAcquisitionEra(tier0Config, "Run2023B")
 setBaseRequestPriority(tier0Config, 251000)
 setBackfill(tier0Config, None)
 setBulkDataType(tier0Config, "data")
@@ -115,15 +115,15 @@ hiTestppScenario = "ppEra_Run3"
 # Defaults for processing version
 defaultProcVersionRAW = 1
 alcarawProcVersion = {
-    'default': "2"
+    'default': "1"
 }
 
 defaultProcVersionReco = {
-    'default': "2"
+    'default': "1"
 }
 
 expressProcVersion = {
-    'default': "2"
+    'default': "1"
 }
 
 # Defaults for GlobalTag

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -998,7 +998,8 @@ for dataset in DATASETS:
 
 
 DATASETS = ["ParkingDoubleElectronLowMass0","ParkingDoubleElectronLowMass1","ParkingDoubleElectronLowMass2",
-            "ParkingDoubleElectronLowMass3","ParkingDoubleElectronLowMass4","ParkingDoubleElectronLowMass5"]
+            "ParkingDoubleElectronLowMass3","ParkingDoubleElectronLowMass4","ParkingDoubleElectronLowMass5",
+            "ParkingDoubleElectronLowMass"]
 
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,


### PR DESCRIPTION
Proposal of updated configuration for Era 2023B, for 13.6 TeV collisions. 

Besides the change of era and processing version, it integrates the  update required by the new HLT menu proposed by @fbrivio in #4806