### PR TITLE
deployment scripts with modified job resubmission

### DIFF
--- a/bin/00_deploy_prod.sh
+++ b/bin/00_deploy_prod.sh
@@ -241,11 +241,11 @@ echo "config.AgentStatusWatcher.runningRepackPercent = 10" >> ./config/tier0/con
 
 #Configurable retry number for failing jobs before they go to paused
 echo "config.RetryManager.PauseAlgo.section_('Express')" >> ./config/tier0/config.py
-echo "config.RetryManager.PauseAlgo.Express.retryErrorCodes = { 70: 0, 50513: 3, 50660: 0, 50661: 0, 50664: 0, 71304: 0 }" >> ./config/tier0/config.py
+echo "config.RetryManager.PauseAlgo.Express.retryErrorCodes = { 70: 0, 50660: 0, 50661: 0, 50664: 0, 71304: 0 }" >> ./config/tier0/config.py
 echo "config.RetryManager.PauseAlgo.section_('Processing')" >> ./config/tier0/config.py
-echo "config.RetryManager.PauseAlgo.Processing.retryErrorCodes = { 70: 0, 50513: 3, 50660: 0, 50661: 1, 50664: 0, 71304: 1 }" >> ./config/tier0/config.py
+echo "config.RetryManager.PauseAlgo.Processing.retryErrorCodes = { 70: 0, 50660: 0, 50661: 1, 50664: 0, 71304: 1 }" >> ./config/tier0/config.py
 echo "config.RetryManager.PauseAlgo.section_('Repack')" >> ./config/tier0/config.py
-echo "config.RetryManager.PauseAlgo.Repack.retryErrorCodes = { 70: 0, 50513: 3, 50660: 0, 50661: 0, 50664: 0, 71304: 0 }" >> ./config/tier0/config.py
+echo "config.RetryManager.PauseAlgo.Repack.retryErrorCodes = { 70: 0, 50660: 0, 50661: 0, 50664: 0, 71304: 0 }" >> ./config/tier0/config.py
 
 #Overwrite ErrorHandler to avoid jobs going to ensure T0 jobs can always be retried
 sed -i "s/config.ErrorHandler.maxFailTime.*/config.ErrorHandler.maxFailTime=601200/g" ./config/tier0/config.py

--- a/bin/00_deploy_prod.sh
+++ b/bin/00_deploy_prod.sh
@@ -241,11 +241,11 @@ echo "config.AgentStatusWatcher.runningRepackPercent = 10" >> ./config/tier0/con
 
 #Configurable retry number for failing jobs before they go to paused
 echo "config.RetryManager.PauseAlgo.section_('Express')" >> ./config/tier0/config.py
-echo "config.RetryManager.PauseAlgo.Express.retryErrorCodes = { 70: 0, 50513: 0, 50660: 0, 50661: 0, 50664: 0, 71304: 0 }" >> ./config/tier0/config.py
+echo "config.RetryManager.PauseAlgo.Express.retryErrorCodes = { 70: 0, 50513: 3, 50660: 0, 50661: 0, 50664: 0, 71304: 0 }" >> ./config/tier0/config.py
 echo "config.RetryManager.PauseAlgo.section_('Processing')" >> ./config/tier0/config.py
-echo "config.RetryManager.PauseAlgo.Processing.retryErrorCodes = { 70: 0, 50513: 0, 50660: 0, 50661: 0, 50664: 0, 71304: 0 }" >> ./config/tier0/config.py
+echo "config.RetryManager.PauseAlgo.Processing.retryErrorCodes = { 70: 0, 50513: 3, 50660: 0, 50661: 1, 50664: 0, 71304: 1 }" >> ./config/tier0/config.py
 echo "config.RetryManager.PauseAlgo.section_('Repack')" >> ./config/tier0/config.py
-echo "config.RetryManager.PauseAlgo.Repack.retryErrorCodes = { 70: 0, 50513: 0, 50660: 0, 50661: 0, 50664: 0, 71304: 0 }" >> ./config/tier0/config.py
+echo "config.RetryManager.PauseAlgo.Repack.retryErrorCodes = { 70: 0, 50513: 3, 50660: 0, 50661: 0, 50664: 0, 71304: 0 }" >> ./config/tier0/config.py
 
 #Overwrite ErrorHandler to avoid jobs going to ensure T0 jobs can always be retried
 sed -i "s/config.ErrorHandler.maxFailTime.*/config.ErrorHandler.maxFailTime=601200/g" ./config/tier0/config.py

--- a/bin/00_deploy_replay.sh
+++ b/bin/00_deploy_replay.sh
@@ -261,11 +261,11 @@ echo "config.AgentStatusWatcher.runningRepackPercent = 10" >> ./config/tier0/con
 
 #Configurable retry number for failing jobs before they go to paused
 echo "config.RetryManager.PauseAlgo.section_('Express')" >> ./config/tier0/config.py
