### PR TITLE
CMSSW_14_0_4 Replay config

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -111,7 +111,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_14_0_3"
+    'default': "CMSSW_14_0_4"
 }
 
 # Configure ScramArch
@@ -121,6 +121,7 @@ setScramArch(tier0Config, "CMSSW_12_3_0", "cs8_amd64_gcc10")
 setScramArch(tier0Config, "CMSSW_14_0_1", "el8_amd64_gcc12")
 setScramArch(tier0Config, "CMSSW_14_0_2", "el8_amd64_gcc12")
 setScramArch(tier0Config, "CMSSW_14_0_3", "el8_amd64_gcc12")
+setScramArch(tier0Config, "CMSSW_14_0_4", "el8_amd64_gcc12")
 
 # Configure scenarios
 ppScenario = "ppEra_Run3"

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -41,7 +41,7 @@ setConfigVersion(tier0Config, "replace with real version")
 # 378343 - Cosmics 3.8T 2024 - 1h long - CTPPS, CTPPS_TOT, L1SCOUT OUT
 # 378238 - 900GeV 2024 SB run - ~3h long - L1SCOUT out
 
-setInjectRuns(tier0Config, [369998, 378343, 378238])
+setInjectRuns(tier0Config, [369998, 375832])
 
 # Use this in order to limit the number of lumisections to process
 #setInjectLimit(tier0Config, 10)


### PR DESCRIPTION
# Replay Request

**Requestor**  
ORM

**Describe the configuration**  
* Release: CMSSW_14_0_4
* Run: 369998, 375832
* GTs:
   * expressGlobalTag = "140X_dataRun3_Express_v2"
   * promptrecoGlobalTag = "140X_dataRun3_Prompt_v2"
* Additional changes:

**Purpose of the test**  
Changing CMSSW version in production

**T0 Operations cmsTalk thread**  
If necessary, provide a link to the cmsTalk thread announcing the test to the relevant groups. 
[Tier0 Operations cmsTalk Forum](https://cms-talk.web.cern.ch/c/offcomp/compops/tier0/210?)
