### PR TITLE
Add processing version parameter to reco_config and express_config ta…

### DIFF
--- a/src/python/T0/WMBS/Oracle/T0DataSvc/GetExpressConfigs.py
+++ b/src/python/T0/WMBS/Oracle/T0DataSvc/GetExpressConfigs.py
@@ -23,6 +23,7 @@ class GetExpressConfigs(DBFormatter):
                         express_config.dqm_seq AS dqm_seq,
                         express_config.global_tag AS global_tag,
                         event_scenario.name AS scenario,
+                        express_config.proc_version AS proc_version,
                         express_config.multicore AS multicore,
                         express_config.write_tiers AS write_tiers,
                         express_config.write_dqm AS write_dqm

--- a/src/python/T0/WMBS/Oracle/T0DataSvc/GetRecoConfigs.py
+++ b/src/python/T0/WMBS/Oracle/T0DataSvc/GetRecoConfigs.py
@@ -22,6 +22,7 @@ class GetRecoConfigs(DBFormatter):
                         reco_config.dqm_seq AS dqm_seq,
                         reco_config.global_tag AS global_tag,
                         event_scenario.name AS scenario,
+                        reco_config.proc_version AS proc_version,
                         reco_config.multicore AS multicore,
                         reco_config.write_reco AS write_reco,
                         reco_config.write_dqm AS write_dqm,

--- a/src/python/T0/WMBS/Oracle/T0DataSvc/InsertExpressConfigs.py
+++ b/src/python/T0/WMBS/Oracle/T0DataSvc/InsertExpressConfigs.py
@@ -24,6 +24,7 @@ class InsertExpressConfigs(DBFormatter):
                               dqm_seq = :DQM_SEQ,
                               global_tag = :GLOBAL_TAG,
                               scenario = :SCENARIO,
+                              proc_version = :PROC_VERSION,
                               multicore = :MULTICORE,
                               write_tiers = :WRITE_TIERS,
                               write_dqm = :WRITE_DQM

--- a/src/python/T0/WMBS/Oracle/T0DataSvc/InsertExpressConfigs.py
+++ b/src/python/T0/WMBS/Oracle/T0DataSvc/InsertExpressConfigs.py
@@ -30,9 +30,9 @@ class InsertExpressConfigs(DBFormatter):
                               write_dqm = :WRITE_DQM
                  WHEN NOT MATCHED THEN
                    INSERT (run, stream, cmssw, scram_arch, reco_cmssw, reco_scram_arch, alca_skim,
-                           dqm_seq, global_tag, scenario, multicore, write_tiers, write_dqm)
+                           dqm_seq, proc_version, global_tag, scenario, proc_version, multicore, write_tiers, write_dqm)
                    VALUES (:RUN, :STREAM, :CMSSW, :SCRAM_ARCH, :RECO_CMSSW, :RECO_SCRAM_ARCH, :ALCA_SKIM,
-                           :DQM_SEQ, :GLOBAL_TAG, :SCENARIO, :MULTICORE, :WRITE_TIERS, :WRITE_DQM)
+                           :DQM_SEQ, :GLOBAL_TAG, :SCENARIO, :PROC_VERSION, :MULTICORE, :WRITE_TIERS, :WRITE_DQM)
                  """
 
         self.dbi.processData(sql, binds, conn = conn,

--- a/src/python/T0/WMBS/Oracle/T0DataSvc/InsertExpressConfigs.py
+++ b/src/python/T0/WMBS/Oracle/T0DataSvc/InsertExpressConfigs.py
@@ -30,7 +30,7 @@ class InsertExpressConfigs(DBFormatter):
                               write_dqm = :WRITE_DQM
                  WHEN NOT MATCHED THEN
                    INSERT (run, stream, cmssw, scram_arch, reco_cmssw, reco_scram_arch, alca_skim,
-                           dqm_seq, proc_version, global_tag, scenario, proc_version, multicore, write_tiers, write_dqm)
+                           dqm_seq, global_tag, scenario, proc_version, multicore, write_tiers, write_dqm)
                    VALUES (:RUN, :STREAM, :CMSSW, :SCRAM_ARCH, :RECO_CMSSW, :RECO_SCRAM_ARCH, :ALCA_SKIM,
                            :DQM_SEQ, :GLOBAL_TAG, :SCENARIO, :PROC_VERSION, :MULTICORE, :WRITE_TIERS, :WRITE_DQM)
                  """

--- a/src/python/T0/WMBS/Oracle/T0DataSvc/InsertRecoConfigs.py
+++ b/src/python/T0/WMBS/Oracle/T0DataSvc/InsertRecoConfigs.py
@@ -23,6 +23,7 @@ class InsertRecoConfigs(DBFormatter):
                               dqm_seq = :DQM_SEQ,
                               global_tag = :GLOBAL_TAG,
                               scenario = :SCENARIO,
+                              proc_version = :PROC_VERSION,
                               multicore = :MULTICORE,
                               write_reco = :WRITE_RECO,
                               write_dqm = :WRITE_DQM,
@@ -31,11 +32,11 @@ class InsertRecoConfigs(DBFormatter):
                               write_nanoaod = :WRITE_NANOAOD
                  WHEN NOT MATCHED THEN
                    INSERT (run, primds, cmssw, scram_arch, alca_skim,
-                           physics_skim, dqm_seq, global_tag, scenario,
+                           physics_skim, dqm_seq, global_tag, scenario, proc_version,
                            multicore, write_reco, write_dqm,
                            write_aod, write_miniaod, write_nanoaod)
                    VALUES (:RUN, :PRIMDS, :CMSSW, :SCRAM_ARCH, :ALCA_SKIM,
-                           :PHYSICS_SKIM, :DQM_SEQ, :GLOBAL_TAG, :SCENARIO,
+                           :PHYSICS_SKIM, :DQM_SEQ, :GLOBAL_TAG, :SCENARIO, :PROC_VERSION,
                            :MULTICORE, :WRITE_RECO, :WRITE_DQM,
                            :WRITE_AOD, :WRITE_MINIAOD, :WRITE_NANOAOD)
                  """

--- a/src/python/T0Component/Tier0Feeder/Tier0FeederPoller.py
+++ b/src/python/T0Component/Tier0Feeder/Tier0FeederPoller.py
@@ -508,6 +508,7 @@ class Tier0FeederPoller(BaseWorkerThread):
                                       'DQM_SEQ' : config['dqm_seq'],
                                       'GLOBAL_TAG' : config['global_tag'][:50],
                                       'SCENARIO' : config['scenario'],
+                                      'PROC_VERSION' : config['proc_version'],
                                       'MULTICORE' : config['multicore'],
                                       'WRITE_TIERS' : config['write_tiers'],
                                       'WRITE_DQM' : config['write_dqm'] } )
@@ -548,6 +549,7 @@ class Tier0FeederPoller(BaseWorkerThread):
                                       'DQM_SEQ' : config['dqm_seq'],
                                       'GLOBAL_TAG' : config['global_tag'][:50],
                                       'SCENARIO' : config['scenario'],
+                                      'PROC_VERSION' : config['proc_version'],
                                       'MULTICORE' : config['multicore'],
                                       'WRITE_RECO' : config['write_reco'],
                                       'WRITE_DQM' : config['write_dqm'],


### PR DESCRIPTION
This PR contains the changes that enable the processing version to be available in the T0WMADATASVC database. This is necessary to fulfill the latest request in this jira ticket: https://its.cern.ch/jira/browse/CMSTZ-1051?filter=-1
