### PR TITLE
Update acquisition Era to Run2023C

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -55,7 +55,7 @@ addSiteConfig(tier0Config, "T0_CH_CERN_Disk",
 #  Data type
 #  Processing site (where jobs run)
 #  PhEDEx locations
-setAcquisitionEra(tier0Config, "Run2023B")
+setAcquisitionEra(tier0Config, "Run2023C")
 setBaseRequestPriority(tier0Config, 251000)
 setBackfill(tier0Config, None)
 setBulkDataType(tier0Config, "data")


### PR DESCRIPTION
# Configuration Change Request 

**Requestor**  
Helena and @saumyaphor4252 as ORMs

**Describe the configuration**  
* Release: CMSSW_13_0_3
* Run: -
* GTs:
   * expressGlobalTag: 130X_dataRun3_Express_v2
   * promptrecoGlobalTag: 130X_dataRun3_Prompt_v2
* Additional changes:
   * No additional changes
   
**Purpose**  
Change Acquisition Era to Run2023C as LHC is scheduled to start Physics runs (1200 bunches, half of LHC full bunches) on Tuesday, May 2nd.

**T0 Operations cmsTalk thread**  
https://cms-talk.web.cern.ch/t/tier0-configuration-acquisition-era-update-for-the-upcoming-physics-run/23475
