### PR TITLE
Procesing version change due to HCAL conditions and Repack version fix

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -112,9 +112,9 @@ alcaPPSScenario = "AlCaPPS_Run3"
 hiTestppScenario = "ppEra_Run3"
 
 # Defaults for processing version
-defaultProcVersionRAW = 2
+defaultProcVersionRAW = 1
 alcarawProcVersion = {
-    'default': "2"
+    'default': "3"
 }
 
 defaultProcVersionReco = {


### PR DESCRIPTION
Prompt processing version change to 3:

- Justification: Deployment of new HcalGains and HcalRespCorrs conditions in Prompt Global Tag
 provided vi AlCaDB @francescobrivio 
- AlCaDB CMSTalk post: https://cms-talk.web.cern.ch/t/hlt-express-prompt-full-track-validation-new-hcal-gains-and-response-corrections-conditions/22527
- Full Track Validation: [CMSALCA-208](https://its.cern.ch/jira/browse/CMSALCA-208)

Repack versiongoing back to 1:
- Repack version was increased to 2 by mistake in the last version update. We are rolling back the change and will reprocess affected runs.