### PR TITLE
Adding skipped streamer info into T0 Data Service

### DIFF
--- a/bin/00_patches.sh
+++ b/bin/00_patches.sh
@@ -27,4 +27,5 @@ curl https://patch-diff.githubusercontent.com/raw/dmwm/T0/pull/4813.patch | patc
 #Adding support for writing nano aod
 curl https://patch-diff.githubusercontent.com/raw/dmwm/T0/pull/4827.patch | patch -d $DEPLOY_DIR/current/apps/t0/lib/python3.8/site-packages/ -p 3
 
-
+#Adding skipped streamer info into T0 Data Service
+curl https://patch-diff.githubusercontent.com/raw/dmwm/T0/pull/4841.patch | patch -d $DEPLOY_DIR/current/apps/t0/lib/python3.8/site-packages/ -p 3

--- a/src/python/T0/WMBS/Oracle/Create.py
+++ b/src/python/T0/WMBS/Oracle/Create.py
@@ -251,6 +251,7 @@ class Create(DBCreator):
                  insert_time   int not null,
                  used          int default 0 not null,
                  deleted       int default 0 not null,
+                 skipped       int default 0 not null,
                  primary key(id)
                )"""
 

--- a/src/python/T0/WMBS/Oracle/T0DataSvc/GetSkippedStreamers.py
+++ b/src/python/T0/WMBS/Oracle/T0DataSvc/GetSkippedStreamers.py
@@ -1,0 +1,31 @@
+"""
+_GetSkippedLumis_
+
+Oracle implementation of GetSkippedLumis
+
+Returns lumis that where skipped during job splitting
+
+"""
+
+from WMCore.Database.DBFormatter import DBFormatter
+
+class GetSkippedStreamers(DBFormatter):
+
+    def execute(self, conn = None, transaction = False):
+
+        sql = """SELECT st.id,
+                       st.run_id, 
+                       s.name, 
+                       st.lumi_id, 
+                       f.events 
+                  FROM wmbs_sub_files_failed ff
+                  JOIN wmbs_file_details f ON f.id = ff.fileid
+                  JOIN streamer st ON st.id = f.id
+                  JOIN stream s ON s.id = st.stream_id
+                  WHERE st.skipped = 0
+                 """
+
+        results = self.dbi.processData(sql, binds = {}, conn = conn,
+                                       transaction = transaction)
+
+        return self.formatDict(results)

--- a/src/python/T0/WMBS/Oracle/T0DataSvc/InsertSkippedStreamers.py
+++ b/src/python/T0/WMBS/Oracle/T0DataSvc/InsertSkippedStreamers.py
@@ -1,0 +1,26 @@
+"""
+_InsertSkippedStreamers_
+
+Oracle implementation of InsertSkippedStreamers
+
+Insert skipped streamers into Tier0 Data Service
+
+"""
+
+from WMCore.Database.DBFormatter import DBFormatter
+
+class InsertSkippedStreamers(DBFormatter):
+
+    def execute(self, binds, conn = None, transaction = False):
+
+        sql = """MERGE INTO skipped_streamers
+                 USING DUAL ON ( run = :RUN AND stream = :STREAM and lumi = :LUMI )
+                 WHEN NOT MATCHED THEN
+                   INSERT (run, stream, lumi, events)
+                   VALUES (:RUN, :STREAM, :LUMI, :EVENTS)
+                 """
+
+        self.dbi.processData(sql, binds, conn = conn,
+                             transaction = transaction)
+
+        return

--- a/src/python/T0/WMBS/Oracle/T0DataSvc/UpdateSkippedStreamers.py
+++ b/src/python/T0/WMBS/Oracle/T0DataSvc/UpdateSkippedStreamers.py
@@ -1,0 +1,24 @@
+"""
+_UpdateSkippedStreamers_
+
+Oracle implementation of UpdateSkippedStreamers
+
+Mark skipped streamers into T0AST
+
+"""
+
+from WMCore.Database.DBFormatter import DBFormatter
+
+class UpdateSkippedStreamers(DBFormatter):
+
+    def execute(self, binds, conn = None, transaction = False):
+
+        sql = """UPDATE streamer
+                 SET skipped = 1
+                 WHERE id = :ID
+                 """
+
+        self.dbi.processData(sql, binds, conn = conn,
+                             transaction = transaction)
+
+        return


### PR DESCRIPTION
This PR is created to implement the following ticket
https://its.cern.ch/jira/browse/CMSTZDEV-784

It adds the necesaary code to upload skipped streamers information into T0 Data Service. This ability is needed to fix the following tickets:
https://its.cern.ch/jira/browse/CMSTZ-939
https://its.cern.ch/jira/browse/CMSTZ-1043

It needs to be deployed pointing to a database that includes this schema update:
https://github.com/dmwm/t0wmadatasvc/pull/38