### PR TITLE
Replay for CMSSW_14_0_6_patch1

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -109,7 +109,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_14_0_5_patch1"
+    'default': "CMSSW_14_0_6_patch1"
 }
 
 # Configure ScramArch


### PR DESCRIPTION
# Replay Request

**Requestor**  
ORM

**Describe the configuration**  
* Release: `CMSSW_14_0_6_patch1`
* Run: `[369998, 379070, 378993]` (unchanged)
* GTs:
   * expressGlobalTag: `140X_dataRun3_Express_v3`  (unchanged)
   * promptrecoGlobalTag: `140X_dataRun3_Prompt_v2`  (unchanged)
* Additional changes:
   * None - except for the release, this configuration is identical to the  previous replays used for CMSSW_14_0_6 and CMSSW_14_0_5_patch1

**Purpose of the test**  
This replay is to test the new CMSSW release that will be deployed in Tier0 and which contains the fix for the crash observed in the CMSSW_14_0_6 replay and reported in [this CMSTalk post](https://cms-talk.web.cern.ch/t/replay-request-for-cmssw-14-0-6/39939/4) and tracked in [this CMSSW issue](https://github.com/cms-sw/cmssw/issues/44862).

**T0 Operations cmsTalk thread**
https://cms-talk.web.cern.ch/t/replay-for-cmssw-14-0-6-patch1/40374