### PR TITLE
Emulated data handling

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -8,6 +8,7 @@ from __future__ import print_function
 from T0.RunConfig.Tier0Config import addDataset
 from T0.RunConfig.Tier0Config import createTier0Config
 from T0.RunConfig.Tier0Config import setAcquisitionEra
+from T0.RunConfig.Tier0Config import setEmulationAcquisitionEra
 from T0.RunConfig.Tier0Config import setDefaultScramArch
 from T0.RunConfig.Tier0Config import setBaseRequestPriority
 from T0.RunConfig.Tier0Config import setBackfill
@@ -56,6 +57,7 @@ addSiteConfig(tier0Config, "T0_CH_CERN_Disk",
 #  Processing site (where jobs run)
 #  PhEDEx locations
 setAcquisitionEra(tier0Config, "Commissioning2024")
+setEmulationAcquisitionEra(tier0Config, "Emulation2024")
 setBaseRequestPriority(tier0Config, 251000)
 setBackfill(tier0Config, None)
 setBulkDataType(tier0Config, "data")
@@ -1395,6 +1397,7 @@ for dataset in DATASETS:
                archival_node=None,
                tape_node=None,
                disk_node="T0_CH_CERN_Disk",
+               dataset_lifetime=15*24*3600,
                scenario=ppScenario)
 
 #######################

--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -1380,6 +1380,23 @@ for dataset in DATASETS:
                sizePerEvent=4000,
                scenario=hiRawPrimeScenario)
 
+######################
+###    DAQ TEST    ###
+######################
+
+DATASETS = ["D01", "D02", "D03", "D04", "D05", "D06", "D07", "D08", "D09", "D10",
+	   "D11", "D12", "D13", "D14", "D15", "D16", "D17", "D18", "D19", "D20",
+	   "D21", "D22", "D23", "D24", "D25", "D26", "D27", "D28", "D29", "D30",
+	   "D31", "D32", "D33", "D34", "D35", "D36", "D37", "D38", "Parking"]
+
+for dataset in DATASETS:
+    addDataset(tier0Config, dataset,
+               do_reco=False,
+               archival_node=None,
+               tape_node=None,
+               disk_node="T0_CH_CERN_Disk",
+               scenario=ppScenario)
+
 #######################
 ### ignored streams ###
 #######################

--- a/src/python/T0/RunConfig/Tier0Config.py
+++ b/src/python/T0/RunConfig/Tier0Config.py
@@ -35,6 +35,8 @@ Tier0Configuration - Global configuration object
 | |       |
 | |       |--> AcquisitionEra - The acquisition era for the run
 | |       |
+| |       |--> EmulationAcquisitionEra - The acquisition era for emulated runs
+| |       |
 | |       |--> Backfill - The backfill mode, can be None, 1 or 2
 | |       |
 | |       |--> ProcessingSite - Main (CERN) site where processing is done.
@@ -608,6 +610,16 @@ def setAcquisitionEra(config, acquisitionEra):
     """
     config.Global.AcquisitionEra = acquisitionEra
     return
+
+def setEmulationAcquisitionEra(config, emulationAcquisitionEra):
+    """
+    _setEmulationAcquisitionEra_
+
+    Set the acquisition era for emulated data.
+    """
+    config.Global.EmulationAcquisitionEra = emulationAcquisitionEra
+    return
+
 
 def setScramArch(config, cmssw, arch):
     """

