### PR TITLE
Replay to test CMSSW_13_0_10

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -35,7 +35,7 @@ setConfigVersion(tier0Config, "replace with real version")
 
 # Set run number to replay
 # 367102 - Collisions 2023 - 1200b - 0.5h long - all components IN
-setInjectRuns(tier0Config, [368823])
+setInjectRuns(tier0Config, [369998])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"
@@ -102,7 +102,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_13_0_9"
+    'default': "CMSSW_13_0_10"
 }
 
 # Configure ScramArch


### PR DESCRIPTION
# Replay Request

**Requestor**  
ORM

**Describe the configuration**  
* Release: [CMSSW_13_0_10](https://github.com/cms-sw/cmssw/releases/CMSSW_13_0_10)
* Run: [369998](https://cmsoms.cern.ch/cms/runs/report?cms_run=369998&cms_run_sequence=GLOBAL-RUN)
  * ~1 hour long global collisions run 
  * after TS1 
  * with all components in 
  * Processed successfully already at T0 including Prompt
* GTs:
   * expressGlobalTag: `130X_dataRun3_Express_v3` (Unchanged)
   * promptrecoGlobalTag: `130X_dataRun3_Prompt_v4` (Unchanged)
* Additional changes:
None

**Purpose of the test**  
Test the new release CMSSW_13_0_10

**T0 Operations cmsTalk thread**  
https://cms-talk.web.cern.ch/t/t0-replay-request-for-cmssw-13-0-10/26471
