### PR TITLE
Replay Request to test limitation on lumisections

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -38,7 +38,8 @@ setConfigVersion(tier0Config, "replace with real version")
 # 367102 - Collisions 2023 - 1200b - 0.5h long - all components IN
 setInjectRuns(tier0Config, [369998])
 
-setInjectLimit(tier0Config, 10)
+# Use this in order to limit the number of lumisections to process
+#setInjectLimit(tier0Config, 10)
 
 # Settings up sites
 processingSite = "T2_CH_CERN"

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -22,6 +22,7 @@ from T0.RunConfig.Tier0Config import specifyStreams
 from T0.RunConfig.Tier0Config import addRepackConfig
 from T0.RunConfig.Tier0Config import addExpressConfig
 from T0.RunConfig.Tier0Config import setInjectRuns
+from T0.RunConfig.Tier0Config import setInjectLimit
 from T0.RunConfig.Tier0Config import setStreamerPNN
 from T0.RunConfig.Tier0Config import setEnableUniqueWorkflowName
 from T0.RunConfig.Tier0Config import addSiteConfig
@@ -36,6 +37,8 @@ setConfigVersion(tier0Config, "replace with real version")
 # Set run number to replay
 # 367102 - Collisions 2023 - 1200b - 0.5h long - all components IN
 setInjectRuns(tier0Config, [368823])
+
+setInjectLimit(tier0Config, 10)
 
 # Settings up sites
 processingSite = "T2_CH_CERN"

--- a/src/python/T0/RunConfig/Tier0Config.py
+++ b/src/python/T0/RunConfig/Tier0Config.py
@@ -24,6 +24,9 @@ Tier0Configuration - Global configuration object
 | |       |
 | |       |--> InjectMaxRun - Highest run number to be injected into the system from the SM database (default is unlimited)
 | |       |
+| |       |--> InjectLimit - Maximum number of filess to be injected into the system 
+| |       |                 from the SM database (default is unlimited) (used for small functional test)
+| |       |
 | |       |--> SpecifiedStreamNames - Streamer names list to be ran exclusivley. (default is None)
 | |       |                           If it is None, all streamer will processed except which is set to be ignored.
 | |       |
@@ -261,6 +264,7 @@ def createTier0Config():
     tier0Config.section_("Global")
 
     tier0Config.Global.InjectRuns = None
+    tier0Config.Global.InjectLimit = None
     tier0Config.Global.InjectMinRun = None
     tier0Config.Global.InjectMaxRun = None
     
@@ -774,6 +778,16 @@ def setInjectMaxRun(config, injectMaxRun):
     """
     config.Global.InjectMaxRun = injectMaxRun
     return
+
+def setInjectLimit(config, injectLimit):
+    """
+    _setInjectLimit_
+
+    Set the limit of files to be injected into the Tier0 (for small functional test).
+    """
+    config.Global.InjectLimit = injectLimit
+    return
+
 
 def setEnableUniqueWorkflowName(config):
     """

--- a/src/python/T0/RunConfig/Tier0Config.py
+++ b/src/python/T0/RunConfig/Tier0Config.py
@@ -24,8 +24,8 @@ Tier0Configuration - Global configuration object
 | |       |
 | |       |--> InjectMaxRun - Highest run number to be injected into the system from the SM database (default is unlimited)
 | |       |
-| |       |--> InjectLimit - Maximum number of filess to be injected into the system 
-| |       |                 from the SM database (default is unlimited) (used for small functional test)
+| |       |--> InjectLimit - Maximum number of lumis to be injected into the system 
+| |       |                  from the SM database (default is unlimited) (used for small functional test)
 | |       |
 | |       |--> SpecifiedStreamNames - Streamer names list to be ran exclusivley. (default is None)
 | |       |                           If it is None, all streamer will processed except which is set to be ignored.
@@ -783,7 +783,7 @@ def setInjectLimit(config, injectLimit):
     """
     _setInjectLimit_
 
-    Set the limit of files to be injected into the Tier0 (for small functional test).
+    Set the limit of lumis to be injected into the Tier0 (for small functional test).
     """
     config.Global.InjectLimit = injectLimit
     return

--- a/src/python/T0/StorageManager/StorageManagerAPI.py
+++ b/src/python/T0/StorageManager/StorageManagerAPI.py
@@ -18,7 +18,8 @@ def injectNewData(dbInterfaceStorageManager,
                   streamerPNN,
                   minRun = None,
                   maxRun = None,
-                  injectRun = None):
+                  injectRun = None,
+                  injectLimit = None):
     """
     _injectNewData_
 
@@ -65,6 +66,7 @@ def injectNewData(dbInterfaceStorageManager,
     newData = getNewDataDAO.execute(minRun = minRun,
                                     maxRun = maxRun,
                                     injectRun = injectRun, 
+                                    injectLimit = injectLimit,
                                     transaction = False)
 
     # remove already processed files

--- a/src/python/T0/WMBS/Oracle/StorageManager/GetNewData.py
+++ b/src/python/T0/WMBS/Oracle/StorageManager/GetNewData.py
@@ -53,7 +53,7 @@ class GetNewData(DBFormatter):
                 """ % whereSql
         
         if injectLimit:
