### PR TITLE
Replay to test CMSSW_13_0_11

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -35,7 +35,7 @@ setConfigVersion(tier0Config, "replace with real version")
 
 # Set run number to replay
 # 367102 - Collisions 2023 - 1200b - 0.5h long - all components IN
-setInjectRuns(tier0Config, [368823])
+setInjectRuns(tier0Config, [369998])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"
@@ -102,7 +102,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_13_0_9"
+    'default': "CMSSW_13_0_10"
 }
 
 # Configure ScramArch

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -102,7 +102,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_13_0_10"
+    'default': "CMSSW_13_0_11"
 }
 
 # Configure ScramArch


### PR DESCRIPTION
# Replay Request

**Requestor**  
ORM, T0

**Describe the configuration**  
* Release: [CMSSW_13_0_11](https://github.com/cms-sw/cmssw/releases/CMSSW_13_0_11)
* Run: [369998](https://cmsoms.cern.ch/cms/runs/report?cms_run=369998&cms_run_sequence=GLOBAL-RUN)
* GTs:
   * expressGlobalTag: `130X_dataRun3_Express_v3` (Unchanged)
   * promptrecoGlobalTag: `130X_dataRun3_Prompt_v4` (Unchanged)
* Additional changes:
None

**Purpose of the test**  
Test the new release CMSSW_13_0_11

**T0 Operations cmsTalk thread**  
To be created