### PR TITLE
Change Production and Replay Configurations to CMSSW_13_0_6

### DIFF
--- a/bin/00_deploy_replay.sh
+++ b/bin/00_deploy_replay.sh
@@ -3,7 +3,7 @@ confirm_deploy="y"
 replay_nodes=("vocms0500" "vocms047" "vocms001" "C4_vocms047")
 bul=0
 for node in ${replay_nodes[@]}; do
-	if [ "$node" == hostname  ]
+	if [ "$node" == `hostname`  ]
 	then
 		bul=1
 		break	

--- a/bin/00_deploy_replay.sh
+++ b/bin/00_deploy_replay.sh
@@ -3,7 +3,7 @@ confirm_deploy="y"
 replay_nodes=("vocms0500.cern.ch" "vocms047.cern.ch" "vocms001.cern.ch" "C4_vocms047.cern.ch")
 bul=0
 for node in ${replay_nodes[@]}; do
-	if [ "$node" == `hostname`  ]
+	if [ "$node" == `hostname` ]
 	then
 		bul=1
 		break	

--- a/bin/00_deploy_replay.sh
+++ b/bin/00_deploy_replay.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-confirm_deploy="y"
+confirm_deploy=""
 replay_nodes=("vocms0500.cern.ch" "vocms047.cern.ch" "vocms001.cern.ch" "C4_vocms047.cern.ch")
 is_production_node=1
 for node in ${replay_nodes[@]}; do
@@ -14,6 +14,8 @@ if [ $is_production_node -eq 1 ]
 then
 	echo "Are you sure you wish to deploy the production node `hostname`? (y/n)"
 	read confirm_deploy
+else
+	confirm_deploy="y"
 fi
 
 

--- a/bin/00_deploy_replay.sh
+++ b/bin/00_deploy_replay.sh
@@ -1,4 +1,25 @@
 #!/bin/bash
+confirm_deploy="y"
+replay_nodes=("vocms0500" "vocms047" "vocms001" "C4_vocms047")
+bul=0
+for node in ${replay_nodes[@]}; do
+	if [ "$node" == hostname  ]
+	then
+		bul=1
+		break	
+	fi
+done
+
+if [ $bul -eq 0 ]
+then
+	echo "Are you sure you wish to deploy a production node? (y/n)"
+	read confirm_deploy
+fi
+
+if [ "$confirm_deploy" == "n" ]
+then
+	exit
+fi
 
 BASE_DIR=/data/tier0
 DEPLOY_DIR=$BASE_DIR/srv/wmagent

--- a/bin/00_deploy_replay.sh
+++ b/bin/00_deploy_replay.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 confirm_deploy="y"
-replay_nodes=("vocms0500" "vocms047" "vocms001" "C4_vocms047")
+replay_nodes=("vocms0500.cern.ch" "vocms047.cern.ch" "vocms001.cern.ch" "C4_vocms047.cern.ch")
 bul=0
 for node in ${replay_nodes[@]}; do
 	if [ "$node" == `hostname`  ]

--- a/bin/00_deploy_replay.sh
+++ b/bin/00_deploy_replay.sh
@@ -1,20 +1,21 @@
 #!/bin/bash
 confirm_deploy="y"
 replay_nodes=("vocms0500.cern.ch" "vocms047.cern.ch" "vocms001.cern.ch" "C4_vocms047.cern.ch")
-bul=0
+is_production_node=1
 for node in ${replay_nodes[@]}; do
 	if [ "$node" == `hostname` ]
 	then
-		bul=1
+		is_production_node=0
 		break	
 	fi
 done
 
-if [ $bul -eq 0 ]
+if [ $is_production_node -eq 1 ]
 then
 	echo "Are you sure you wish to deploy a production node? (y/n)"
 	read confirm_deploy
 fi
+
 
 if [ "$confirm_deploy" == "n" ]
 then

--- a/bin/00_deploy_replay.sh
+++ b/bin/00_deploy_replay.sh
@@ -12,13 +12,14 @@ done
 
 if [ $is_production_node -eq 1 ]
 then
-	echo "Are you sure you wish to deploy a production node? (y/n)"
+	echo "Are you sure you wish to deploy the production node `hostname`? (y/n)"
 	read confirm_deploy
 fi
 
 
-if [ "$confirm_deploy" == "n" ]
+if [ "$confirm_deploy" != "y" ]
 then
+	echo "Deployment aborted"
 	exit
 fi
 

--- a/bin/00_deploy_replay.sh
+++ b/bin/00_deploy_replay.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 confirm_deploy=""
-replay_nodes=("vocms0500.cern.ch" "vocms047.cern.ch" "vocms001.cern.ch" "C4_vocms047.cern.ch")
+replay_nodes=("vocms0500.cern.ch" "vocms047.cern.ch" "vocms001.cern.ch" "vocms015.cern.ch")
 is_production_node=1
 for node in ${replay_nodes[@]}; do
 	if [ "$node" == `hostname` ]

--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -112,17 +112,17 @@ alcaPPSScenario = "AlCaPPS_Run3"
 hiTestppScenario = "ppEra_Run3"
 
 # Defaults for processing version
-defaultProcVersionRAW = 1
+defaultProcVersionRAW = 2
 alcarawProcVersion = {
-    'default': "1"
+    'default': "2"
 }
 
 defaultProcVersionReco = {
-    'default': "1"
+    'default': "2"
 }
 
 expressProcVersion = {
-    'default': "1"
+    'default': "2"
 }
 
 # Defaults for GlobalTag

--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -94,7 +94,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_13_0_5_patch2"
+    'default': "CMSSW_13_0_6"
 }
 
 # Configure ScramArch

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -102,7 +102,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_13_0_5_patch2"
+    'default': "CMSSW_13_0_6"
 }
 
 # Configure ScramArch


### PR DESCRIPTION
A replay of good run 367102 was tested with CMSSW_13_0_6 and it was successful. 

The PR with the corresponding replay request is #4822.

It is requested to use CMSSW_13_0_6 as the default CMSSW version for ProdOfflineConfiguration.py and ReplayOfflineConfiguration.py.

Regards,

Antonio for T0