### PR TITLE
Replay testing CMSSW_13_0_9 and standardDQMExpress sequence

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -207,6 +207,7 @@ addExpressConfig(tier0Config, "Express",
                                  "PromptCalibProdSiStripGains", "PromptCalibProdSiStripGainsAAG", "PromptCalibProdSiPixel",
                                  "PromptCalibProdSiPixelLA", "PromptCalibProdSiStripHitEff", "PromptCalibProdSiPixelAliHG"
                                 ],
+                 dqm_sequences=["@standardDQMExpress"],
                  reco_version=defaultCMSSWVersion,
                  multicore=numberOfCores,
                  global_tag_connect=globalTagConnect,

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -35,7 +35,7 @@ setConfigVersion(tier0Config, "replace with real version")
 
 # Set run number to replay
 # 367102 - Collisions 2023 - 1200b - 0.5h long - all components IN
-setInjectRuns(tier0Config, [367102])
+setInjectRuns(tier0Config, [368823])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"
@@ -102,7 +102,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_13_0_7"
+    'default': "CMSSW_13_0_9"
 }
 
 # Configure ScramArch
@@ -129,8 +129,8 @@ expressProcVersion = dt
 alcarawProcVersion = dt
 
 # Defaults for GlobalTag
-expressGlobalTag = "130X_dataRun3_Express_v2"
-promptrecoGlobalTag = "130X_dataRun3_Prompt_v3"
+expressGlobalTag = "130X_dataRun3_Express_v3"
+promptrecoGlobalTag = "130X_dataRun3_Prompt_v4"
 
 # Mandatory for CondDBv2
 globalTagConnect = "frontier://PromptProd/CMS_CONDITIONS"


### PR DESCRIPTION
# Replay Request

**Requestor**  
ORM,DQM

**Describe the configuration**  
* Release:   CMSSW_13_0_9
* Run: 368823
* GTs:
   * expressGlobalTag: 130X_dataRun3_Express_v3
   * promptrecoGlobalTag: 130X_dataRun3_Prompt_v4 
* Additional changes: Add `standardDQMExpress` to Express stream configuration.

**Purpose of the test**  
Test new release for production deployment within Run2023D

**T0 Operations cmsTalk thread**  
[cmsTalk](https://cms-talk.web.cern.ch/t/replay-testing-cmssw-13-0-9-and-standarddqmexpress-dqm-sequence/26045)














