### PR TITLE
Replay configuration for CMSSW_13_2_6_patch2

### DIFF
--- a/etc/HIReplayOfflineConfiguration.py
+++ b/etc/HIReplayOfflineConfiguration.py
@@ -39,7 +39,7 @@ setConfigVersion(tier0Config, "replace with real version")
 # 356005 - 2022 pp at 13.6 TeV (1h long, 600 bunches - ALL detectors included)
 # 359060 - 2022 cosmics - Oberved failures in Express (https://cms-talk.web.cern.ch/t/paused-jobs-for-express-run359045-streamexpress/15232)
 # 361694:361699,361779 - 2022 HI dry-run test runs
-setInjectRuns(tier0Config, [374951])
+setInjectRuns(tier0Config, [375820])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"
@@ -106,7 +106,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_13_2_6"
+    'default': "CMSSW_13_2_6_patch2"
 }
 
 # Configure ScramArch


### PR DESCRIPTION
# Replay Request

**Requestor**  
ORM Kevin Pedro

**Describe the configuration**  
* Release: CMSSW_13_2_6_patch2
* Run: 375820
* GTs:
   * Express: 132X_dataRun3_Express_v4
   * Prompt: 132X_dataRun3_Prompt_v4

**Purpose of the test**  
Test new CMSSW release

**T0 Operations cmsTalk thread**  
https://cms-talk.web.cern.ch/t/replay-request-for-cmssw-13-2-6-patch2/31094

