### PR TITLE
Production configuration change after magnet half cycle

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -92,9 +92,11 @@ setPromptCalibrationConfig(tier0Config,
 #   'maxRun': {100000: Value3, 200000: Value4},
 #   'default': Value5 }
 
+maxRunPreviousConfig = 999999 # Last run before magnet half cycle 13 July 2023
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_13_0_9"
+    'default': "CMSSW_13_0_10",
+    'maxRun': {maxRunPreviousConfig: "CMSSW_13_0_9"}
 }
 
 # Configure ScramArch
@@ -113,15 +115,18 @@ hiTestppScenario = "ppEra_Run3"
 
 # Defaults for processing version
 alcarawProcVersion = {
-    'default': "1"
+    'maxRun': {maxRunPreviousConfig: 1},
+    'default': 2
 }
 
 defaultProcVersionReco = {
-    'default': "1"
+    'maxRun': {maxRunPreviousConfig: 1},
+    'default': 2
 }
 
 expressProcVersion = {
-    'default': "1"
+    'maxRun': {maxRunPreviousConfig: 1},
+    'default': 2
 }
 
 # Defaults for GlobalTag

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -35,7 +35,7 @@ setConfigVersion(tier0Config, "replace with real version")
 
 # Set run number to replay
 # 367102 - Collisions 2023 - 1200b - 0.5h long - all components IN
-setInjectRuns(tier0Config, [368823])
+setInjectRuns(tier0Config, [369998])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"
@@ -102,7 +102,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_13_0_9"
+    'default': "CMSSW_13_0_10"
 }
 
 # Configure ScramArch


### PR DESCRIPTION
New T0 production configuration to be deployed after magnet half cycle.
- CMSSW version changes to CMSSW_13_0_10 (tested in #4848)
- Moves processing version to 2

The proper value for `maxRunPreviousConfig` will be determined in coordination with P5