-            sql = sql % """ LIMIT {}""".format(injectLimit)
+            sql += " AND CMS_STOMGR.FILE_TRANSFER_STATUS.LS < {injectLimit}".format(injectLimit = injectLimit)
 
         results = self.dbi.processData(sql, binds, conn = conn,
                                        transaction = transaction)

--- a/src/python/T0/WMBS/Oracle/StorageManager/GetNewData.py
+++ b/src/python/T0/WMBS/Oracle/StorageManager/GetNewData.py
@@ -11,7 +11,7 @@ from WMCore.Database.DBFormatter import DBFormatter
 
 class GetNewData(DBFormatter):
 
-    def execute(self, minRun = None, maxRun = None, injectRun = None, conn = None, transaction = False):
+    def execute(self, minRun = None, maxRun = None, injectRun = None, injectLimit = None,  conn = None, transaction = False):
 
         if injectRun:
             binds = { 'RUN': injectRun }
@@ -35,22 +35,40 @@ class GetNewData(DBFormatter):
                 whereSql += """AND CMS_STOMGR.FILE_TRANSFER_STATUS.RUNNUMBER <= :MAXRUN
                                """
 
-        sql = """SELECT CMS_STOMGR.FILE_TRANSFER_STATUS.FILE_ID AS p5_id,
-                        CMS_STOMGR.FILE_TRANSFER_STATUS.RUNNUMBER AS run,
-                        CMS_STOMGR.FILE_TRANSFER_STATUS.LS AS lumi,
-                        CMS_STOMGR.FILE_TRANSFER_STATUS.STREAM AS stream,
-                        CMS_STOMGR.FILE_TRANSFER_STATUS.PATH AS path,
-                        CMS_STOMGR.FILE_TRANSFER_STATUS.FILENAME AS filename,
-                        CMS_STOMGR.FILE_QUALITY_CONTROL.FILE_SIZE AS filesize,
-                        NVL(CMS_STOMGR.FILE_QUALITY_CONTROL.EVENTS_ACCEPTED, 0) AS events
-                 FROM CMS_STOMGR.FILE_TRANSFER_STATUS
-                 INNER JOIN CMS_STOMGR.FILE_QUALITY_CONTROL ON
-                   CMS_STOMGR.FILE_QUALITY_CONTROL.FILENAME = CMS_STOMGR.FILE_TRANSFER_STATUS.FILENAME
-                 %s
-                 AND CMS_STOMGR.FILE_TRANSFER_STATUS.PATH IS NOT NULL
-                 AND CMS_STOMGR.FILE_QUALITY_CONTROL.FILE_SIZE IS NOT NULL
-                 AND CMS_STOMGR.FILE_QUALITY_CONTROL.FILE_SIZE > 0
-                 """ % whereSql
+        if injectLimit:
+            sql = """SELECT CMS_STOMGR.FILE_TRANSFER_STATUS.FILE_ID AS p5_id,
+                            CMS_STOMGR.FILE_TRANSFER_STATUS.RUNNUMBER AS run,
+                            CMS_STOMGR.FILE_TRANSFER_STATUS.LS AS lumi,
+                            CMS_STOMGR.FILE_TRANSFER_STATUS.STREAM AS stream,
+                            CMS_STOMGR.FILE_TRANSFER_STATUS.PATH AS path,
+                            CMS_STOMGR.FILE_TRANSFER_STATUS.FILENAME AS filename,
+                            CMS_STOMGR.FILE_QUALITY_CONTROL.FILE_SIZE AS filesize,
+                            NVL(CMS_STOMGR.FILE_QUALITY_CONTROL.EVENTS_ACCEPTED, 0) AS events
+                    FROM CMS_STOMGR.FILE_TRANSFER_STATUS
+                    INNER JOIN CMS_STOMGR.FILE_QUALITY_CONTROL ON
+                    CMS_STOMGR.FILE_QUALITY_CONTROL.FILENAME = CMS_STOMGR.FILE_TRANSFER_STATUS.FILENAME
+                    %s
+                    AND CMS_STOMGR.FILE_TRANSFER_STATUS.PATH IS NOT NULL
+                    AND CMS_STOMGR.FILE_QUALITY_CONTROL.FILE_SIZE IS NOT NULL
+                    AND CMS_STOMGR.FILE_QUALITY_CONTROL.FILE_SIZE > 0
+                    """ % whereSql % """ LIMIT {}""".format(injectLimit)
+        else:
+            sql = """SELECT CMS_STOMGR.FILE_TRANSFER_STATUS.FILE_ID AS p5_id,
+                            CMS_STOMGR.FILE_TRANSFER_STATUS.RUNNUMBER AS run,
+                            CMS_STOMGR.FILE_TRANSFER_STATUS.LS AS lumi,
+                            CMS_STOMGR.FILE_TRANSFER_STATUS.STREAM AS stream,
+                            CMS_STOMGR.FILE_TRANSFER_STATUS.PATH AS path,
+                            CMS_STOMGR.FILE_TRANSFER_STATUS.FILENAME AS filename,
+                            CMS_STOMGR.FILE_QUALITY_CONTROL.FILE_SIZE AS filesize,
+                            NVL(CMS_STOMGR.FILE_QUALITY_CONTROL.EVENTS_ACCEPTED, 0) AS events
+                    FROM CMS_STOMGR.FILE_TRANSFER_STATUS
+                    INNER JOIN CMS_STOMGR.FILE_QUALITY_CONTROL ON
+                    CMS_STOMGR.FILE_QUALITY_CONTROL.FILENAME = CMS_STOMGR.FILE_TRANSFER_STATUS.FILENAME
+                    %s
+                    AND CMS_STOMGR.FILE_TRANSFER_STATUS.PATH IS NOT NULL
+                    AND CMS_STOMGR.FILE_QUALITY_CONTROL.FILE_SIZE IS NOT NULL
+                    AND CMS_STOMGR.FILE_QUALITY_CONTROL.FILE_SIZE > 0
+                    """ % whereSql
 
         results = self.dbi.processData(sql, binds, conn = conn,
                                        transaction = transaction)

