### PR TITLE
Replay testing CMSSW_13_2_1 wit ppCollisions run

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -35,7 +35,7 @@ setConfigVersion(tier0Config, "replace with real version")
 
 # Set run number to replay
 # 367102 - Collisions 2023 - 1200b - 0.5h long - all components IN
-setInjectRuns(tier0Config, [369998])
+setInjectRuns(tier0Config, [371306])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"
@@ -102,7 +102,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_13_0_10"
+    'default': "CMSSW_13_2_0"
 }
 
 # Configure ScramArch
@@ -129,8 +129,8 @@ expressProcVersion = dt
 alcarawProcVersion = dt
 
 # Defaults for GlobalTag
-expressGlobalTag = "130X_dataRun3_Express_v3"
-promptrecoGlobalTag = "130X_dataRun3_Prompt_v4"
+expressGlobalTag = "132X_dataRun3_Express_v2"
+promptrecoGlobalTag = "132X_dataRun3_Prompt_v2"
 
 # Mandatory for CondDBv2
 globalTagConnect = "frontier://PromptProd/CMS_CONDITIONS"

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -35,7 +35,7 @@ setConfigVersion(tier0Config, "replace with real version")
 
 # Set run number to replay
 # 367102 - Collisions 2023 - 1200b - 0.5h long - all components IN
-setInjectRuns(tier0Config, [371306])
+setInjectRuns(tier0Config, [369998])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -102,7 +102,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_13_2_0"
+    'default': "CMSSW_13_2_1"
 }
 
 # Configure ScramArch
@@ -702,7 +702,7 @@ for dataset in DATASETS:
     addDataset(tier0Config, dataset,
                do_reco=True,
                write_dqm=True,
-               alca_producers=["TkAlMinBias", "SiStripCalMinBias", "HcalCalIsoTrk", "HcalCalIsolatedBunchFilter"],
+               alca_producers=["TkAlMinBias", "SiStripCalMinBias", "HcalCalIsoTrk"],
                dqm_sequences=["@common", "@L1TMon", "@hcal"],
                physics_skims=["EcalActivity", "LogError", "LogErrorMonitor"],
                timePerEvent=12,


### PR DESCRIPTION
# Replay Request

**Requestor**  
RC and PPD

**Describe the configuration**  
* Release: CMSSW_13_2_1
* Run: 369998
* GTs:
   * expressGlobalTag: 132X_dataRun3_Express_v2
   * promptrecoGlobalTag: 132X_dataRun3_Prompt_v2
* Additional changes:

**Purpose of the test**  
Test a CMSSW_13_2_X release in preparation for resuming operations at LHC

**T0 Operations cmsTalk thread**  
https://cms-talk.web.cern.ch/t/testing-of-cmssw-13-2-x-releases-before-restart-of-operations/28475
