### PR TITLE
13_2_5_patch2 Replay

### DIFF
--- a/etc/HIReplayOfflineConfiguration.py
+++ b/etc/HIReplayOfflineConfiguration.py
@@ -39,7 +39,7 @@ setConfigVersion(tier0Config, "replace with real version")
 # 356005 - 2022 pp at 13.6 TeV (1h long, 600 bunches - ALL detectors included)
 # 359060 - 2022 cosmics - Oberved failures in Express (https://cms-talk.web.cern.ch/t/paused-jobs-for-express-run359045-streamexpress/15232)
 # 361694:361699,361779 - 2022 HI dry-run test runs
-setInjectRuns(tier0Config, [374291])
+setInjectRuns(tier0Config, [374599, 374591])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"
@@ -106,7 +106,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_13_2_5_patch1"
+    'default': "CMSSW_13_2_5_patch2"
 }
 
 # Configure ScramArch
@@ -134,8 +134,8 @@ expressProcVersion = dt
 alcarawProcVersion = dt
 
 # Defaults for GlobalTag
-expressGlobalTag = "132X_dataRun3_Express_v4"
-promptrecoGlobalTag = "132X_dataRun3_Prompt_v3"
+expressGlobalTag = "132X_dataRun3_Express_HcalEmapT0Replay_v1"
+promptrecoGlobalTag = "132X_dataRun3_Prompt_HcalEmapT0Replay_v1"
 
 # Mandatory for CondDBv2
 globalTagConnect = "frontier://PromptProd/CMS_CONDITIONS"


### PR DESCRIPTION
# Replay Request

**Requestor**  
AlCa

**Describe the configuration**  
* Release: CMSSW_13_2_5_patch2
* Run: 
* GTs:
   * expressGlobalTag: 132X_dataRun3_Express_HcalEmapT0Replay_v1
   * promptrecoGlobalTag: 132X_dataRun3_Prompt_HcalEmapT0Replay_v1
* Additional changes:

**Purpose of the test**  
**T0 Operations cmsTalk thread**  
https://cms-talk.web.cern.ch/t/replay-testing-cmssw-13-2-5-patch2/30168
