### PR TITLE
Add SpecialZeroBias dataset to reco config in configuration files

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -1140,13 +1140,13 @@ DATASETS += ["ZeroBiasPD01", "ZeroBiasPD02", "ZeroBiasPD03",
 
 DATASETS += ["ZeroBiasNonColliding"]
 
-DATASETS += ["SpecialZeroBias", "SpecialZeroBias0", "SpecialZeroBias1",
-				"SpecialZeroBias2", "SpecialZeroBias3", "SpecialZeroBias4",
-				"SpecialZeroBias5", "SpecialZeroBias6", "SpecialZeroBias7",
-				"SpecialZeroBias8", "SpecialZeroBias9", "SpecialZeroBias10",
-            	"SpecialZeroBias11", "SpecialZeroBias12", "SpecialZeroBias13",
-            	"SpecialZeroBias14", "SpecialZeroBias15", "SpecialZeroBias16",
-             	"SpecialZeroBias17", "SpecialZeroBias18", "SpecialZeroBias19"]
+DATASETS += ["SpecialZeroBias", "SpecialZeroBias0", "SpecialZeroBias1", 
+	     "SpecialZeroBias2", "SpecialZeroBias3", "SpecialZeroBias4", 
+	     "SpecialZeroBias5", "SpecialZeroBias6", "SpecialZeroBias7",
+	     "SpecialZeroBias8", "SpecialZeroBias9", "SpecialZeroBias10",
+	     "SpecialZeroBias11", "SpecialZeroBias12", "SpecialZeroBias13",
+	     "SpecialZeroBias14", "SpecialZeroBias15", "SpecialZeroBias16",
+	     "SpecialZeroBias17", "SpecialZeroBias18", "SpecialZeroBias19"]
 
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,

--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -1140,6 +1140,14 @@ DATASETS += ["ZeroBiasPD01", "ZeroBiasPD02", "ZeroBiasPD03",
 
 DATASETS += ["ZeroBiasNonColliding"]
 
+DATASETS += ["SpecialZeroBias", "SpecialZeroBias0", "SpecialZeroBias1",
+				"SpecialZeroBias2", "SpecialZeroBias3", "SpecialZeroBias4",
+				"SpecialZeroBias5", "SpecialZeroBias6", "SpecialZeroBias7",
+				"SpecialZeroBias8", "SpecialZeroBias9", "SpecialZeroBias10",
+            	"SpecialZeroBias11", "SpecialZeroBias12", "SpecialZeroBias13",
+            	"SpecialZeroBias14", "SpecialZeroBias15", "SpecialZeroBias16",
+             	"SpecialZeroBias17", "SpecialZeroBias18", "SpecialZeroBias19"]
+
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,
                do_reco=True,

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -1025,6 +1025,14 @@ DATASETS += ["ZeroBiasPD01", "ZeroBiasPD02", "ZeroBiasPD03",
 
 DATASETS += ["ZeroBiasNonColliding"]
 
+DATASETS += ["SpecialZeroBias", "SpecialZeroBias0", "SpecialZeroBias1",
+				"SpecialZeroBias2", "SpecialZeroBias3", "SpecialZeroBias4",
+				"SpecialZeroBias5", "SpecialZeroBias6", "SpecialZeroBias7",
+				"SpecialZeroBias8", "SpecialZeroBias9", "SpecialZeroBias10",
+            	"SpecialZeroBias11", "SpecialZeroBias12", "SpecialZeroBias13",
+            	"SpecialZeroBias14", "SpecialZeroBias15", "SpecialZeroBias16",
+             	"SpecialZeroBias17", "SpecialZeroBias18", "SpecialZeroBias19"]
+
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,
                do_reco=True,


### PR DESCRIPTION
It has been requested to add the SpecialZeroBiasN Datasets in the configuration file. The request can be seen in [this jira ticket](https://its.cern.ch/jira/browse/CMSTZ-1052)
