### PR TITLE
Add files that support the primary dataset config history API entry

### DIFF
--- a/bin/00_patches.sh
+++ b/bin/00_patches.sh
@@ -31,3 +31,6 @@ curl https://patch-diff.githubusercontent.com/raw/dmwm/T0/pull/4827.patch | patc
 
 #Adding skipped streamer info into T0 Data Service
 curl https://patch-diff.githubusercontent.com/raw/dmwm/T0/pull/4841.patch | patch -d $DEPLOY_DIR/current/apps/t0/lib/python3.8/site-packages/ -p 3
+
+#Adding primary_dataset_config into T0 Data Service
+curl https://patch-diff.githubusercontent.com/raw/dmwm/T0/pull/4857.patch | patch -d $DEPLOY_DIR/current/apps/t0/lib/python3.8/site-packages/ -p 3

--- a/src/python/T0/WMBS/Oracle/T0DataSvc/GetPrimaryDatasetConfigs.py
+++ b/src/python/T0/WMBS/Oracle/T0DataSvc/GetPrimaryDatasetConfigs.py
@@ -26,8 +26,7 @@ class GetPrimaryDatasetConfigs(DBFormatter):
                 FROM reco_config
                 JOIN run ON run.run_id = reco_config.run_id
                 WHERE reco_config.in_datasvc = 1
