### PR TITLE
Remove the new component WorkflowUpdater

### DIFF
--- a/bin/tier0-mod-config
+++ b/bin/tier0-mod-config
@@ -71,6 +71,8 @@ def modifyConfiguration(config, **args):
         delattr(config, "WorkQueueManager")
     if hasattr(config, "ArchiveDataReporter"):
         delattr(config, "ArchiveDataReporter")
+    if hasattr(config, "WorkflowUpdater"):
+        delattr(config, "WorkflowUpdater")
 
     config.TaskArchiver.useWorkQueue = False
 


### PR DESCRIPTION
The latest version of WMCore features a new Component of the Agent called WorkflowUpdater. Since T0 does not use such component, this PR is to not take it in to account during deployment.
