### PR TITLE
update replay configuration to test `CMSSW_13_0_6`

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -102,7 +102,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_13_0_5_patch2"
+    'default': "CMSSW_13_0_6"
 }
 
 # Configure ScramArch


### PR DESCRIPTION
# Replay Request

**Requestor**  
ORM

**Describe the configuration**  
* Release: `CMSSW_13_0_6`
* Run: [367102](https://cmsoms.cern.ch/cms/runs/report?cms_run=367102&cms_run_sequence=GLOBAL-RUN) (Collisions 2023 - 1200b - 30 minutes long - all components IN), as agreed [here](https://cms-talk.web.cern.ch/t/streamers-to-keep-for-2023-1200b-run/23845/4)
* GTs:
   * expressGlobalTag: `130X_dataRun3_Express_v2` (unchanged)
   * promptrecoGlobalTag: `130X_dataRun3_Prompt_v3` (unchanged)
* Additional changes: None

**Purpose of the test**  
Test at Tier-0 the new release `CMSSW_13_0_6` announced [here](https://cms-talk.web.cern.ch/t/production-release-cmssw-13-0-6-now-available/24086/1)  as per PPS / DAQ request. As the HLT unpacks PPS, it should move to the new release (see for more info [here](https://github.com/cms-sw/cmssw/pull/41518#issuecomment-1539949518)), which forces Tier-0 to move as well.

**T0 Operations cmsTalk thread**  

[Link to cmsTalk thread](https://cms-talk.web.cern.ch/t/replay-for-testing-cmssw-13-0-6/24101)
