### PR TITLE
PromptCalibProdSiStripHitEff tests on 13_3_0

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -36,15 +36,15 @@ setConfigVersion(tier0Config, "replace with real version")
 
 # Set run number to replay
 # 367102 - Collisions 2023 - 1200b - 0.5h long - all components IN
-setInjectRuns(tier0Config, [369998, 372704])
+setInjectRuns(tier0Config, [369998, 359762])
 
 # Use this in order to limit the number of lumisections to process
 #setInjectLimit(tier0Config, 10)
 
 # Settings up sites
 processingSite = "T2_CH_CERN"
-storageSite = "T0_CH_CERN_Disk"
-streamerPNN = "T0_CH_CERN_Disk"
+storageSite = "T2_CH_CERN"
+streamerPNN = "T2_CH_CERN"
 
 addSiteConfig(tier0Config, "T0_CH_CERN_Disk",
                 siteLocalConfig="/cvmfs/cms.cern.ch/SITECONF/T0_CH_CERN/JobConfig/site-local-config.xml",
@@ -106,7 +106,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_13_2_3"
+    'default': "CMSSW_13_3_0"
 }
 
 # Configure ScramArch
@@ -134,8 +134,8 @@ expressProcVersion = dt
 alcarawProcVersion = dt
 
 # Defaults for GlobalTag
-expressGlobalTag = "132X_dataRun3_Express_SiStripLA_v1"
-promptrecoGlobalTag = "132X_dataRun3_Prompt_SiStripLA_v1"
+expressGlobalTag = "133X_dataRun3_Express_v1"
+promptrecoGlobalTag = "133X_dataRun3_Prompt_v1"
 
 # Mandatory for CondDBv2
 globalTagConnect = "frontier://PromptProd/CMS_CONDITIONS"
@@ -1251,6 +1251,8 @@ ignoreStream(tier0Config, "streamHLTRates")
 ignoreStream(tier0Config, "streamL1Rates")
 ignoreStream(tier0Config, "streamDQMRates")
 ignoreStream(tier0Config, "DQMPPSRandom")
+
+specifyStreams(tier0Config, "StreamExpress")
 
 ###################################
 ### currently inactive settings ###

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -110,7 +110,7 @@ defaultCMSSWVersion = {
 }
 
 # Configure ScramArch
-setDefaultScramArch(tier0Config, "el8_amd64_gcc11")
+setDefaultScramArch(tier0Config, "el8_amd64_gcc12")
 setScramArch(tier0Config, "CMSSW_12_4_9", "el8_amd64_gcc10")
 setScramArch(tier0Config, "CMSSW_12_3_0", "cs8_amd64_gcc10")
 


### PR DESCRIPTION
# Replay Request

**Requestor**  
AlCaDB

**Describe the configuration**  
* Release: CMSSW_13_3_0
* Run: 369998, 359762
* GTs:
   * expressGlobalTag: 133X_dataRun3_Express_v1
   * promptrecoGlobalTag: 133X_dataRun3_Prompt_v1
* Additional changes:

**Purpose of the test**  
Test recent changes in PromptCalibProdSiStripHitEff.

**T0 Operations cmsTalk thread**  
If necessary, provide a link to the cmsTalk thread announcing the test to the relevant groups. 
[Tier0 Operations cmsTalk Forum](https://cms-talk.web.cern.ch/t/replay-to-test-improvements-in-sistriphitefficiencyharvester-via-pr-42793/32586)
