### PR TITLE
Replay testing CMSSW_13_0_8 and standardDQMExpress sequence

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -35,7 +35,7 @@ setConfigVersion(tier0Config, "replace with real version")
 
 # Set run number to replay
 # 367102 - Collisions 2023 - 1200b - 0.5h long - all components IN
-setInjectRuns(tier0Config, [367907])
+setInjectRuns(tier0Config, [368389])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -102,7 +102,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_13_0_7"
+    'default': "CMSSW_13_0_7_patch1"
 }
 
 # Configure ScramArch
@@ -129,8 +129,8 @@ expressProcVersion = dt
 alcarawProcVersion = dt
 
 # Defaults for GlobalTag
-expressGlobalTag = "130X_dataRun3_Express_v2"
-promptrecoGlobalTag = "130X_dataRun3_Prompt_v3"
+expressGlobalTag = "130X_dataRun3_Express_v3"
+promptrecoGlobalTag = "130X_dataRun3_Prompt_v4"
 
 # Mandatory for CondDBv2
 globalTagConnect = "frontier://PromptProd/CMS_CONDITIONS"

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -35,7 +35,7 @@ setConfigVersion(tier0Config, "replace with real version")
 
 # Set run number to replay
 # 367102 - Collisions 2023 - 1200b - 0.5h long - all components IN
-setInjectRuns(tier0Config, [368389])
+setInjectRuns(tier0Config, [368823])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"
@@ -102,7 +102,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_13_0_7_patch1"
+    'default': "CMSSW_13_0_8"
 }
 
 # Configure ScramArch
@@ -207,6 +207,7 @@ addExpressConfig(tier0Config, "Express",
                                  "PromptCalibProdSiStripGains", "PromptCalibProdSiStripGainsAAG", "PromptCalibProdSiPixel",
                                  "PromptCalibProdSiPixelLA", "PromptCalibProdSiStripHitEff", "PromptCalibProdSiPixelAliHG"
                                 ],
+                 dqm_sequences=["@standardDQMExpress"],
                  reco_version=defaultCMSSWVersion,
                  multicore=numberOfCores,
                  global_tag_connect=globalTagConnect,

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -35,7 +35,7 @@ setConfigVersion(tier0Config, "replace with real version")
 
 # Set run number to replay
 # 367102 - Collisions 2023 - 1200b - 0.5h long - all components IN
-setInjectRuns(tier0Config, [367102])
+setInjectRuns(tier0Config, [367907])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"


### PR DESCRIPTION
# Replay Request

**Requestor**  
ORM, DQM

**Describe the configuration**  
* Release: CMSSW_13_0_8
* Run: 368823
* GTs: 
   * Exxpress global tag: 130X_dataRun3_Express_v3
   * Prompt global tag: 130X_dataRun3_Prompt_v4
* Additional changes: Add `standardDQMExpress` to Express stream configuration.

**Purpose of the test**  
Test new release for production deployment within Run2023D

**T0 Operations cmsTalk thread**  
[Tier0 Operations cmsTalk post](https://cms-talk.web.cern.ch/t/ask-t0-reply-of-13-0-x-with-a-new-dqm-sequence-to-be-run-on-express-stream/25956)
