### PR TITLE
Reprocessing configuration for runs 367763-367840

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -33,10 +33,10 @@ tier0Config = createTier0Config()
 setConfigVersion(tier0Config, "replace with real version")
 
 # Set the min run number:
-setInjectMinRun(tier0Config, 9999999)
+setInjectMinRun(tier0Config, 367765)
 
 # Set the max run number:
-setInjectMaxRun(tier0Config, 9999999)
+setInjectMaxRun(tier0Config, 367840)
 
 # Settings up sites
 processingSite = "T2_CH_CERN"
@@ -1263,6 +1263,15 @@ ignoreStream(tier0Config, "streamHLTRates")
 ignoreStream(tier0Config, "streamL1Rates")
 ignoreStream(tier0Config, "streamDQMRates")
 ignoreStream(tier0Config, "DQMPPSRandom")
+
+# Ignoring Express streams for reprocessing
+ignoreStream(tier0Config, "Calibration")
+ignoreStream(tier0Config, "ExpressCosmics")
+ignoreStream(tier0Config, "ALCAPPSExpress")
+ignoreStream(tier0Config, "Express")
+ignoreStream(tier0Config, "ALCALumiPixelsCountsExpress")
+ignoreStream(tier0Config, "ExpressAlignment")
+ignoreStream(tier0Config, "HLTMonitor")
 
 ###################################
 ### currently inactive settings ###

--- a/src/python/T0/WMBS/Oracle/StorageManager/GetNewData.py
+++ b/src/python/T0/WMBS/Oracle/StorageManager/GetNewData.py
@@ -22,9 +22,9 @@ class GetNewData(DBFormatter):
                           """
         else:
             binds = {}
-            whereSql = """WHERE CMS_STOMGR.T0_NEEDS_TO_INJECT(CMS_STOMGR.FILE_TRANSFER_STATUS.STATUS_FLAG,
-                                                     CMS_STOMGR.FILE_TRANSFER_STATUS.INJECT_FLAG,
-                                                     CMS_STOMGR.FILE_TRANSFER_STATUS.BAD_CHECKSUM) = 0
+            whereSql = """WHERE CMS_STOMGR.FILE_TRANSFER_STATUS.STATUS_FLAG >= 2
+                          AND CMS_STOMGR.FILE_TRANSFER_STATUS.INJECT_FLAG = 1
+                          AND CMS_STOMGR.FILE_TRANSFER_STATUS.BAD_CHECKSUM = 0
                           """
             if minRun:
                 binds['MINRUN'] = minRun


### PR DESCRIPTION
Configuration for the reprocessing of runs affected by the RAWv2 error. This is a continuation of #4828 for runs 367763-367840.
This reprocessing will produce v4 output, with NanoAOD datasets

The recovery procedure is described here:

https://its.cern.ch/jira/browse/CMSTZ-1040
https://cms-talk.web.cern.ch/t/t0-reprocessing-due-to-wrong-raw-version/24528
