### PR TITLE
Replay configuration for CMSSW_13_1_0 test

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -102,7 +102,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_13_0_6"
+    'default': "CMSSW_13_1_0"
 }
 
 # Configure ScramArch


### PR DESCRIPTION
# Replay Request

**Requestor**  
Team or person that requests this replay

Tier 0

**Describe the configuration**  
* Release: CMSSW_13_1_0
* Run: 367102
* GTs:
   * expressGlobalTag: "130X_dataRun3_Express_v2"
   * promptrecoGlobalTag: "130X_dataRun3_Prompt_v3"
* Additional changes:

**Purpose of the test**  
Test new CMSSW_13_1_0
