### PR TITLE
Production configuration change to CMSSW_14_0_2

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -98,7 +98,7 @@ setPromptCalibrationConfig(tier0Config,
 #maxRunPreviousConfig = 999999 # Last run before era change 08/09/23
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_14_0_1"
+    'default': "CMSSW_14_0_2"
     #'acqEra': {'Run2023E': "CMSSW_13_2_2"},
     #'maxRun': {maxRunPreviousConfig: "CMSSW_13_2_2"}
 }
@@ -110,7 +110,7 @@ setDefaultScramArch(tier0Config, "el8_amd64_gcc12")
 #setScramArch(tier0Config, "CMSSW_13_3_0", "el8_amd64_gcc12")
 
 # Configure scenarios
-ppScenario = "ppEra_Run3_2023"
+ppScenario = "ppEra_Run3"
 ppScenarioB0T = "ppEra_Run3"
 cosmicsScenario = "cosmicsEra_Run3"
 hcalnzsScenario = "hcalnzsEra_Run3"

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -35,7 +35,10 @@ tier0Config = createTier0Config()
 setConfigVersion(tier0Config, "replace with real version")
 
 # Set run number to replay
-# 367102 - Collisions 2023 - 1200b - 0.5h long - all components IN
+# 369998 - Collisions 2023 - 1800b - 1h long - ALL components in
+# 365537 - Splashes 2023 - 2h40 long - CSC, CTPPS, CTPPS_TOT, DT, GEM, PIXEL, RPC, TRACKER OUT
+# 375832 - Cosmics 3.8T 2023 - 3h long - CTPPS, CTPPS_TOT OUT
+
 setInjectRuns(tier0Config, [369998, 365537, 375832])
 
 # Use this in order to limit the number of lumisections to process
@@ -106,7 +109,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_14_0_1"
+    'default': "CMSSW_14_0_2"
 }
 
 # Configure ScramArch
@@ -114,10 +117,11 @@ setDefaultScramArch(tier0Config, "el8_amd64_gcc11")
 setScramArch(tier0Config, "CMSSW_12_4_9", "el8_amd64_gcc10")
 setScramArch(tier0Config, "CMSSW_12_3_0", "cs8_amd64_gcc10")
 setScramArch(tier0Config, "CMSSW_14_0_1", "el8_amd64_gcc12")
+setScramArch(tier0Config, "CMSSW_14_0_2", "el8_amd64_gcc12")
 
 
 # Configure scenarios
-ppScenario = "ppEra_Run3_2023"
+ppScenario = "ppEra_Run3"
 ppScenarioB0T = "ppEra_Run3"
 cosmicsScenario = "cosmicsEra_Run3"
 hcalnzsScenario = "hcalnzsEra_Run3"


### PR DESCRIPTION
Update Production configuration to use CMSSW_14_0_2.
Tested in #4929 