-                GROUP BY acq_era, primds, cmssw,  global_tag, physics_skim, dqm_seq
-                ORDER BY primds
+                ORDER BY primds, run desc
                 """
 
         results = self.dbi.processData(sql, binds = {}, conn = conn,

--- a/src/python/T0/WMBS/Oracle/T0DataSvc/GetPrimaryDatasetConfigs.py
+++ b/src/python/T0/WMBS/Oracle/T0DataSvc/GetPrimaryDatasetConfigs.py
@@ -1,0 +1,37 @@
+"""
+_GetPrimaryDatasetConfigs_
+
+Oracle implementation of GetPrimaryDatasetConfigs
+
+Return reco configuration for each primary dataset and the run intervals where such configuration took place
+
+"""
+
+from WMCore.Database.DBFormatter import DBFormatter
+
+class GetPrimaryDatasetConfigs(DBFormatter):
+
+    def execute(self, conn = None, transaction = False):
+
+
+        sql = """
+                SELECT 
+                      reco_config.primds_id AS primds, 
+                      run.acq_era AS acq_era, 
+                      MIN(run.run_id) AS min_run, 
+                      MAX(run.run_id) AS max_run, 
+                      reco_config.cmssw_id AS cmssw, 
+                      reco_config.global_tag AS global_tag, 
+                      reco_config.physics_skim AS physics_skim, 
+                      reco_config.dqm_seq AS dqm_seq
+                FROM reco_config
+                JOIN run ON run.run_id = reco_config.run_id
+                WHERE checkForZeroState(reco_config.in_datasvc) = 1
+                GROUP BY acq_era, primds, cmssw,  global_tag, physics_skim, dqm_seq
+                ORDER BY primds, min_run desc
+                """
+
+        results = self.dbi.processData(sql, binds = {}, conn = conn,
+                                       transaction = transaction)
+
+        return self.formatDict(results)

--- a/src/python/T0/WMBS/Oracle/T0DataSvc/GetPrimaryDatasetConfigs.py
+++ b/src/python/T0/WMBS/Oracle/T0DataSvc/GetPrimaryDatasetConfigs.py
@@ -18,17 +18,16 @@ class GetPrimaryDatasetConfigs(DBFormatter):
                 SELECT 
                       reco_config.primds_id AS primds, 
                       run.acq_era AS acq_era, 
-                      MIN(run.run_id) AS min_run, 
-                      MAX(run.run_id) AS max_run, 
+                      run.run_id AS run,
                       reco_config.cmssw_id AS cmssw, 
                       reco_config.global_tag AS global_tag, 
                       reco_config.physics_skim AS physics_skim, 
                       reco_config.dqm_seq AS dqm_seq
                 FROM reco_config
                 JOIN run ON run.run_id = reco_config.run_id
-                WHERE checkForZeroState(reco_config.in_datasvc) = 1
+                WHERE reco_config.in_datasvc = 1
                 GROUP BY acq_era, primds, cmssw,  global_tag, physics_skim, dqm_seq
-                ORDER BY primds, min_run desc
+                ORDER BY primds
                 """
 
         results = self.dbi.processData(sql, binds = {}, conn = conn,

--- a/src/python/T0/WMBS/Oracle/T0DataSvc/InsertPrimaryDatasetConfigs.py
+++ b/src/python/T0/WMBS/Oracle/T0DataSvc/InsertPrimaryDatasetConfigs.py
@@ -16,8 +16,8 @@ class InsertPrimaryDatasetConfigs(DBFormatter):
         sql = """MERGE INTO primary_dataset_config
                  USING DUAL ON ( primds = :PRIMDS )
                  WHEN NOT MATCHED THEN
-                   INSERT (primds, acq_era, min_run, max_run, cmssw, global_tag, physics_skim, dqm_seq)
-                   VALUES (:PRIMDS, :ACQ_ERA, :MIN_RUN, :MAX_RUN, :CMSSW, :GLOBAL_TAG, :PHYSICS_SKIM, DQM_SEQ)
+                   INSERT (primds, acq_era, run, cmssw, global_tag, physics_skim, dqm_seq)
+                   VALUES (:PRIMDS, :ACQ_ERA, :RUN, :MAX_RUN, :CMSSW, :GLOBAL_TAG, :PHYSICS_SKIM, DQM_SEQ)
                  """
 
         self.dbi.processData(sql, binds, conn = conn,

--- a/src/python/T0/WMBS/Oracle/T0DataSvc/InsertPrimaryDatasetConfigs.py
+++ b/src/python/T0/WMBS/Oracle/T0DataSvc/InsertPrimaryDatasetConfigs.py
@@ -17,7 +17,7 @@ class InsertPrimaryDatasetConfigs(DBFormatter):
                  USING DUAL ON ( primds = :PRIMDS )
                  WHEN NOT MATCHED THEN
                    INSERT (primds, acq_era, run, cmssw, global_tag, physics_skim, dqm_seq)
-                   VALUES (:PRIMDS, :ACQ_ERA, :RUN, :MAX_RUN, :CMSSW, :GLOBAL_TAG, :PHYSICS_SKIM, DQM_SEQ)
+                   VALUES (:PRIMDS, :ACQ_ERA, :RUN, :CMSSW, :GLOBAL_TAG, :PHYSICS_SKIM, DQM_SEQ)
                  """
 
         self.dbi.processData(sql, binds, conn = conn,

--- a/src/python/T0/WMBS/Oracle/T0DataSvc/InsertPrimaryDatasetConfigs.py
+++ b/src/python/T0/WMBS/Oracle/T0DataSvc/InsertPrimaryDatasetConfigs.py
@@ -1,0 +1,26 @@
+"""
+_InsertPrimaryDatasetConfigs_
+
+Oracle implementation of InsertPrimaryDatasetConfigs
+
+Insert skipped streamers into Tier0 Data Service
+
+"""
+
+from WMCore.Database.DBFormatter import DBFormatter
+
+class InsertSkippedStreamers(DBFormatter):
+
+    def execute(self, binds, conn = None, transaction = False):
+
+        sql = """MERGE INTO primary_dataset_config
+                 USING DUAL ON ( primds = :PRIMDS )
+                 WHEN NOT MATCHED THEN
+                   INSERT (primds, acq_era, min_run, max_run, cmssw, global_tag, physics_skim, dqm_seq)
+                   VALUES (:PRIMDS, :ACQ_ERA, :MIN_RUN, :MAX_RUN, :CMSSW, :GLOBAL_TAG, :PHYSICS_SKIM, DQM_SEQ)
+                 """
+
+        self.dbi.processData(sql, binds, conn = conn,
+                             transaction = transaction)
+
+        return

--- a/src/python/T0/WMBS/Oracle/T0DataSvc/InsertPrimaryDatasetConfigs.py
+++ b/src/python/T0/WMBS/Oracle/T0DataSvc/InsertPrimaryDatasetConfigs.py
@@ -9,7 +9,7 @@ Insert skipped streamers into Tier0 Data Service
 
 from WMCore.Database.DBFormatter import DBFormatter
 
-class InsertSkippedStreamers(DBFormatter):
+class InsertPrimaryDatasetConfigs(DBFormatter):
 
     def execute(self, binds, conn = None, transaction = False):
 


### PR DESCRIPTION
A new T0 API entry has been requested by DQM/PPD to keep track of the configuration used for each primary dataset as their respective configuration changes. Such request can be seen in this Jira ticket: https://its.cern.ch/jira/browse/CMSTZDEV-793?filter=-1

A replay will be launched with this changes included. 

