### PR TITLE
Replay testing CMSSW_13_0_5_patch1

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -1119,6 +1119,8 @@ DATASETS = ["ParkingDoubleElectronLowMass","ParkingDoubleElectronLowMass0"]
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,
                do_reco=True,
+               write_dqm=True,
+               dqm_sequences=["@common"]
                archival_node=None,
                siteWhitelist = ["T2_CH_CERN_P5", "T2_CH_CERN"],
                tape_node="T0_CH_CERN_MSS",
@@ -1131,6 +1133,8 @@ DATASETS = ["ParkingDoubleElectronLowMass1","ParkingDoubleElectronLowMass2",
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,
                do_reco=True,
+               write_dqm=True,
+               dqm_sequences=["@common"]
                archival_node=None,
                aod_to_disk=False,
                siteWhitelist = ["T2_CH_CERN_P5", "T2_CH_CERN"],

--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -1120,7 +1120,7 @@ for dataset in DATASETS:
     addDataset(tier0Config, dataset,
                do_reco=True,
                write_dqm=True,
-               dqm_sequences=["@common"]
+               dqm_sequences=["@common"],
                archival_node=None,
                siteWhitelist = ["T2_CH_CERN_P5", "T2_CH_CERN"],
                tape_node="T0_CH_CERN_MSS",
@@ -1134,7 +1134,7 @@ for dataset in DATASETS:
     addDataset(tier0Config, dataset,
                do_reco=True,
                write_dqm=True,
-               dqm_sequences=["@common"]
+               dqm_sequences=["@common"],
                archival_node=None,
                aod_to_disk=False,
                siteWhitelist = ["T2_CH_CERN_P5", "T2_CH_CERN"],

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -104,7 +104,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_13_0_4"
+    'default': "CMSSW_13_0_5"
 }
 
 # Configure ScramArch

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -37,7 +37,7 @@ setConfigVersion(tier0Config, "replace with real version")
 # Cosmics from cruzet, splashes, and 2022 collisions
 # 365118 - CRAFT 2023
 # 359691 - Collisions 2022
-setInjectRuns(tier0Config, [366498])
+setInjectRuns(tier0Config, [366794,366829])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"
@@ -104,7 +104,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_13_0_5"
+    'default': "CMSSW_13_0_5_patch1"
 }
 
 # Configure ScramArch
@@ -133,7 +133,7 @@ alcarawProcVersion = dt
 
 # Defaults for GlobalTag
 expressGlobalTag = "130X_dataRun3_Express_v2"
-promptrecoGlobalTag = "130X_dataRun3_Prompt_Candidate_2023_03_09_09_47_16"
+promptrecoGlobalTag = "130X_dataRun3_Prompt_v2"
 
 # Mandatory for CondDBv2
 globalTagConnect = "frontier://PromptProd/CMS_CONDITIONS"

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -477,7 +477,7 @@ for dataset in DATASETS:
                do_reco=True,
                write_dqm=True,
                dqm_sequences=["@common"],
-               physics_skims=["EXODisplacedJet", "EXODelayedJet", "EXODTCluster", "LogError", "LogErrorMonitor", "EXOCSCCluster"],
+               physics_skims=["EXODisplacedJet", "EXODelayedJet", "EXODTCluster", "LogError", "LogErrorMonitor", "EXOLLPJetHCAL"],
                scenario=ppScenario)
 
 DATASETS = ["DoubleMuon"]
@@ -618,7 +618,7 @@ for dataset in DATASETS:
                                "SiPixelCalSingleMuonLoose", "SiPixelCalSingleMuonTight",
                                "TkAlZMuMu", "TkAlDiMuonAndVertex"],
                dqm_sequences=["@common", "@muon", "@lumi", "@L1TMuon"],
-               physics_skims=["ZMu", "EXODisappTrk", "LogError", "LogErrorMonitor"],
+               physics_skims=["ZMu", "EXODisappTrk", "LogError", "LogErrorMonitor", "EXOCSCCluster", "EXODisappMuon"],
                scenario=ppScenario)
 
 DATASETS = ["NoBPTX"]

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -1029,6 +1029,8 @@ DATASETS = ["ParkingDoubleElectronLowMass0","ParkingDoubleElectronLowMass1","Par
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,
                do_reco=True,
+               write_dqm=True,
+               dqm_sequences=["@common"]
                tape_node=None,
                scenario=ppScenario)
 

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -104,7 +104,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_13_0_3"
+    'default': "CMSSW_13_0_4"
 }
 
 # Configure ScramArch
@@ -113,7 +113,7 @@ setScramArch(tier0Config, "CMSSW_12_4_9", "el8_amd64_gcc10")
 setScramArch(tier0Config, "CMSSW_12_3_0", "cs8_amd64_gcc10")
 
 # Configure scenarios
-ppScenario = "ppEra_Run3"
+ppScenario = "ppEra_Run3_2023"
 ppScenarioB0T = "ppEra_Run3"
 cosmicsScenario = "cosmicsEra_Run3"
 hcalnzsScenario = "hcalnzsEra_Run3"

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -1030,7 +1030,7 @@ for dataset in DATASETS:
     addDataset(tier0Config, dataset,
                do_reco=True,
                write_dqm=True,
-               dqm_sequences=["@common"]
+               dqm_sequences=["@common"],
                tape_node=None,
                scenario=ppScenario)
 

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -37,7 +37,7 @@ setConfigVersion(tier0Config, "replace with real version")
 # Cosmics from cruzet, splashes, and 2022 collisions
 # 365118 - CRAFT 2023
 # 359691 - Collisions 2022
-setInjectRuns(tier0Config, [365118,359691])
+setInjectRuns(tier0Config, [366498])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"

--- a/src/python/T0/WMBS/Oracle/Create.py
+++ b/src/python/T0/WMBS/Oracle/Create.py
@@ -934,7 +934,8 @@ class Create(DBCreator):
                            44 : "ppEra_Run3_pp_on_PbPb",
                            45 : "trackingOnlyEra_Run3_pp_on_PbPb",
                            46 : "hcalnzsEra_Run3_pp_on_PbPb",
-                           47 : "ppEra_Run3_pp_on_PbPb_approxSiStripClusters" }
+                           47 : "ppEra_Run3_pp_on_PbPb_approxSiStripClusters",
+                           48 : "ppEra_Run3_2023" }
         for id, name in list(eventScenarios.items()):
             sql = """INSERT INTO event_scenario
                      (ID, NAME)


### PR DESCRIPTION
# Replay Request

**Requestor**  
ORM

**Describe the configuration**  
* Release: CMSSW_13_0_5_patch1
* Run: 366794, 366829
* GTs:
   * expressGlobalTag: 130X_dataRun3_Express_v2
   * promptrecoGlobalTag: 130X_dataRun3_Prompt_v2
* Additional changes: Include the DQM sequence as `@common` in the ParkingDoubleElectronLowMass PD. Also added write_dqm to mimic the ParkingDoubleMuonLowMass PD.

**Purpose of the test**  

- Continuation fo the test in #4810. After finding memory issues in 13_0_3 replay with run 366498, we will test new runs post scrubbing.

**T0 Operations cmsTalk thread**  
https://cms-talk.web.cern.ch/t/update-parkingdoubleelectronlowmass-dqm-sequence/23274