### PR TITLE
Replay configuration for CMSSW_13_0_5_patch2

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -37,7 +37,7 @@ setConfigVersion(tier0Config, "replace with real version")
 # Cosmics from cruzet, splashes, and 2022 collisions
 # 365118 - CRAFT 2023
 # 359691 - Collisions 2022
-setInjectRuns(tier0Config, [366794,366829])
+setInjectRuns(tier0Config, [366891])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"
@@ -104,7 +104,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_13_0_5_patch1"
+    'default': "CMSSW_13_0_5_patch2"
 }
 
 # Configure ScramArch


### PR DESCRIPTION
# Replay Request

**Requestor**  
ORM

**Describe the configuration**  
* Release: CMSSW_13_0_5_patch2
* Run: [366891](https://cmsoms.cern.ch/cms/runs/report?cms_run=366891&cms_run_sequence=GLOBAL-RUN) 
   * 900b
   * 2 hour run
   *  all components in 
* GTs:
   * expressGlobalTag: 130X_dataRun3_Express_v2
   * promptrecoGlobalTag: 130X_dataRun3_Prompt_v2
* Additional changes:
None

**Purpose of the test**  
- Test new CMSSW_13_0_5_patch2 release. 
- The PR included in this patch requires a processing version change when deployed. 
- But if tested successfully before the 1200b arrive in LHC (for which we anyways have to change the era), we can deploy the patch together with the era change avoiding the need for changing processing version later on.

**T0 Operations cmsTalk thread**  
Not yet.
[Tier0 Operations cmsTalk Forum](https://cms-talk.web.cern.ch/c/offcomp/compops/tier0/210?)
