### PR TITLE
Replay to test `ZeroBiasNonColliding` PD processing of the TOTEM run

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -35,7 +35,7 @@ setConfigVersion(tier0Config, "replace with real version")
 
 # Set run number to replay
 # 367102 - Collisions 2023 - 1200b - 0.5h long - all components IN
-setInjectRuns(tier0Config, [367102])
+setInjectRuns(tier0Config, [369585])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"
@@ -102,7 +102,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_13_0_7"
+    'default': "CMSSW_13_0_7_TOTEM"
 }
 
 # Configure ScramArch
@@ -1158,6 +1158,9 @@ ignoreStream(tier0Config, "streamHLTRates")
 ignoreStream(tier0Config, "streamL1Rates")
 ignoreStream(tier0Config, "streamDQMRates")
 ignoreStream(tier0Config, "DQMPPSRandom")
+
+# Run only on PhysicsCommissioning stream which contains the ZeroBiasNonColliding dataset
+specifyStreams(tier0Config, ["PhysicsCommissioning"])
 
 ###################################
 ### currently inactive settings ###


### PR DESCRIPTION
# Replay Request

**Requestor**  
ORM

**Describe the configuration**  
* Release: `CMSSW_13_0_7_TOTEM`
* Run: [369585](https://cmsoms.cern.ch/cms/runs/report?cms_run=369585&cms_run_sequence=GLOBAL-RUN)
   * ~50 minutes run with all components in
   * Has the `RP_HighZB_EMTF` trigger path active
* GTs: (Unchenged)
   * ExpressGlobalTag: `130X_dataRun3_Express_v2`
   * PromptrecoGlobalTag: `130X_dataRun3_Prompt_v3`
   
* Additional changes: 
   * Used `specifyStreams` method to run on `PhysicsCommissioning` stream only, which has the corresponding PD

**Purpose of the test**  

A new PD `ZeroBiasNonColliding` was included in the production configuration last week with the deployment of `CMSSW_13_0_7_TOTEM` [1][2].  The PD contains the HLT path `HLT_L1_BptxXOR` which corresponds to the non-colliding bunch in the beams as detailed in [3] and the reconstruction follows the same sequences as other `ZeroBias*` PDs [3]. Since there were no beams during the TOTEM test run, the dataset produced was empty and there wasn't an appropriate run that could have tested the sequences in replays earlier. As the run `369585` was just taken with the corresponding ZeroBias trigger active, doing a replay with this run to test the current configuration might be beneficial to ensure that there are no surprises in the coming days for Prompt processing.

[1] https://cms-talk.web.cern.ch/t/new-primary-dataset-zerobiasnoncolliding-for-special-totem-hlt-menu-collisions/25728
[2] https://cms-talk.web.cern.ch/t/change-t0-production-node-configuration-to-use-cmssw-13-0-7-totem/25767
[3] [https://its.cern.ch/jira/browse/CMSHLT-2828](https://its.cern.ch/jira/browse/CMSHLT-2828?focusedCommentId=4860401&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-4860401)
[3] https://github.com/dmwm/T0/blob/96a7f0630fd768df17feac08a0e86a107ff98204/etc/ProdOfflineConfiguration.py#L1118-L1132
 
**T0 Operations cmsTalk thread** 
https://cms-talk.web.cern.ch/t/new-primary-dataset-zerobiasnoncolliding-for-special-totem-hlt-menu-collisions/25728


