### PR TITLE
Replay testing CMSSW_14_0_6

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -109,7 +109,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_14_0_5_patch1"
+    'default': "CMSSW_14_0_6"
 }
 
 # Configure ScramArch


### PR DESCRIPTION
# Replay Request

**Requestor**  
ORM 

* Release: `CMSSW_14_0_6
* Runs: 
  * 369998 
  * 379070
  * 378993
* GTs:
   * expressGlobalTag: `140X_dataRun3_Express_v3` 
   * promptrecoGlobalTag: `140X_dataRun3_Prompt_v2`
* Additional changes:
   * None  

**Purpose of the test**  
To test the release `CMSSW_14_0_6 for deployment at T0/HLT/DQM for data-taking

**T0 Operations cmsTalk thread**  
[Tier0 Operations cmsTalk Forum](https://cms-talk.web.cern.ch/t/replay-request-for-cmssw-14-0-6/39939)