-echo "config.RetryManager.PauseAlgo.Express.retryErrorCodes = { 70: 0, 50513: 3, 50660: 0, 50661: 0, 50664: 0, 71304: 0 }" >> ./config/tier0/config.py
+echo "config.RetryManager.PauseAlgo.Express.retryErrorCodes = { 70: 0, 50660: 0, 50661: 0, 50664: 0, 71304: 0 }" >> ./config/tier0/config.py
 echo "config.RetryManager.PauseAlgo.section_('Processing')" >> ./config/tier0/config.py
-echo "config.RetryManager.PauseAlgo.Processing.retryErrorCodes = { 70: 0, 50513: 3, 50660: 0, 50661: 1, 50664: 0, 71304: 1 }" >> ./config/tier0/config.py
+echo "config.RetryManager.PauseAlgo.Processing.retryErrorCodes = { 70: 0, 50660: 0, 50661: 1, 50664: 0, 71304: 1 }" >> ./config/tier0/config.py
 echo "config.RetryManager.PauseAlgo.section_('Repack')" >> ./config/tier0/config.py
-echo "config.RetryManager.PauseAlgo.Repack.retryErrorCodes = { 70: 0, 50513: 3, 50660: 0, 50661: 0, 50664: 0, 71304: 0 }" >> ./config/tier0/config.py
+echo "config.RetryManager.PauseAlgo.Repack.retryErrorCodes = { 70: 0, 50660: 0, 50661: 0, 50664: 0, 71304: 0 }" >> ./config/tier0/config.py
 
 #Overwrite RetryManager to show Logcollect and CleanUp jobs paused instead of automatically fails
 sed -i "s/config.RetryManager.plugins.*/config.RetryManager.plugins={'default': 'PauseAlgo', 'Cleanup': 'PauseAlgo', 'LogCollect': 'PauseAlgo'}/g" ./config/tier0/config.py

--- a/bin/00_deploy_replay.sh
+++ b/bin/00_deploy_replay.sh
@@ -261,11 +261,11 @@ echo "config.AgentStatusWatcher.runningRepackPercent = 10" >> ./config/tier0/con
 
 #Configurable retry number for failing jobs before they go to paused
 echo "config.RetryManager.PauseAlgo.section_('Express')" >> ./config/tier0/config.py
-echo "config.RetryManager.PauseAlgo.Express.retryErrorCodes = { 70: 0, 50513: 0, 50660: 0, 50661: 0, 50664: 0, 71304: 0 }" >> ./config/tier0/config.py
+echo "config.RetryManager.PauseAlgo.Express.retryErrorCodes = { 70: 0, 50513: 3, 50660: 0, 50661: 0, 50664: 0, 71304: 0 }" >> ./config/tier0/config.py
 echo "config.RetryManager.PauseAlgo.section_('Processing')" >> ./config/tier0/config.py
-echo "config.RetryManager.PauseAlgo.Processing.retryErrorCodes = { 70: 0, 50513: 0, 50660: 0, 50661: 0, 50664: 0, 71304: 0 }" >> ./config/tier0/config.py
+echo "config.RetryManager.PauseAlgo.Processing.retryErrorCodes = { 70: 0, 50513: 3, 50660: 0, 50661: 1, 50664: 0, 71304: 1 }" >> ./config/tier0/config.py
 echo "config.RetryManager.PauseAlgo.section_('Repack')" >> ./config/tier0/config.py
-echo "config.RetryManager.PauseAlgo.Repack.retryErrorCodes = { 70: 0, 50513: 0, 50660: 0, 50661: 0, 50664: 0, 71304: 0 }" >> ./config/tier0/config.py
+echo "config.RetryManager.PauseAlgo.Repack.retryErrorCodes = { 70: 0, 50513: 3, 50660: 0, 50661: 0, 50664: 0, 71304: 0 }" >> ./config/tier0/config.py
 
 #Overwrite RetryManager to show Logcollect and CleanUp jobs paused instead of automatically fails
 sed -i "s/config.RetryManager.plugins.*/config.RetryManager.plugins={'default': 'PauseAlgo', 'Cleanup': 'PauseAlgo', 'LogCollect': 'PauseAlgo'}/g" ./config/tier0/config.py


### PR DESCRIPTION
As described in the jira ticket https://its.cern.ch/jira/browse/CMSTZDEV-800, the automatic job resubmission could be friendlier to operators when processing jobs fail due to temporary issues, as well as SCRAM errors that result in failed jobs after 0 retries. This PR is the interpreted proposal from said jira ticket.