--- a/src/python/T0/StorageManager/StorageManagerAPI.py
+++ b/src/python/T0/StorageManager/StorageManagerAPI.py
@@ -56,6 +56,7 @@ def injectNewData(dbInterfaceStorageManager,
 
     getNewDataDAO = daoFactoryStorageManager(classname = "StorageManager.GetNewData")
     getRunInfoDAO = daoFactoryHltConf(classname = "StorageManager.GetRunInfo")
+    getRunSetup = daoFactoryStorageManager(classname = "StorageManager.GetRunSetup")
     insertRunDAO = daoFactory(classname = "RunConfig.InsertRun")
     insertStreamDAO = daoFactory(classname = "RunConfig.InsertStream")
     insertCMSSWVersionDAO = daoFactory(classname = "RunConfig.InsertCMSSWVersion")
@@ -96,12 +97,14 @@ def injectNewData(dbInterfaceStorageManager,
     bindRunStreamCMSSW = []
     for run in sorted(list(newRuns)):
         (hltkey, cmssw) = getRunInfoDAO.execute(run = run, transaction = False)
+        setupLabel = getRunSetup.execute(run = run, transaction = False)
         logging.debug("StorageManagerAPI: run = %d, hltkey = %s, cmssw = %s", run, hltkey, cmssw)
         if hltkey and cmssw:
             cmssw = '_'.join(cmssw.split('_')[0:4]) # only consider base release
             cmsswVersions.add(cmssw)
             bindRunHltKey.append( { 'RUN': run,
-                                    'HLTKEY': hltkey } )
+                                    'HLTKEY': hltkey,
+                                    'SETUP_LABEL': setupLabel } )
             for stream in newRunStreams[run]:
                 streams.add(stream)
                 bindRunStreamCMSSW.append( { 'RUN': run,

--- a/src/python/T0/WMBS/Oracle/Create.py
+++ b/src/python/T0/WMBS/Oracle/Create.py
@@ -114,6 +114,7 @@ class Create(DBCreator):
                  status             int           default 1 not null,
                  express_released   int           default 0 not null,
                  hltkey             varchar2(255) not null,
+                 setup_label        varchar2(255) not null,
                  start_time         int           default 0 not null,
                  stop_time          int           default 0 not null,
                  close_time         int           default 0 not null,

--- a/src/python/T0/WMBS/Oracle/RunConfig/GetRunInfo.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/GetRunInfo.py
@@ -25,7 +25,8 @@ class GetRunInfo(DBFormatter):
                         run.ah_lumi_url AS ah_lumi_url,
                         run.cond_timeout AS cond_timeout,
                         run.db_host AS db_host,
-                        run.valid_mode AS valid_mode
+                        run.valid_mode AS valid_mode,
+                        run.setup_label as setup_label
                  FROM run
                  WHERE run.run_id = :RUN
                  """

--- a/src/python/T0/WMBS/Oracle/RunConfig/InsertRun.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/InsertRun.py
@@ -12,9 +12,10 @@ class InsertRun(DBFormatter):
     def execute(self, binds, conn = None, transaction = False):
 
         sql = """INSERT INTO run
-                 (RUN_ID, HLTKEY)
+                 (RUN_ID, HLTKEY, SETUP_LABEL)
                  SELECT :RUN,
-                        :HLTKEY
+                        :HLTKEY,
+                        :SETUP_LABEL
                  FROM DUAL
                  WHERE NOT EXISTS (
                    SELECT * FROM run WHERE run_id = :RUN

--- a/src/python/T0/WMBS/Oracle/StorageManager/GetRunSetup.py
+++ b/src/python/T0/WMBS/Oracle/StorageManager/GetRunSetup.py
@@ -1,0 +1,24 @@
+"""
+_GetRunSetup_
+
+Oracle implementation of GetRunSetup
+
+Retrieve run setup information about run from online sources
+
+"""
+
+from WMCore.Database.DBFormatter import DBFormatter
+
+class GetRunSetup(DBFormatter):
+
+    def execute(self, run, conn = None, transaction = False):
+
+        binds = { 'RUN' : run }
+
+        sql = """SELECT SETUPLABEL FROM CMS_STOMGR.RUNS
+                 WHERE CMS_STOMGR.RUNS.RUNNUMBER = :RUN
+                 """
+        results = self.dbi.processData(sql, binds, conn = conn,
+                                       transaction = transaction)
+
+        return self.formatOne(results)[0]


### PR DESCRIPTION
DAQ has the ability of emulating detector data. This can be used to test the SM->T0 data chain, e.g. DAQ file system, P5-T0 data link, EOS, etc.

Tier0 needs to make sure this data is not mixed with regular production data. In the past, this has been handled manually by T0 operators, often by running an additional headnode in parallel, configured to handled this emulated data. 

There are 2 main configuration changes to take into a:

- Data storage: Emulated data should not be sent to Tape, nor should it remain in disk for a long time.
- DBS: Datasets from emulated runs should not be mixed with datasets from regular runs. Tipically done by using a different Acquisition Era.

This PR aims to automate both configuration changes.

- ProdOfflineConfiguration.py: 
   - Addition of Emulation PRs, configured only keep data at T0 disk for a short time.
   - Set acquisition era for Emulation runs.
- StorageManagerAPI: Retrieve the `setup_label` from SM database, add it to T0AST.
- RunConfigAPI: Runs with the `Emulation` label are assigned a different Acq Era.