### PR TITLE
Production configuration change to CMSSW_13_2_6

### DIFF
--- a/etc/HIProdOfflineConfiguration.py
+++ b/etc/HIProdOfflineConfiguration.py
@@ -91,11 +91,9 @@ setPromptCalibrationConfig(tier0Config,
 #   'maxRun': {100000: Value3, 200000: Value4},
 #   'default': Value5 }
 
-maxRunPreviousConfig = 9999999 # Last run before processing version change 05/10/23
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_13_2_5_patch3",
-    'maxRun': {maxRunPreviousConfig: "CMSSW_13_2_5_patch1"}
+    'default': "CMSSW_13_2_6",
 }
 
 # Configure ScramArch
@@ -114,25 +112,19 @@ alcaLumiPixelsScenario = "AlCaLumiPixels_Run3"
 alcaPPSScenario = "AlCaPPS_Run3"
 hiTestppScenario = "ppEra_Run3_pp_on_PbPb_2023"
 hiRawPrimeScenario = "ppEra_Run3_pp_on_PbPb_approxSiStripClusters_2023"
-hiForwardScenario = {
-    'default': "ppEra_Run3_2023_repacked",
-    'maxRun': {maxRunPreviousConfig: "ppEra_Run3_pp_on_PbPb_2023"}
-}
+hiForwardScenario = "ppEra_Run3_2023_repacked"
 
 # Defaults for processing version
 alcarawProcVersion = {
     'default': "2",
-    'maxRun': {maxRunPreviousConfig: "1"}
 }
 
 defaultProcVersionReco = {
     'default': "2",
-    'maxRun': {maxRunPreviousConfig: "1"}
 }
 
 expressProcVersion = {
     'default': "2",
-    'maxRun': {maxRunPreviousConfig: "1"}
 }
 
 # Defaults for GlobalTag
@@ -1550,13 +1542,25 @@ for dataset in DATASETS:
                dqm_sequences=["@commonSiStripZeroBias"],
                scenario=hiTestppScenario)
 
-DATASETS = ["HIEphemeralHLTPhysics", "HIEphemeralZeroBias0", "HIEphemeralZeroBias1"]
+DATASETS = ["HIEphemeralHLTPhysics"]
 
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,
                do_reco=True,
                raw_to_disk=False,
                write_dqm=True,
+               disk_node="T2_US_Vanderbilt",
+               dqm_sequences=["@commonSiStripZeroBias"],
+               scenario=hiTestppScenario)
+
+DATASETS = ["HIEphemeralZeroBias0", "HIEphemeralZeroBias1"]
+
+for dataset in DATASETS:
+    addDataset(tier0Config, dataset,
+               do_reco=True,
+               raw_to_disk=False,
+               write_dqm=True,
+               timePerEvent=1,
                disk_node="T2_US_Vanderbilt",
                dqm_sequences=["@commonSiStripZeroBias"],
                scenario=hiTestppScenario)

--- a/etc/HIReplayOfflineConfiguration.py
+++ b/etc/HIReplayOfflineConfiguration.py
@@ -39,7 +39,7 @@ setConfigVersion(tier0Config, "replace with real version")
 # 356005 - 2022 pp at 13.6 TeV (1h long, 600 bunches - ALL detectors included)
 # 359060 - 2022 cosmics - Oberved failures in Express (https://cms-talk.web.cern.ch/t/paused-jobs-for-express-run359045-streamexpress/15232)
 # 361694:361699,361779 - 2022 HI dry-run test runs
-setInjectRuns(tier0Config, [374599])
+setInjectRuns(tier0Config, [374951])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"
@@ -106,7 +106,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_13_2_5_patch3"
+    'default': "CMSSW_13_2_6"
 }
 
 # Configure ScramArch
@@ -1477,13 +1477,13 @@ for dataset in DATASETS:
 #######################
 ### ignored streams ###
 #######################
-specifyStreams(tier0Config, ["HIForward0", "HIForward1", "HIForward2",
-            "HIForward3", "HIForward4", "HIForward5",
-            "HIForward6", "HIForward7", "HIForward8",
-            "HIForward9", "HIForward10", "HIForward11",
-            "HIForward12", "HIForward13", "HIForward14",
-            "HIForward15", "HIForward16", "HIForward17",
-            "HIForward18", "HIForward19"])
+#specifyStreams(tier0Config, ["HIForward0", "HIForward1", "HIForward2",
+#            "HIForward3", "HIForward4", "HIForward5",
+#            "HIForward6", "HIForward7", "HIForward8",
+#            "HIForward9", "HIForward10", "HIForward11",
+#            "HIForward12", "HIForward13", "HIForward14",
+#            "HIForward15", "HIForward16", "HIForward17",
+#            "HIForward18", "HIForward19"])
 
 ignoreStream(tier0Config, "Error")
 ignoreStream(tier0Config, "HLTMON")

--- a/etc/HIReplayOfflineConfiguration.py
+++ b/etc/HIReplayOfflineConfiguration.py
@@ -1413,13 +1413,26 @@ for dataset in DATASETS:
                dqm_sequences=["@commonSiStripZeroBias"],
                scenario=hiTestppScenario)
 
-DATASETS = ["HIEphemeralHLTPhysics", "HIEphemeralZeroBias0", "HIEphemeralZeroBias1"]
+DATASETS = ["HIEphemeralHLTPhysics"]
 
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,
                do_reco=True,
                raw_to_disk=False,
                write_dqm=True,
+               disk_node="T2_US_Vanderbilt",
+               dqm_sequences=["@commonSiStripZeroBias"],
+               scenario=hiTestppScenario)
+
+DATASETS = ["HIEphemeralZeroBias0", "HIEphemeralZeroBias1"]
+
+for dataset in DATASETS:
+    addDataset(tier0Config, dataset,
+               do_reco=True,
+               raw_to_disk=False,
+               write_dqm=True,
+               timePerEvent=1,
+               disk_node="T2_US_Vanderbilt",
                dqm_sequences=["@commonSiStripZeroBias"],
                scenario=hiTestppScenario)
 


### PR DESCRIPTION
Update configuration to CMSSW_13_2_6

Additionally, reduce the stimated time per event for `HIEphemeralZeroBias` PDs

This configuration was tested in #4896 
