### PR TITLE
Replay to test PPS Reco geometry tag

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -35,7 +35,8 @@ setConfigVersion(tier0Config, "replace with real version")
 
 # Set run number to replay
 # 367102 - Collisions 2023 - 1200b - 0.5h long - all components IN
-setInjectRuns(tier0Config, [367102])
+# 367696 - Collisions 2023 - 2400b - 12h long - all components IN
+setInjectRuns(tier0Config, [367696])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"
@@ -129,7 +130,7 @@ expressProcVersion = dt
 alcarawProcVersion = dt
 
 # Defaults for GlobalTag
-expressGlobalTag = "130X_dataRun3_Express_v2"
+expressGlobalTag = "130X_dataRun3_Express_PPSReplay_w23_2023_v1"
 promptrecoGlobalTag = "130X_dataRun3_Prompt_v3"
 
 # Mandatory for CondDBv2
@@ -1156,6 +1157,9 @@ ignoreStream(tier0Config, "streamHLTRates")
 ignoreStream(tier0Config, "streamL1Rates")
 ignoreStream(tier0Config, "streamDQMRates")
 ignoreStream(tier0Config, "DQMPPSRandom")
+
+# Run only on ALCAPPSExpress stream
+specifyStreams(tier0Config, ["ALCAPPSExpress"])
 
 ###################################
 ### currently inactive settings ###


### PR DESCRIPTION
# Replay Request

**Requestor**  
AlCaDB for PPS

**Describe the configuration**  
* Release: CMSSW_13_0_7
* Run: 367696 ([OMS link](https://cmsoms.cern.ch/cms/runs/report?cms_run=367696&cms_run_sequence=GLOBAL-RUN))
* GTs:
   * expressGlobalTag: `130X_dataRun3_Express_PPSReplay_w23_2023_v1`
   * promptrecoGlobalTag: `130X_dataRun3_Prompt_v3` (unchanged)
* Additional changes:
   * Added `specifyStreams` to run only on `ALCAPPSExpress` stream

**Purpose of the test**  
This replay is to test an updated PPS Reco geometry to improve PPS track reconstruction in PCL (see [this CMSTalk post](https://cms-talk.web.cern.ch/t/full-track-validation-hlt-express-prompt-validation-of-a-pps-geometry-payload-with-internal-sensors-alignment-included/25139)).
For this we have created an _ad hoc_ Express GT:
 - GT: `130X_dataRun3_Express_PPSReplay_w23_2023_v1`
    - Diff wrt production Express GT is available [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_dataRun3_Express_v2/130X_dataRun3_Express_PPSReplay_w23_2023_v1)

The run proposed for this replay is a direct request from PPS experts (@wpcarvalho), and, despite being quite long (12 hours), given that we are exclusively running on the PPS Express stream, I believe it should be rather quick and not take too much ressources. (I also checked that the streamer files for this run are still available.)

**T0 Operations cmsTalk thread** 
https://cms-talk.web.cern.ch/t/replay-to-test-new-pps-reco-geometry-for-pcl/25167

FYI @sarafiorendi as ORM