--- a/src/python/T0/WMBS/Oracle/StorageManager/GetNewData.py
+++ b/src/python/T0/WMBS/Oracle/StorageManager/GetNewData.py
@@ -35,40 +35,25 @@ class GetNewData(DBFormatter):
                 whereSql += """AND CMS_STOMGR.FILE_TRANSFER_STATUS.RUNNUMBER <= :MAXRUN
                                """
 
+        sql = """SELECT CMS_STOMGR.FILE_TRANSFER_STATUS.FILE_ID AS p5_id,
+                        CMS_STOMGR.FILE_TRANSFER_STATUS.RUNNUMBER AS run,
+                        CMS_STOMGR.FILE_TRANSFER_STATUS.LS AS lumi,
+                        CMS_STOMGR.FILE_TRANSFER_STATUS.STREAM AS stream,
+                        CMS_STOMGR.FILE_TRANSFER_STATUS.PATH AS path,
+                        CMS_STOMGR.FILE_TRANSFER_STATUS.FILENAME AS filename,
+                        CMS_STOMGR.FILE_QUALITY_CONTROL.FILE_SIZE AS filesize,
+                        NVL(CMS_STOMGR.FILE_QUALITY_CONTROL.EVENTS_ACCEPTED, 0) AS events
+                FROM CMS_STOMGR.FILE_TRANSFER_STATUS
+                INNER JOIN CMS_STOMGR.FILE_QUALITY_CONTROL ON
+                CMS_STOMGR.FILE_QUALITY_CONTROL.FILENAME = CMS_STOMGR.FILE_TRANSFER_STATUS.FILENAME
+                %s
+                AND CMS_STOMGR.FILE_TRANSFER_STATUS.PATH IS NOT NULL
+                AND CMS_STOMGR.FILE_QUALITY_CONTROL.FILE_SIZE IS NOT NULL
+                AND CMS_STOMGR.FILE_QUALITY_CONTROL.FILE_SIZE > 0
+                """ % whereSql
+        
         if injectLimit:
