### PR TITLE
Replay to test addition of BeamSpotOnline tags to Prompt GT

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -36,7 +36,7 @@ setConfigVersion(tier0Config, "replace with real version")
 # Set run number to replay
 # Cosmics from cruzet, splashes, and 2022 collisions
 # 367102 - Collisions 2023 - 1200b - 0.5h long - all components IN
-setInjectRuns(tier0Config, [367100])
+setInjectRuns(tier0Config, [367102])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"
@@ -1131,7 +1131,7 @@ ignoreStream(tier0Config, "streamDQMRates")
 ignoreStream(tier0Config, "DQMPPSRandom")
 
 # Run only on the ZB streams
-specifyStreams(tier0Config, ["PhysicsZeroBias0", "PhysicsZeroBias1", "PhysicsZeroBias2", "PhysicsZeroBias3", "PhysicsZeroBias4", "PhysicsZeroBias5", "PhysicsZeroBias6", "PhysicsZeroBias7", "PhysicsZeroBias8", "PhysicsZeroBias9"])
+specifyStreams(tier0Config, [PhysicsCommissioning])
 
 ###################################
 ### currently inactive settings ###

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -1131,7 +1131,7 @@ ignoreStream(tier0Config, "streamDQMRates")
 ignoreStream(tier0Config, "DQMPPSRandom")
 
 # Run only on the ZB streams
-specifyStreams(tier0Config, [PhysicsCommissioning])
+specifyStreams(tier0Config, ["PhysicsCommissioning"])
 
 ###################################
 ### currently inactive settings ###

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -36,7 +36,7 @@ setConfigVersion(tier0Config, "replace with real version")
 # Set run number to replay
 # Cosmics from cruzet, splashes, and 2022 collisions
 # 367102 - Collisions 2023 - 1200b - 0.5h long - all components IN
-setInjectRuns(tier0Config, [367102])
+setInjectRuns(tier0Config, [367100])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -35,8 +35,8 @@ setConfigVersion(tier0Config, "replace with real version")
 
 # Set run number to replay
 # Cosmics from cruzet, splashes, and 2022 collisions
-# 367100 - Collisions 2023 - 1200b - 2h30min long - all components IN
-setInjectRuns(tier0Config, [367100])
+# 367102 - Collisions 2023 - 1200b - 0.5h long - all components IN
+setInjectRuns(tier0Config, [367102])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"
@@ -1131,16 +1131,7 @@ ignoreStream(tier0Config, "streamDQMRates")
 ignoreStream(tier0Config, "DQMPPSRandom")
 
 # Run only on the ZB streams
-specifyStreams(tier0Config, "PhysicsZeroBias0")
-specifyStreams(tier0Config, "PhysicsZeroBias1")
-specifyStreams(tier0Config, "PhysicsZeroBias2")
-specifyStreams(tier0Config, "PhysicsZeroBias3")
-specifyStreams(tier0Config, "PhysicsZeroBias4")
-specifyStreams(tier0Config, "PhysicsZeroBias5")
-specifyStreams(tier0Config, "PhysicsZeroBias6")
-specifyStreams(tier0Config, "PhysicsZeroBias7")
-specifyStreams(tier0Config, "PhysicsZeroBias8")
-specifyStreams(tier0Config, "PhysicsZeroBias9")
+specifyStreams(tier0Config, ["PhysicsZeroBias0", "PhysicsZeroBias1", "PhysicsZeroBias2", "PhysicsZeroBias3", "PhysicsZeroBias4", "PhysicsZeroBias5", "PhysicsZeroBias6", "PhysicsZeroBias7", "PhysicsZeroBias8", "PhysicsZeroBias9"])
 
 ###################################
 ### currently inactive settings ###

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -35,8 +35,7 @@ setConfigVersion(tier0Config, "replace with real version")
 
 # Set run number to replay
 # Cosmics from cruzet, splashes, and 2022 collisions
-# 365118 - CRAFT 2023
-# 359691 - Collisions 2022
+# 366891 - Collisions 2023 - 900b - 1h50min long - all components IN
 setInjectRuns(tier0Config, [366891])
 
 # Settings up sites
