### PR TITLE
Replay for CMSSW_14_0_7

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -36,11 +36,10 @@ tier0Config = createTier0Config()
 setConfigVersion(tier0Config, "replace with real version")
 
 # Set run number to replay
-# 369998 - Collisions 2023 - 1800b - 1h long - ALL components in
 # 379070 - Cosmics 3.8T 2024 - 3h long - ALL components in
-# 378993 - 2024 13.6TeV Collisions run - 12b - 1h long - ALL components in
+# 380128 - 2024 13.6 TeV Collision run - 2340b - 2.5h long - ALL components in
 
-setInjectRuns(tier0Config, [369998, 379070, 378993])
+setInjectRuns(tier0Config, [379070, 380128])
 
 # Use this in order to limit the number of lumisections to process
 #setInjectLimit(tier0Config, 10)
@@ -110,7 +109,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_14_0_6_patch1"
+    'default': "CMSSW_14_0_7"
 }
 
 # Configure ScramArch


### PR DESCRIPTION
# Replay Request

**Requestor**  
(This week and next week) ORMs

**Describe the configuration**  
* Release: CMSSW_14_0_7
* Run: `[379070, 380128]`
* GTs:
   * expressGlobalTag: `140X_dataRun3_Express_v3` (unchanged)
   * promptrecoGlobalTag: `140X_dataRun3_Prompt_v2` (unchanged)
* Additional changes:
  * The only change (a part from the release of course) is the updates of the runs to be replayed:
     * Removed `369998` as it was a 2023 collision run
     * Replaced `378993` (known to have issues in some StreamHLTMonitor streamer files) with `380128`, which is a more recent 2024 collision run (see details in [this CMSTalk post](https://cms-talk.web.cern.ch/t/streamers-to-keep-for-2024-collision-run-380128/40394))

**Purpose of the test**  
Replay for next data-taking release

**T0 Operations cmsTalk thread**  
https://cms-talk.web.cern.ch/t/replay-testing-cmssw-14-0-7/41286

### Important note
Currently the release is still being built, see https://github.com/cms-sw/cmssw/issues/44982.

-------
FYI @consuegs,  @lguzzi, @anpicci , Eddie

