### PR TITLE
Replay testing CMSSW_13_0_7_TOTEM

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -102,7 +102,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_13_0_7"
+    'default': "CMSSW_13_0_7_TOTEM"
 }
 
 # Configure ScramArch

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -35,7 +35,7 @@ setConfigVersion(tier0Config, "replace with real version")
 
 # Set run number to replay
 # 367102 - Collisions 2023 - 1200b - 0.5h long - all components IN
-setInjectRuns(tier0Config, [367102])
+setInjectRuns(tier0Config, [368805])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"


### PR DESCRIPTION
# Replay Request

**Requestor**  
Shadow ORM

**Describe the configuration**  
* Release: CMSSW\_13\_0\_7\_TOTEM
* Run: 368805 -  Cosmics 2023 - 9 minutes long - all components IN except for GEM and RPC
* GTs:
   * expressGlobalTag: 130X_dataRun3_Express_v2
   * promptrecoGlobalTag: 130X_dataRun3_Prompt_v3

**Purpose of the test**  
Test dedicated release for special TOTEM run

**T0 Operations cmsTalk thread**  
If necessary, provide a link to the cmsTalk thread announcing the test to the relevant groups. 
[Tier0 Operations cmsTalk Forum](https://cms-talk.web.cern.ch/t/replay-testing-cmssw-13-0-7-totem/2549)
