### PR TITLE
Add AlCaLumiPixelsCountsGated to the datasets

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -885,6 +885,20 @@ for dataset in DATASETS:
                sizePerEvent=38,
                scenario=alcaLumiPixelsScenario)
 
+DATASETS = ["AlCaLumiPixelsCountsGated"]
+
+for dataset in DATASETS:
+    addDataset(tier0Config, dataset,
+               do_reco=False,
+               write_reco=False, write_aod=False, write_miniaod=False, write_dqm=False,
+               raw_to_disk=True,
+               disk_node="T2_CH_CERN",
+               tape_node=None,
+               reco_split=alcarawSplitting,
+               proc_version=alcarawProcVersion,
+               timePerEvent=0.02,
+               sizePerEvent=38,
+               scenario=alcaLumiPixelsScenario)
 
 DATASETS = ["AlCaPhiSym"]
 

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -813,6 +813,20 @@ for dataset in DATASETS:
                sizePerEvent=38,
                scenario=alcaLumiPixelsScenario)
 
+DATASETS = ["AlCaLumiPixelsCountsGated"]
+
+for dataset in DATASETS:
+    addDataset(tier0Config, dataset,
+               do_reco=False,
+               write_reco=False, write_aod=False, write_miniaod=False, write_dqm=False,
+               disk_node=None,
+               tape_node=None,
+               reco_split=alcarawSplitting,
+               proc_version=alcarawProcVersion,
+               timePerEvent=0.02,
+               sizePerEvent=38,
+               scenario=alcaLumiPixelsScenario)
+
 DATASETS = ["AlCaPhiSym"]
 
 for dataset in DATASETS:


### PR DESCRIPTION
# Configuration update request

**Requestor**  
Helena as ORM

**Describe the configuration**  
* Release: _same as current config_
* Run: _same as current config_
* GTs: _same as current config_
   * expressGlobalTag: _same as current config_
   * promptrecoGlobalTag: _same as current config_
* Additional changes: Add `AlCaLumiPixelsCountsGated` to the configuration

**Purpose of the test**  
The purpose of this PR is to add the configuration of a new PD, `AlCaLumiPixelsCountsGated`,  for the upcoming emittance scan in 400b fill for Bril. Although it is not strictly needed in the configuration, it could be useful to have it for future reference. It is being discussed in this JIRA ticket: https://its.cern.ch/jira/browse/CMSHLT-2762 

**T0 Operations cmsTalk thread**  
Will add it soon.
