### PR TITLE
Adds support to handle DAQ test runs automatically

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -1380,6 +1380,23 @@ for dataset in DATASETS:
                sizePerEvent=4000,
                scenario=hiRawPrimeScenario)
 
+######################
+###    DAQ TEST    ###
+######################
+
+DATASETS = ["D01", "D02", "D03", "D04", "D05", "D06", "D07", "D08", "D09", "D10",
+	   "D11", "D12", "D13", "D14", "D15", "D16", "D17", "D18", "D19", "D20",
+	   "D21", "D22", "D23", "D24", "D25", "D26", "D27", "D28", "D29", "D30",
+	   "D31", "D32", "D33", "D34", "D35", "D36", "D37", "D38", "Parking"]
+
+for dataset in DATASETS:
+    addDataset(tier0Config, dataset,
+               do_reco=False,
+               archival_node=None,
+               tape_node=None,
+               disk_node="T0_CH_CERN_Disk",
+               scenario=ppScenario)
+
 #######################
 ### ignored streams ###
 #######################


### PR DESCRIPTION
**ProdOfflineConfig**

- Adds test PDs

**StorageManagerAPI**

- Queries `cms_stomgr.runs.setuplabel` to identifiy emulated runs

**RunConfigAPI**

- Sets acquisition era according to the setup label