### PR TITLE
Replay testing ALCA producers for SiStripLA

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -36,7 +36,7 @@ setConfigVersion(tier0Config, "replace with real version")
 
 # Set run number to replay
 # 367102 - Collisions 2023 - 1200b - 0.5h long - all components IN
-setInjectRuns(tier0Config, [369998])
+setInjectRuns(tier0Config, [372704])
 
 # Use this in order to limit the number of lumisections to process
 #setInjectLimit(tier0Config, 10)
@@ -106,7 +106,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_13_2_2"
+    'default': "CMSSW_13_2_3"
 }
 
 # Configure ScramArch
@@ -133,8 +133,8 @@ expressProcVersion = dt
 alcarawProcVersion = dt
 
 # Defaults for GlobalTag
-expressGlobalTag = "132X_dataRun3_Express_v3"
-promptrecoGlobalTag = "132X_dataRun3_Prompt_v2"
+expressGlobalTag = "132X_dataRun3_Express_SiStripLA_v1"
+promptrecoGlobalTag = "132X_dataRun3_Prompt_SiStripLA_v1"
 
 # Mandatory for CondDBv2
 globalTagConnect = "frontier://PromptProd/CMS_CONDITIONS"
@@ -236,8 +236,8 @@ addExpressConfig(tier0Config, "ExpressCosmics",
                  data_tiers=["FEVT"],
                  write_dqm=True,
                  alca_producers=["SiStripPCLHistos", "SiStripCalZeroBias", "TkAlCosmics0T",
-                                 "SiPixelCalZeroBias", "SiPixelCalCosmics",
-                                 "PromptCalibProdSiStrip", "PromptCalibProdSiPixelLAMCS"
+                                 "SiPixelCalZeroBias", "SiPixelCalCosmics", "SiStripCalCosmics",
+                                 "PromptCalibProdSiStrip", "PromptCalibProdSiPixelLAMCS", "PromptCalibProdSiStripLA"
                                 ],
                  reco_version=defaultCMSSWVersion,
                  multicore=numberOfCores,


### PR DESCRIPTION
# Replay Request

**Requestor**  
ALCA

**Describe the configuration**  
* Release: CMSSW_13_2_3
* Run: 372704
* GTs:
   * expressGlobalTag: 132X_dataRun3_Express_SiStripLA_v1
   * promptrecoGlobalTag: 132X_dataRun3_Prompt_SiStripLA_v1
* Additional changes: Added AlCa producers `SiStripCalCosmics` and `PromptCalibProdSiStripLA`

**Purpose of the test**  
Test the new alca producers, and first test of 13_2_3

**T0 Operations cmsTalk thread**  
If necessary, provide a link to the cmsTalk thread announcing the test to the relevant groups. 
[Tier0 Operations cmsTalk Forum](https://cms-talk.web.cern.ch/t/replay-request-to-test-new-sistripla-pcl-worflow-with-cmssw-13-2-3/29234/2)
