### PR TITLE
Replay to add `jetmet` DQM sequence to Muon datasets

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -639,7 +639,7 @@ for dataset in DATASETS:
                                "HcalCalHO", "HcalCalHBHEMuonProducerFilter",
                                "SiPixelCalSingleMuonLoose", "SiPixelCalSingleMuonTight",
                                "TkAlZMuMu", "TkAlDiMuonAndVertex"],
-               dqm_sequences=["@common", "@muon", "@lumi", "@L1TMuon"],
+               dqm_sequences=["@common", "@muon", "@lumi", "@L1TMuon", "@jetmet"],
                physics_skims=["ZMu", "EXODisappTrk", "LogError", "LogErrorMonitor", "EXOCSCCluster", "EXODisappMuon"],
                scenario=ppScenario)
 
@@ -1159,6 +1159,9 @@ ignoreStream(tier0Config, "streamHLTRates")
 ignoreStream(tier0Config, "streamL1Rates")
 ignoreStream(tier0Config, "streamDQMRates")
 ignoreStream(tier0Config, "DQMPPSRandom")
+
+# Run only on Muon0 and Muon1 streams
+specifyStreams(tier0Config, ["PhysicsMuon0","PhysicsMuon1"])
 
 ###################################
 ### currently inactive settings ###


### PR DESCRIPTION
# Replay Request

**Requestor**  
ORM for JME group

**Describe the configuration**  
* Release: CMSSW_13_0_7
* Run: 367102
* GTs:
   * expressGlobalTag: 130X_dataRun3_Express_v2 (unchanged)
   * promptrecoGlobalTag: 130X_dataRun3_Prompt_v3 (unchanged)
* Additional changes:
   * Added the `@jetmet` DQM sequence to the Muon0 and Muon1 datasets
   * Used `specifyStreams` method to run only on the Muon streams

**Purpose of the test**  
This replay is to test the addition of the `@jetmet` sequence to the `Muon0` and `Muon1` datasets as requested by the JME group (FYI @rseidita) in the CMSTalk post linked below.

**T0 Operations cmsTalk thread**  
https://cms-talk.web.cern.ch/t/inclusion-of-jetmet-sequence-on-muon-pd-in-dqm/24884