### PR TITLE
New PDs for HLT menu 2023 V1.1

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -575,6 +575,20 @@ for dataset in DATASETS:
                disk_node="T2_CH_CERN",
                scenario=ppScenario)
 
+DATASETS = ["ParkingHH", "ParkingLLP", "ParkingVBF0",
+            "ParkingVBF1", "ParkingVBF2", "ParkingVBF3"]
+
+for dataset in DATASETS:
+    addDataset(tier0Config, dataset,
+               do_reco=True,
+               write_dqm=True,
+               aod_to_disk=False,
+               dqm_sequences=["@common"],
+               archival_node=None,
+               tape_node="T0_CH_CERN_MSS",
+               disk_node="T2_CH_CERN",
+               scenario=ppScenario)
+
 DATASETS = ["EmptyBX"]
 
 for dataset in DATASETS:

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -539,6 +539,17 @@ for dataset in DATASETS:
                alca_producers=["TkAlJpsiMuMu", "TkAlUpsilonMuMu"],
                scenario=ppScenario)
 
+DATASETS = ["ParkingHH", "ParkingLLP", "ParkingVBF0",
+            "ParkingVBF1", "ParkingVBF2", "ParkingVBF3"]
+
+for dataset in DATASETS:
+    addDataset(tier0Config, dataset,
+               do_reco=True,
+               write_dqm=True,
+               aod_to_disk=False,
+               dqm_sequences=["@common"],
+               scenario=ppScenario)
+
 DATASETS = ["EmptyBX"]
 
 for dataset in DATASETS:


### PR DESCRIPTION
Adds new PDs in preparation for new HLT menu as requested [here](https://cms-talk.web.cern.ch/t/new-datasets-in-next-hlt-menu-2023-v1-1-hlt-menu/24154/2). The new PDs are:
- ParkingHH
- ParkingLLP
- ParkingVBF0
- ParkingVBF1
- ParkingVBF2
- ParkingVBF3