### PR TITLE
Update DQM sequence for ParkingDoubleElectronLowMass PD

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -1119,6 +1119,8 @@ DATASETS = ["ParkingDoubleElectronLowMass","ParkingDoubleElectronLowMass0"]
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,
                do_reco=True,
+               write_dqm=True,
+               dqm_sequences=["@common"]
                archival_node=None,
                siteWhitelist = ["T2_CH_CERN_P5", "T2_CH_CERN"],
                tape_node="T0_CH_CERN_MSS",
@@ -1131,6 +1133,8 @@ DATASETS = ["ParkingDoubleElectronLowMass1","ParkingDoubleElectronLowMass2",
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,
                do_reco=True,
+               write_dqm=True,
+               dqm_sequences=["@common"]
                archival_node=None,
                aod_to_disk=False,
                siteWhitelist = ["T2_CH_CERN_P5", "T2_CH_CERN"],

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -1029,6 +1029,8 @@ DATASETS = ["ParkingDoubleElectronLowMass0","ParkingDoubleElectronLowMass1","Par
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,
                do_reco=True,
+               write_dqm=True,
+               dqm_sequences=["@common"]
                tape_node=None,
                scenario=ppScenario)
 

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -37,7 +37,7 @@ setConfigVersion(tier0Config, "replace with real version")
 # Cosmics from cruzet, splashes, and 2022 collisions
 # 365118 - CRAFT 2023
 # 359691 - Collisions 2022
-setInjectRuns(tier0Config, [365118,359691])
+setInjectRuns(tier0Config, [366498])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"


### PR DESCRIPTION
# Replay Request

**Requestor**  
Helena as ORM

**Describe the configuration**  
* Release: CMSSW_13_0_3
* Run: 366498
* GTs:
   * expressGlobalTag: 130X_dataRun3_Express_v2
   * promptrecoGlobalTag: 130X_dataRun3_Prompt_Candidate_2023_03_09_09_47_16
* Additional changes: Include the DQM sequence as `@common` in the ParkingDoubleElectronLowMass PD. Also added write_dqm to mimic the ParkingDoubleMuonLowMass PD.

**Purpose of the test**  
Test the configuration for the ParkingDoubleElectronLowMass dataset with new dqm settings.

**T0 Operations cmsTalk thread**  
To be added very soon