### PR TITLE
Release change to CMSSW_13_0_7_TOTEM during TS1

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -94,7 +94,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_13_0_7"
+    'default': "CMSSW_13_0_7_TOTEM"
 }
 
 # Configure ScramArch

--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -1113,6 +1113,8 @@ DATASETS += ["ZeroBiasPD01", "ZeroBiasPD02", "ZeroBiasPD03",
              "ZeroBiasPD07", "ZeroBiasPD08", "ZeroBiasPD09",
              "ZeroBiasPD10"]
 
+DATASETS += ["ZeroBiasNonColliding"]
+
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,
                do_reco=True,

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -1022,6 +1022,8 @@ DATASETS += ["ZeroBiasPD01", "ZeroBiasPD02", "ZeroBiasPD03",
              "ZeroBiasPD07", "ZeroBiasPD08", "ZeroBiasPD09",
              "ZeroBiasPD10"]
 
+DATASETS += ["ZeroBiasNonColliding"]
+
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,
                do_reco=True,


### PR DESCRIPTION
Configuration tested in https://github.com/dmwm/T0/pull/4840

To handle TOTEM runs during TS1 2023.

Adds dataset `ZeroBiasNonColliding` according to https://cms-talk.web.cern.ch/t/new-primary-dataset-zerobiasnoncolliding-for-special-totem-hlt-menu-collisions/25728