### PR TITLE
Adds attribute DataTier to Repack configuration

### DIFF
--- a/src/python/T0/RunConfig/RunConfigAPI.py
+++ b/src/python/T0/RunConfig/RunConfigAPI.py
@@ -215,7 +215,7 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
     # treat centralDAQ or miniDAQ runs (have an HLT key) different from local runs
     if runInfo['hltkey'] != None:
 
-        # streams not explicitely configured are repacked
+        # streams not explicitly configured are repacked
         if stream not in list(tier0Config.Streams.dictionary_().keys()):
             addRepackConfig(tier0Config, stream)
 
@@ -449,8 +449,8 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
                 selectEvents.append("%s:%s" % (path, runInfo['process']))
 
             if streamConfig.ProcessingStyle == "Bulk":
-
-                outputModuleDetails.append( { 'dataTier' : "RAW",
+                dataTier = streamConfig.Repack.DataTier
+                outputModuleDetails.append( { 'dataTier' : dataTier,
                                               'eventContent' : "ALL",
                                               'selectEvents' : selectEvents,
                                               'primaryDataset' : dataset } )
@@ -489,7 +489,7 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
                                             'priority' : "high",
                                             'primaryDataset' : dataset,
                                             'deleteFromSource' : True,
-                                            'dataTier' : "RAW",
+                                            'dataTier' : dataTier,
                                             'datasetLifetime' : datasetConfig.datasetLifetime } )
 
                 #
@@ -500,7 +500,7 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
                                             'priority' : "high",
                                             'primaryDataset' : "%s-Error" % dataset,
                                             'deleteFromSource' : True,
-                                            'dataTier' : "RAW",
+                                            'dataTier' : dataTier,
                                             'datasetLifetime' : datasetConfig.datasetLifetime } )
 
 

--- a/src/python/T0/RunConfig/Tier0Config.py
+++ b/src/python/T0/RunConfig/Tier0Config.py
@@ -95,6 +95,8 @@ Tier0Configuration - Global configuration object
 |             |     |
 |             |     |--> ProcessingVersion - processing version
 |             |     |
+|             |     |--> DataTier - Output data tier for repacking the strea,
+|             |     |
 |             |     |--> MaxSizeSingleLumi - max size of single lumi before we break
 |             |     |                        it up into multiple repack jobs
 |             |     |
@@ -929,6 +931,10 @@ def addRepackConfig(config, streamName, **options):
     else:
         streamConfig.Repack.MaxMemory = options.get("maxMemory", 2000)
 
+    if hasattr(streamConfig.Repack, "DataTier"):
+        streamConfig.Repack.DataTier = options.get("dataTier", streamConfig.Repack.DataTier)
+    else:
+        streamConfig.Repack.DataTier = options.get("dataTier", "RAW")
     return
 
 def addExpressConfig(config, streamName, **options):


### PR DESCRIPTION
Adds the possibility of configuring the output data tier for Repack workflows. The default data tier will continue to be `RAW`. 
In order to produce a different data tier, call addRepackConfig() specifiying the affected stream, and the desired data tier:
```python3
addRepackConfig(tier0Config, "Default",
                proc_ver=1, # Should remain 1. Changing it can cause several issues.
                maxSizeSingleLumi=24 * 1024 * 1024 * 1024,
                maxSizeMultiLumi=8 * 1024 * 1024 * 1024,
                minInputSize=2.1 * 1024 * 1024 * 1024,
                maxInputSize=4 * 1024 * 1024 * 1024,
                maxEdmSize=24 * 1024 * 1024 * 1024,
                maxOverSize=8 * 1024 * 1024 * 1024,
                maxInputEvents=3 * 1000 * 1000,
                maxInputFiles=1000,
                maxLatency=24 * 3600,
                blockCloseDelay=24 * 3600,
                maxMemory=2000,
                versionOverride=repackVersionOverride)

addRepackConfig(tier0Config, "ScoutingPF",
                dataTier="HLTSCOUT" )
```