@@ -132,7 +131,7 @@ alcarawProcVersion = dt
 
 # Defaults for GlobalTag
 expressGlobalTag = "130X_dataRun3_Express_v2"
-promptrecoGlobalTag = "130X_dataRun3_Prompt_v2"
+promptrecoGlobalTag = "130X_dataRun3_Prompt_addBSOnline_v1"
 
 # Mandatory for CondDBv2
 globalTagConnect = "frontier://PromptProd/CMS_CONDITIONS"
@@ -1130,6 +1129,18 @@ ignoreStream(tier0Config, "streamHLTRates")
 ignoreStream(tier0Config, "streamL1Rates")
 ignoreStream(tier0Config, "streamDQMRates")
 ignoreStream(tier0Config, "DQMPPSRandom")
+
+# Run only on the ZB streams
+specifyStreams(tier0Config, "PhysicsZeroBias0")
+specifyStreams(tier0Config, "PhysicsZeroBias1")
+specifyStreams(tier0Config, "PhysicsZeroBias2")
+specifyStreams(tier0Config, "PhysicsZeroBias3")
+specifyStreams(tier0Config, "PhysicsZeroBias4")
+specifyStreams(tier0Config, "PhysicsZeroBias5")
+specifyStreams(tier0Config, "PhysicsZeroBias6")
+specifyStreams(tier0Config, "PhysicsZeroBias7")
+specifyStreams(tier0Config, "PhysicsZeroBias8")
+specifyStreams(tier0Config, "PhysicsZeroBias9")
 
 ###################################
 ### currently inactive settings ###

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -131,7 +131,7 @@ alcarawProcVersion = dt
 
 # Defaults for GlobalTag
 expressGlobalTag = "130X_dataRun3_Express_v2"
-promptrecoGlobalTag = "130X_dataRun3_Prompt_addBSOnline_v1"
+promptrecoGlobalTag = "130X_dataRun3_Prompt_v3"
 
 # Mandatory for CondDBv2
 globalTagConnect = "frontier://PromptProd/CMS_CONDITIONS"

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -35,8 +35,8 @@ setConfigVersion(tier0Config, "replace with real version")
 
 # Set run number to replay
 # Cosmics from cruzet, splashes, and 2022 collisions
-# 366891 - Collisions 2023 - 900b - 1h50min long - all components IN
-setInjectRuns(tier0Config, [366891])
+# 367100 - Collisions 2023 - 1200b - 2h30min long - all components IN
+setInjectRuns(tier0Config, [367100])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"


### PR DESCRIPTION
# Replay Request

**Requestor**  
AlCaDB (FYI @mmusich as ORM)

**Describe the configuration**  
* Release: CMSSW_13_0_5_patch2 
* Run: [367100](https://cmsoms.cern.ch/cms/runs/report?cms_run=367100&cms_run_sequence=GLOBAL-RUN) (Collisions 2023 - 1200b - 2.5h long - all components IN)
* GTs:
   * expressGlobalTag: `130X_dataRun3_Express_v2` (unchanged)
   * promptrecoGlobalTag: `130X_dataRun3_Prompt_v3` (NEW!)
* Additional changes:
   * New Prompt GT which contains BeamSpotOnline tags
   * Run only Prompt reco on ZB streams (ingore everything else)
      * @germanfgv I have used the `specifyStreams` feature - but i'm not sure if it is used correctly, can you check?

**Purpose of the test**  
This Replay is to test the addition of the BeamSpotOnline tags to the Prompt GT following discussion in https://github.com/cms-sw/cmssw/issues/41459. Adding these new tags will allow to:
 - reduce LogErrors and LogWarnings in tier0 prompt logs
 - allow to compare online and offline beamspot in Prompt DQM (this feature was already there in Run2 - but not available anymore so far in RUn3 since the removal of SCAL)

Following recent discussions at the JointOps meeting we prepared an ad hoc GT for this replay:
 - `130X_dataRun3_Prompt_v3`
    -  with infinite snapshot
    - diff from current Prompt GT [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_dataRun3_Prompt_v2/130X_dataRun3_Prompt_v3) 

**T0 Operations cmsTalk thread**  
https://cms-talk.web.cern.ch/t/replay-for-testing-addition-of-beamspotonline-tags-to-prompt-gt/23848