### PR TITLE
Add MuonShower to Production config

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -581,6 +581,18 @@ for dataset in DATASETS:
                disk_node="T2_CH_CERN",
                scenario=ppScenario)
 
+DATASETS = ["MuonShower"]
+
+for dataset in DATASETS:
+    addDataset(tier0Config, dataset,
+               do_reco=True,
+               write_reco=False,
+               write_aod=True,
+               write_miniaod=True,
+               write_nanoaod=True,
+               physics_skims=["EXOCSCCluster"],
+               scenario=ppScenario)
+
 DATASETS = ["ParkingHH", "ParkingVBF0",
             "ParkingVBF1", "ParkingVBF2", "ParkingVBF3",
             "ParkingVBF4", "ParkingVBF5", "ParkingVBF6",

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -541,6 +541,18 @@ for dataset in DATASETS:
                alca_producers=["TkAlJpsiMuMu", "TkAlUpsilonMuMu"],
                scenario=ppScenario)
 
+DATASETS = ["MuonShower"]
+
+for dataset in DATASETS:
+    addDataset(tier0Config, dataset,
+               do_reco=True,
+               write_reco=False,
+               write_aod=True,
+               write_miniaod=True,
+               write_nanoaod=True,
+               physics_skims=["EXOCSCCluster"],
+               scenario=ppScenario)
+
 DATASETS = [ "ParkingLLP" ]
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,


### PR DESCRIPTION
The PD `MuonShower` will be present in the next version of HLT Cosmics and Circulating beam menu, so we are adding the data set to the configuration according to their request.

You can find the request and configuration discussion here:
https://cms-talk.web.cern.ch/t/new-primary-dataset-muonshower/28871
