### PR TITLE
Update ReplayConfig files with full path to DeploymentID.txt

### DIFF
--- a/etc/HIReplayOfflineConfiguration.py
+++ b/etc/HIReplayOfflineConfiguration.py
@@ -129,7 +129,7 @@ hiForwardScenario = "ppEra_Run3_2023_repacked"
 
 # Procesing version number replays
 # Taking Replay processing ID from the last 8 digits of the DeploymentID
-dt = int(open("DeploymentID.txt","r").read()[4:])
+dt = int(open("/data/tier0/srv/wmagent/3.1.2/install/tier0/Tier0Feeder/DeploymentID.txt","r").read()[4:])
 defaultProcVersion = dt
 expressProcVersion = dt
 alcarawProcVersion = dt

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -128,7 +128,7 @@ hiRawPrimeScenario = "ppEra_Run3_pp_on_PbPb_approxSiStripClusters_2023"
 
 # Procesing version number replays
 # Taking Replay processing ID from the last 8 digits of the DeploymentID
-dt = int(open("DeploymentID.txt","r").read()[4:])
+dt = int(open("/data/tier0/srv/wmagent/3.1.2/install/tier0/Tier0Feeder/DeploymentID.txt","r").read()[4:])
 defaultProcVersion = dt
 expressProcVersion = dt
 alcarawProcVersion = dt


### PR DESCRIPTION
The new Headnode summary backend code uses a function from the WMCore module called loadConfigurationFile: https://github.com/dmwm/WMCore/blob/master/src/python/WMCore/Configuration.py#L588

This function reads the ProdOfflineConfiguration and ReplayOfflineConfiguration files to get the object that represents the T0 Configuration. When reading the ReplayConfig file, it crashes because it cant find the DeploymentID.txt file, reason for which these changes simply include the full path to such file.
