### PR TITLE
Replay configuration for `CMSSW_14_0_2`

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -35,7 +35,10 @@ tier0Config = createTier0Config()
 setConfigVersion(tier0Config, "replace with real version")
 
 # Set run number to replay
-# 367102 - Collisions 2023 - 1200b - 0.5h long - all components IN
+# 369998 - Collisions 2023 - 1800b - 1h long - ALL components in
+# 365537 - Splashes 2023 - 2h40 long - CSC, CTPPS, CTPPS_TOT, DT, GEM, PIXEL, RPC, TRACKER OUT
+# 375832 - Cosmics 3.8T 2023 - 3h long - CTPPS, CTPPS_TOT OUT
+
 setInjectRuns(tier0Config, [369998, 365537, 375832])
 
 # Use this in order to limit the number of lumisections to process
@@ -106,7 +109,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_14_0_1"
+    'default': "CMSSW_14_0_2"
 }
 
 # Configure ScramArch
@@ -114,10 +117,11 @@ setDefaultScramArch(tier0Config, "el8_amd64_gcc11")
 setScramArch(tier0Config, "CMSSW_12_4_9", "el8_amd64_gcc10")
 setScramArch(tier0Config, "CMSSW_12_3_0", "cs8_amd64_gcc10")
 setScramArch(tier0Config, "CMSSW_14_0_1", "el8_amd64_gcc12")
+setScramArch(tier0Config, "CMSSW_14_0_2", "el8_amd64_gcc12")
 
 
 # Configure scenarios
-ppScenario = "ppEra_Run3_2023"
+ppScenario = "ppEra_Run3"
 ppScenarioB0T = "ppEra_Run3"
 cosmicsScenario = "cosmicsEra_Run3"
 hcalnzsScenario = "hcalnzsEra_Run3"


### PR DESCRIPTION
# Replay Request

**Requestor**  
ORM

**Describe the configuration**  
* Release: `CMSSW_14_0_2`
* Run: 369998, 365537, 375832
* GTs:
   * expressGlobalTag: `140X_dataRun3_Express_v2`
   * promptrecoGlobalTag: `140X_dataRun3_Prompt_v2`
   
* Additional changes:
None


**Purpose of the test**  
Test of CMSSW_14_0_2, based on the configuration used for the earlier replay of 14_0_1.
Intended for deployment before first beam 2024.
Also:
   * discuss usage of Tier-0 era for 2024
  
**T0 Operations cmsTalk thread**  
https://cms-talk.web.cern.ch/t/replay-testing-cmssw-14-0-2/36965
