### PR TITLE
Include nanoaod in Tier0DataSvc

### DIFF
--- a/bin/00_patches.sh
+++ b/bin/00_patches.sh
@@ -23,8 +23,6 @@ DEPLOY_DIR=$BASE_DIR/srv/wmagent
 #Include nanoaod support in Tier0FeederPoller
 curl https://patch-diff.githubusercontent.com/raw/dmwm/T0/pull/4836.patch | patch -d $DEPLOY_DIR/current/apps/t0/lib/python3.8/site-packages/ -p 3
 
-#Adding skipped streamer info into T0 Data Service
-#curl https://patch-diff.githubusercontent.com/raw/dmwm/T0/pull/4841.patch | patch -d $DEPLOY_DIR/current/apps/t0/lib/python3.8/site-packages/ -p 3
 
 #Patches on top of 3.1.0
 #Adding support for writing nano aod

--- a/bin/00_patches.sh
+++ b/bin/00_patches.sh
@@ -27,4 +27,6 @@ curl https://patch-diff.githubusercontent.com/raw/dmwm/T0/pull/4813.patch | patc
 #Adding support for writing nano aod
 curl https://patch-diff.githubusercontent.com/raw/dmwm/T0/pull/4827.patch | patch -d $DEPLOY_DIR/current/apps/t0/lib/python3.8/site-packages/ -p 3
 
+#Include nanoaod support in Tier0FeederPoller
+curl https://patch-diff.githubusercontent.com/raw/dmwm/T0/pull/4836.patch | patch -d $DEPLOY_DIR/current/apps/t0/lib/python3.8/site-packages/ -p 3
 

--- a/src/python/T0/WMBS/Oracle/T0DataSvc/GetRecoConfigs.py
+++ b/src/python/T0/WMBS/Oracle/T0DataSvc/GetRecoConfigs.py
@@ -26,7 +26,8 @@ class GetRecoConfigs(DBFormatter):
                         reco_config.write_reco AS write_reco,
                         reco_config.write_dqm AS write_dqm,
                         reco_config.write_aod AS write_aod,
-                        reco_config.write_miniaod AS write_miniaod
+                        reco_config.write_miniaod AS write_miniaod,
+                        reco_config.write_nanoaod AS write_nanoaod
                  FROM reco_config
                  INNER JOIN primary_dataset ON
                    primary_dataset.id = reco_config.primds_id

--- a/src/python/T0/WMBS/Oracle/T0DataSvc/InsertRecoConfigs.py
+++ b/src/python/T0/WMBS/Oracle/T0DataSvc/InsertRecoConfigs.py
@@ -27,16 +27,17 @@ class InsertRecoConfigs(DBFormatter):
                               write_reco = :WRITE_RECO,
                               write_dqm = :WRITE_DQM,
                               write_aod = :WRITE_AOD,
-                              write_miniaod = :WRITE_MINIAOD
+                              write_miniaod = :WRITE_MINIAOD,
+                              write_nanoaod = :WRITE_NANOAOD
                  WHEN NOT MATCHED THEN
                    INSERT (run, primds, cmssw, scram_arch, alca_skim,
                            physics_skim, dqm_seq, global_tag, scenario,
                            multicore, write_reco, write_dqm,
-                           write_aod, write_miniaod)
+                           write_aod, write_miniaod, write_nanoaod)
                    VALUES (:RUN, :PRIMDS, :CMSSW, :SCRAM_ARCH, :ALCA_SKIM,
                            :PHYSICS_SKIM, :DQM_SEQ, :GLOBAL_TAG, :SCENARIO,
                            :MULTICORE, :WRITE_RECO, :WRITE_DQM,
-                           :WRITE_AOD, :WRITE_MINIAOD)
+                           :WRITE_AOD, :WRITE_MINIAOD, :WRITE_NANOAOD)
                  """
 
         self.dbi.processData(sql, binds, conn = conn,

--- a/src/python/T0Component/Tier0Feeder/Tier0FeederPoller.py
+++ b/src/python/T0Component/Tier0Feeder/Tier0FeederPoller.py
@@ -549,7 +549,8 @@ class Tier0FeederPoller(BaseWorkerThread):
                                       'WRITE_RECO' : config['write_reco'],
                                       'WRITE_DQM' : config['write_dqm'],
                                       'WRITE_AOD' : config['write_aod'],
-                                      'WRITE_MINIAOD' : config['write_miniaod'] } )
+                                      'WRITE_MINIAOD' : config['write_miniaod'],
+                                      'WRITE_NANOAOD' : config['write_nanoaod']} )
                 bindsUpdate.append( { 'RUN' : config['run'],
                                       'PRIMDS' : config['primds'] } )
 

--- a/src/python/T0Component/Tier0Feeder/Tier0FeederPoller.py
+++ b/src/python/T0Component/Tier0Feeder/Tier0FeederPoller.py
@@ -550,7 +550,7 @@ class Tier0FeederPoller(BaseWorkerThread):
                                       'WRITE_DQM' : config['write_dqm'],
                                       'WRITE_AOD' : config['write_aod'],
                                       'WRITE_MINIAOD' : config['write_miniaod'],
-                                      'WRITE_NANOAOD' : config['write_nanoaod']} )
+                                      'WRITE_NANOAOD' : config['write_nanoaod'] } )
                 bindsUpdate.append( { 'RUN' : config['run'],
                                       'PRIMDS' : config['primds'] } )
 


### PR DESCRIPTION
This PR with update in the Tier0FeederPoller.py is required to include the modification in a patch for correct agent deployment.
It also includes changes needed in the GetRecoConfigs and InsertRecoConfigs files