-            sql = """SELECT CMS_STOMGR.FILE_TRANSFER_STATUS.FILE_ID AS p5_id,
-                            CMS_STOMGR.FILE_TRANSFER_STATUS.RUNNUMBER AS run,
-                            CMS_STOMGR.FILE_TRANSFER_STATUS.LS AS lumi,
-                            CMS_STOMGR.FILE_TRANSFER_STATUS.STREAM AS stream,
-                            CMS_STOMGR.FILE_TRANSFER_STATUS.PATH AS path,
-                            CMS_STOMGR.FILE_TRANSFER_STATUS.FILENAME AS filename,
-                            CMS_STOMGR.FILE_QUALITY_CONTROL.FILE_SIZE AS filesize,
-                            NVL(CMS_STOMGR.FILE_QUALITY_CONTROL.EVENTS_ACCEPTED, 0) AS events
-                    FROM CMS_STOMGR.FILE_TRANSFER_STATUS
-                    INNER JOIN CMS_STOMGR.FILE_QUALITY_CONTROL ON
-                    CMS_STOMGR.FILE_QUALITY_CONTROL.FILENAME = CMS_STOMGR.FILE_TRANSFER_STATUS.FILENAME
-                    %s
-                    AND CMS_STOMGR.FILE_TRANSFER_STATUS.PATH IS NOT NULL
-                    AND CMS_STOMGR.FILE_QUALITY_CONTROL.FILE_SIZE IS NOT NULL
-                    AND CMS_STOMGR.FILE_QUALITY_CONTROL.FILE_SIZE > 0
-                    """ % whereSql % """ LIMIT {}""".format(injectLimit)
-        else:
-            sql = """SELECT CMS_STOMGR.FILE_TRANSFER_STATUS.FILE_ID AS p5_id,
-                            CMS_STOMGR.FILE_TRANSFER_STATUS.RUNNUMBER AS run,
-                            CMS_STOMGR.FILE_TRANSFER_STATUS.LS AS lumi,
-                            CMS_STOMGR.FILE_TRANSFER_STATUS.STREAM AS stream,
-                            CMS_STOMGR.FILE_TRANSFER_STATUS.PATH AS path,
-                            CMS_STOMGR.FILE_TRANSFER_STATUS.FILENAME AS filename,
-                            CMS_STOMGR.FILE_QUALITY_CONTROL.FILE_SIZE AS filesize,
-                            NVL(CMS_STOMGR.FILE_QUALITY_CONTROL.EVENTS_ACCEPTED, 0) AS events
-                    FROM CMS_STOMGR.FILE_TRANSFER_STATUS
-                    INNER JOIN CMS_STOMGR.FILE_QUALITY_CONTROL ON
-                    CMS_STOMGR.FILE_QUALITY_CONTROL.FILENAME = CMS_STOMGR.FILE_TRANSFER_STATUS.FILENAME
-                    %s
-                    AND CMS_STOMGR.FILE_TRANSFER_STATUS.PATH IS NOT NULL
-                    AND CMS_STOMGR.FILE_QUALITY_CONTROL.FILE_SIZE IS NOT NULL
-                    AND CMS_STOMGR.FILE_QUALITY_CONTROL.FILE_SIZE > 0
-                    """ % whereSql
+            sql = sql % """ LIMIT {}""".format(injectLimit)
 
         results = self.dbi.processData(sql, binds, conn = conn,
                                        transaction = transaction)

--- a/src/python/T0Component/Tier0Feeder/Tier0FeederPoller.py
+++ b/src/python/T0Component/Tier0Feeder/Tier0FeederPoller.py
@@ -160,7 +160,8 @@ class Tier0FeederPoller(BaseWorkerThread):
                                                     self.dbInterfaceSMNotify,
                                                     streamerPNN = tier0Config.Global.StreamerPNN,
                                                     minRun = tier0Config.Global.InjectMinRun,
-                                                    maxRun = tier0Config.Global.InjectMaxRun)
+                                                    maxRun = tier0Config.Global.InjectMaxRun,
+                                                    injectLimit= tier0Config.Global.InjectLimit)
                 else:
                     injectRuns = set()
                     for injectRun in tier0Config.Global.InjectRuns:

--- a/src/python/T0Component/Tier0Feeder/Tier0FeederPoller.py
+++ b/src/python/T0Component/Tier0Feeder/Tier0FeederPoller.py
@@ -160,8 +160,7 @@ class Tier0FeederPoller(BaseWorkerThread):
                                                     self.dbInterfaceSMNotify,
                                                     streamerPNN = tier0Config.Global.StreamerPNN,
                                                     minRun = tier0Config.Global.InjectMinRun,
-                                                    maxRun = tier0Config.Global.InjectMaxRun,
-                                                    injectLimit= tier0Config.Global.InjectLimit)
+                                                    maxRun = tier0Config.Global.InjectMaxRun)
                 else:
                     injectRuns = set()
                     for injectRun in tier0Config.Global.InjectRuns:
@@ -172,7 +171,8 @@ class Tier0FeederPoller(BaseWorkerThread):
                                                         self.dbInterfaceHltConf,
                                                         self.dbInterfaceSMNotify,
                                                         streamerPNN = tier0Config.Global.StreamerPNN,
-                                                        injectRun = injectRun)
+                                                        injectRun = injectRun,
+                                                        injectLimit= tier0Config.Global.InjectLimit)
                         self.injectedRuns.add(injectRun)
             except:
                 # shouldn't happen, just a catch all insurance


### PR DESCRIPTION
Requestor
T0

Release:  CMSSW_13_0_9
Run: 368823
GTs:
    expressGlobalTag: 130X_dataRun3_Express_v3
    promptrecoGlobalTag: 130X_dataRun3_Prompt_v4
Additional changes:  adding a new parameter to limit the number of lumisections to inject into the system.

Purpose of the test
An attempt to limit the number of lumisections in the replay test. It will be used in new small functional test in the future.

