### PR TITLE
Replay to test PPSalignment tags

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -129,8 +129,8 @@ expressProcVersion = dt
 alcarawProcVersion = dt
 
 # Defaults for GlobalTag
-expressGlobalTag = "130X_dataRun3_Express_v2"
-promptrecoGlobalTag = "130X_dataRun3_Prompt_v3"
+expressGlobalTag = "130X_dataRun3_Express_PPSReplay_w19_2023_v1"
+promptrecoGlobalTag = "130X_dataRun3_Prompt_PPSReplay_w19_2023_v1"
 
 # Mandatory for CondDBv2
 globalTagConnect = "frontier://PromptProd/CMS_CONDITIONS"
@@ -1128,6 +1128,9 @@ ignoreStream(tier0Config, "streamHLTRates")
 ignoreStream(tier0Config, "streamL1Rates")
 ignoreStream(tier0Config, "streamDQMRates")
 ignoreStream(tier0Config, "DQMPPSRandom")
+
+# Run only on ALCAPPS streams
+specifyStreams(tier0Config, ["ALCAPPSExpress","ALCAPPSPrompt"])
 
 ###################################
 ### currently inactive settings ###


### PR DESCRIPTION
# Replay Request

**Requestor**
AlCaDB

**Describe the configuration**  
* Release: CMSSW_13_0_5_patch2
* Run: 367102
* GTs:
   * expressGlobalTag: 130X_dataRun3_Express_PPSReplay_w19_2023_v1
   * promptrecoGlobalTag: 130X_dataRun3_Prompt_PPSReplay_w19_2023_v1
* Additional changes:
   * Run only on `ALCAPPSExpress` and `ALCAPPSPrompt` streams

**Purpose of the test**
This replay is to test the new PPSAlignment tags proposed in [this CMSTalk thread](https://cms-talk.web.cern.ch/t/ppd-alcadb-gt-online-hlt-express-prompt-updated-pps-alignment-conditions-for-pcl/24053).
Given that these tags were causing crashes in the PPS PCL workflow in Tier0 (see [this CMSTalk](https://cms-talk.web.cern.ch/t/paused-job-in-stream-alcappsexpress-for-run-366035/22681) and https://github.com/cms-sw/cmssw/issues/41335) the current ORM (@mmusich) suggested to test them in a Replay before deploying in production.
For this we have created the following GTs:
 - Express: `130X_dataRun3_Express_PPSReplay_w19_2023_v1`
    - Diff wrt production Express GT [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_dataRun3_Express_v2/130X_dataRun3_Express_PPSReplay_w19_2023_v1)
 - Prompt: `130X_dataRun3_Prompt_PPSReplay_w19_2023_v1`
    - Diff wrt production Prompt GT [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_dataRun3_Prompt_v3/130X_dataRun3_Prompt_PPSReplay_w19_2023_v1)

Given that these tags are only relevant to PPS we propose to run this replay only on the PPS streams to save computing and disk ressources.

**T0 Operations cmsTalk thread**
Will be provided soon