### PR TITLE
CMSSW_13_2_5 and new HIForward scenario

### DIFF
--- a/etc/HIReplayOfflineConfiguration.py
+++ b/etc/HIReplayOfflineConfiguration.py
@@ -106,7 +106,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_13_2_4"
+    'default': "CMSSW_13_2_5"
 }
 
 # Configure ScramArch
@@ -125,6 +125,7 @@ alcaLumiPixelsScenario = "AlCaLumiPixels_Run3"
 alcaPPSScenario = "AlCaPPS_Run3"
 hiTestppScenario = "ppEra_Run3_pp_on_PbPb_2023"
 hiRawPrimeScenario = "ppEra_Run3_pp_on_PbPb_approxSiStripClusters_2023"
+hiForwardScenario = "ppEra_Run3_2023_repacked"
 
 # Procesing version number replays
 # Taking Replay processing ID from the last 8 digits of the DeploymentID
@@ -1388,7 +1389,7 @@ for dataset in DATASETS:
                                "HcalCalIsolatedBunchSelector", "HcalCalIterativePhiSym","HcalCalMinBias",
                                "TkAlJpsiMuMu", "TkAlUpsilonMuMu","TkAlZMuMu","TkAlMuonIsolated"],
                dqm_sequences=["@commonSiStripZeroBias", "@ecal", "@hcal", "@muon", "@jetmet", "@egamma"],
-               scenario=ppScenario)
+               scenario=hiForwardScenario)
 
 DATASETS = ["HIMinimumBias0", "HIMinimumBias1", "HIMinimumBias2", "HIMinimumBias3"]
 


### PR DESCRIPTION
# Replay Request

**Requestor**  
ORM, HI

**Describe the configuration**  
* Release: CMSSW_13_2_5
* Run: 374291
* GTs:
   * expressGlobalTag: 132X_dataRun3_Express_v4
   * promptrecoGlobalTag: 132X_dataRun3_Prompt_v3
* Additional changes: Adds scenario for  HIForward  PDs

**Purpose of the test**  
This new release needs to be tested and moved to production as soon as possible

**T0 Operations cmsTalk thread** 