### PR TITLE
Production configuration for CMSSW_13_2_3

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -55,7 +55,7 @@ addSiteConfig(tier0Config, "T0_CH_CERN_Disk",
 #  Data type
 #  Processing site (where jobs run)
 #  PhEDEx locations
-setAcquisitionEra(tier0Config, "Run2023E")
+setAcquisitionEra(tier0Config, "Run2023F")
 setBaseRequestPriority(tier0Config, 251000)
 setBackfill(tier0Config, None)
 setBulkDataType(tier0Config, "data")
@@ -92,10 +92,11 @@ setPromptCalibrationConfig(tier0Config,
 #   'maxRun': {100000: Value3, 200000: Value4},
 #   'default': Value5 }
 
-maxRunPreviousConfig = 999999 # Last run before era change 29/08/23
+maxRunPreviousConfig = 999999 # Last run before era change 08/09/23
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
     'default': "CMSSW_13_2_3",
+    'acqEra': {'Run2023E': "CMSSW_13_2_2"},
     'maxRun': {maxRunPreviousConfig: "CMSSW_13_2_2"}
 }
 
@@ -115,23 +116,28 @@ hiTestppScenario = "ppEra_Run3"
 
 # Defaults for processing version
 alcarawProcVersion = {
-    'maxRun': {maxRunPreviousConfig: 1},
     'default': 1
 }
 
 defaultProcVersionReco = {
-    'maxRun': {maxRunPreviousConfig: 1},
     'default': 1
 }
 
 expressProcVersion = {
-    'maxRun': {maxRunPreviousConfig: 1},
     'default': 1
 }
 
 # Defaults for GlobalTag
-expressGlobalTag = "132X_dataRun3_Express_v4"
-promptrecoGlobalTag = "132X_dataRun3_Prompt_v3"
+expressGlobalTag = {
+    'default': "132X_dataRun3_Express_v4",
+    'acqEra': {'Run2023E': "132X_dataRun3_Express_v3"},
+    'maxRun': {maxRunPreviousConfig: "132X_dataRun3_Express_v3"}
+}
+promptrecoGlobalTag = {
+    'default': "132X_dataRun3_Prompt_v3",
+    'acqEra': {'Run2023E': "132X_dataRun3_Prompt_v2"},
+    'maxRun': {maxRunPreviousConfig: "132X_dataRun3_Prompt_v2"}
+}
 
 # Mandatory for CondDBv2
 globalTagConnect = "frontier://PromptProd/CMS_CONDITIONS"

--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -95,8 +95,8 @@ setPromptCalibrationConfig(tier0Config,
 maxRunPreviousConfig = 999999 # Last run before era change 29/08/23
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_13_2_2",
-    'maxRun': {maxRunPreviousConfig: "CMSSW_13_0_10"}
+    'default': "CMSSW_13_2_3",
+    'maxRun': {maxRunPreviousConfig: "CMSSW_13_2_2"}
 }
 
 # Configure ScramArch
@@ -115,23 +115,23 @@ hiTestppScenario = "ppEra_Run3"
 
 # Defaults for processing version
 alcarawProcVersion = {
-    'maxRun': {maxRunPreviousConfig: 2},
+    'maxRun': {maxRunPreviousConfig: 1},
     'default': 1
 }
 
 defaultProcVersionReco = {
-    'maxRun': {maxRunPreviousConfig: 2},
+    'maxRun': {maxRunPreviousConfig: 1},
     'default': 1
 }
 
 expressProcVersion = {
-    'maxRun': {maxRunPreviousConfig: 2},
+    'maxRun': {maxRunPreviousConfig: 1},
     'default': 1
 }
 
 # Defaults for GlobalTag
-expressGlobalTag = "132X_dataRun3_Express_v3"
-promptrecoGlobalTag = "132X_dataRun3_Prompt_v2"
+expressGlobalTag = "132X_dataRun3_Express_v4"
+promptrecoGlobalTag = "132X_dataRun3_Prompt_v3"
 
 # Mandatory for CondDBv2
 globalTagConnect = "frontier://PromptProd/CMS_CONDITIONS"
@@ -235,8 +235,8 @@ addExpressConfig(tier0Config, "ExpressCosmics",
                  data_tiers=["FEVT"],
                  write_dqm=True,
                  alca_producers=["SiStripPCLHistos", "SiStripCalZeroBias", "TkAlCosmics0T",
-                                 "SiPixelCalZeroBias", "SiPixelCalCosmics",
-                                 "PromptCalibProdSiStrip", "PromptCalibProdSiPixelLAMCS"
+                                 "SiPixelCalZeroBias", "SiPixelCalCosmics", "SiStripCalCosmics",
+                                 "PromptCalibProdSiStrip", "PromptCalibProdSiPixelLAMCS", "PromptCalibProdSiStripLA"
                                 ],
                  reco_version=defaultCMSSWVersion,
                  multicore=numberOfCores,

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -36,7 +36,7 @@ setConfigVersion(tier0Config, "replace with real version")
 
 # Set run number to replay
 # 367102 - Collisions 2023 - 1200b - 0.5h long - all components IN
-setInjectRuns(tier0Config, [372704])
+setInjectRuns(tier0Config, [369998, 372704])
 
 # Use this in order to limit the number of lumisections to process
 #setInjectLimit(tier0Config, 10)

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -36,7 +36,7 @@ setConfigVersion(tier0Config, "replace with real version")
 
 # Set run number to replay
 # 367102 - Collisions 2023 - 1200b - 0.5h long - all components IN
-setInjectRuns(tier0Config, [369998])
+setInjectRuns(tier0Config, [372704])
 
 # Use this in order to limit the number of lumisections to process
 #setInjectLimit(tier0Config, 10)
@@ -106,7 +106,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_13_2_2"
+    'default': "CMSSW_13_2_3"
 }
 
 # Configure ScramArch
@@ -133,8 +133,8 @@ expressProcVersion = dt
 alcarawProcVersion = dt
 
 # Defaults for GlobalTag
-expressGlobalTag = "132X_dataRun3_Express_v3"
-promptrecoGlobalTag = "132X_dataRun3_Prompt_v2"
+expressGlobalTag = "132X_dataRun3_Express_SiStripLA_v1"
+promptrecoGlobalTag = "132X_dataRun3_Prompt_SiStripLA_v1"
 
 # Mandatory for CondDBv2
 globalTagConnect = "frontier://PromptProd/CMS_CONDITIONS"
@@ -236,8 +236,8 @@ addExpressConfig(tier0Config, "ExpressCosmics",
                  data_tiers=["FEVT"],
                  write_dqm=True,
                  alca_producers=["SiStripPCLHistos", "SiStripCalZeroBias", "TkAlCosmics0T",
-                                 "SiPixelCalZeroBias", "SiPixelCalCosmics",
-                                 "PromptCalibProdSiStrip", "PromptCalibProdSiPixelLAMCS"
+                                 "SiPixelCalZeroBias", "SiPixelCalCosmics", "SiStripCalCosmics",
+                                 "PromptCalibProdSiStrip", "PromptCalibProdSiPixelLAMCS", "PromptCalibProdSiStripLA"
                                 ],
                  reco_version=defaultCMSSWVersion,
                  multicore=numberOfCores,


### PR DESCRIPTION
Changes to release CMSSW_13_2_3. Also adds alca producers `SiStripCalCosmics` and `PromptCalibProdSiStripLA` to `ExpressCosmics`

Configuration tested in #4869 
