### PR TITLE
T0 Production Era change for collisions at 900GeV

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -57,7 +57,7 @@ addSiteConfig(tier0Config, "T0_CH_CERN_Disk",
 #  Data type
 #  Processing site (where jobs run)
 #  PhEDEx locations
-setAcquisitionEra(tier0Config, "Commissioning2024")
+setAcquisitionEra(tier0Config, "Run2024A")
 setEmulationAcquisitionEra(tier0Config, "Emulation2024")
 setBaseRequestPriority(tier0Config, 251000)
 setBackfill(tier0Config, None)


### PR DESCRIPTION
Changes T0 Production acquisition era to `Run2024A`.

This is done in preparation for collisions at 900GeV, and was decided in Joint Ops meeting of March 18:
https://cms-talk.web.cern.ch/t/weekly-joint-ops-meeting-mar-18th/36862
