### PR TITLE
Replay testing CMSSW_13_2_4

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -133,8 +133,8 @@ expressProcVersion = dt
 alcarawProcVersion = dt
 
 # Defaults for GlobalTag
-expressGlobalTag = "132X_dataRun3_Express_SiStripLA_v1"
-promptrecoGlobalTag = "132X_dataRun3_Prompt_SiStripLA_v1"
+expressGlobalTag = "132X_dataRun3_Express_v4"
+promptrecoGlobalTag = "132X_dataRun3_Prompt_v3"
 
 # Mandatory for CondDBv2
 globalTagConnect = "frontier://PromptProd/CMS_CONDITIONS"

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -35,8 +35,7 @@ tier0Config = createTier0Config()
 setConfigVersion(tier0Config, "replace with real version")
 
 # Set run number to replay
-# 367102 - Collisions 2023 - 1200b - 0.5h long - all components IN
-setInjectRuns(tier0Config, [369998, 372704])
+setInjectRuns(tier0Config, [373226, 373272, 373273])
 
 # Use this in order to limit the number of lumisections to process
 #setInjectLimit(tier0Config, 10)
@@ -106,7 +105,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_13_2_3"
+    'default': "CMSSW_13_2_4"
 }
 
 # Configure ScramArch


### PR DESCRIPTION
# Replay Request

**Requestor**  
ORM

**Describe the configuration**  
* Release: CMSSW_13_2_4
* Run: 373226, 373272, 373273
* GTs:
   * expressGlobalTag: 132X_dataRun3_Express_v4
   * promptrecoGlobalTag: 132X_dataRun3_Prompt_v3
* Additional changes:

**Purpose of the test**  
Test release to be used during HI Run 2023

**T0 Operations cmsTalk thread** 
