### PR TITLE
T0 production Era change to Run2024B

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -57,7 +57,7 @@ addSiteConfig(tier0Config, "T0_CH_CERN_Disk",
 #  Data type
 #  Processing site (where jobs run)
 #  PhEDEx locations
-setAcquisitionEra(tier0Config, "Run2024A")
+setAcquisitionEra(tier0Config, "Run2024B")
 setEmulationAcquisitionEra(tier0Config, "Emulation2024")
 setBaseRequestPriority(tier0Config, 251000)
 setBackfill(tier0Config, None)


### PR DESCRIPTION
Change to era Run2024B, to reflect the arrival of 13.6TeV collissions to P5