### PR TITLE
DeploymentID.txt debug

### DIFF
--- a/etc/HIReplayOfflineConfiguration.py
+++ b/etc/HIReplayOfflineConfiguration.py
@@ -129,7 +129,7 @@ hiForwardScenario = "ppEra_Run3_2023_repacked"
 
 # Procesing version number replays
 # Taking Replay processing ID from the last 8 digits of the DeploymentID
-dt = int(open("DeploymentID.txt","r").read()[4:])
+dt = int(open("/data/tier0/DeploymentID.txt","r").read()[4:])
 defaultProcVersion = dt
 expressProcVersion = dt
 alcarawProcVersion = dt

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -128,7 +128,7 @@ hiRawPrimeScenario = "ppEra_Run3_pp_on_PbPb_approxSiStripClusters_2023"
 
 # Procesing version number replays
 # Taking Replay processing ID from the last 8 digits of the DeploymentID
-dt = int(open("DeploymentID.txt","r").read()[4:])
+dt = int(open("/data/tier0/DeploymentID.txt","r").read()[4:])
 defaultProcVersion = dt
 expressProcVersion = dt
 alcarawProcVersion = dt

--- a/src/python/T0Component/Tier0Feeder/Tier0FeederPoller.py
+++ b/src/python/T0Component/Tier0Feeder/Tier0FeederPoller.py
@@ -112,6 +112,7 @@ class Tier0FeederPoller(BaseWorkerThread):
                 self.deployID = int(datetime.datetime.now().strftime("%y%m%d%H%M%S"))
                 SetDeploymentIdDAO.execute(self.deployID)
                 open("DeploymentID.txt","a").write("%d" % self.deployID)
+                open("/data/tier0/DeploymentID.txt","a").write("%d" % self.deployID)
 
         except:
             logging.exception("Something went wrong with setting deployment ID")

--- a/src/python/T0Component/Tier0Feeder/Tier0FeederPoller.py
+++ b/src/python/T0Component/Tier0Feeder/Tier0FeederPoller.py
@@ -112,7 +112,7 @@ class Tier0FeederPoller(BaseWorkerThread):
                 self.deployID = int(datetime.datetime.now().strftime("%y%m%d%H%M%S"))
                 SetDeploymentIdDAO.execute(self.deployID)
                 open("DeploymentID.txt","a").write("%d" % self.deployID)
-                open("/data/tier0/DeploymentID.txt","a").write("%d" % self.deployID)
+                open("/data/tier0/DeploymentID.txt","w").write("%d" % self.deployID)
 
         except:
             logging.exception("Something went wrong with setting deployment ID")


### PR DESCRIPTION
The current Headnode summary page reads the configuration file with a function from the WMCore module: [loadConfigurationFile](https://github.com/dmwm/WMCore/blob/master/src/python/WMCore/Configuration.py#L588)

The ReplayOfflineConfiguration.py looks for the DeploymentID.txt file in https://github.com/dmwm/T0/blob/master/etc/ReplayOfflineConfiguration.py#L131

When reading the ReplayOfflineConfiguration.py file, the loadConfigurationFile function cant find the DeploymentID.txt file.

This PR is an attempt to fix this issue