### PR TITLE
Production configuration change to Run2024E and CMSSW_14_0_7

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -100,7 +100,7 @@ setPromptCalibrationConfig(tier0Config,
 # maxRunPreviousConfig = 999999 # Last run before era change 08/09/23
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_14_0_6_patch1",
+    'default': "CMSSW_14_0_7",
     'acqEra': {'Run2024D': "CMSSW_14_0_6_patch1"}
     #'maxRun': {maxRunPreviousConfig: "CMSSW_13_2_2"}
 }

--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -1253,7 +1253,7 @@ for dataset in DATASETS:
                                "HcalCalIsolatedBunchSelector"],
                physics_skims=["LogError", "LogErrorMonitor"],
                siteWhitelist = ["T2_CH_CERN_P5", "T2_CH_CERN"],
-               timePerEvent=3.5,
+               timePerEvent=1,
                sizePerEvent=1500,
                tape_node="T1_ES_PIC_MSS",
                disk_node="T1_ES_PIC_Disk",

--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -59,7 +59,7 @@ addSiteConfig(tier0Config, "T0_CH_CERN_Disk",
 #  Data type
 #  Processing site (where jobs run)
 #  PhEDEx locations
-setAcquisitionEra(tier0Config, "Run2024D")
+setAcquisitionEra(tier0Config, "Run2024E")
 setEmulationAcquisitionEra(tier0Config, "Emulation2024")
 setBaseRequestPriority(tier0Config, 251000)
 setBackfill(tier0Config, None)
@@ -101,7 +101,7 @@ setPromptCalibrationConfig(tier0Config,
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
     'default': "CMSSW_14_0_6_patch1",
-    #'acqEra': {'Run2024B': "CMSSW_14_0_4"}
+    'acqEra': {'Run2024D': "CMSSW_14_0_6_patch1"}
     #'maxRun': {maxRunPreviousConfig: "CMSSW_13_2_2"}
 }
 

--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -1282,12 +1282,7 @@ for dataset in DATASETS:
 ### Parking and Scouting PDs                         ###
 ########################################################
 
-DATASETS = ["L1Scouting"]
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=False)
-
-DATASETS = ["L1ScoutingSelection"]
+DATASETS = ["L1Scouting","L1ScoutingSelection"]
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,
                do_reco=False)


### PR DESCRIPTION
Configuration change to era Run2024E and CMSSW_14_0_7.
Configuration tested in #4952

CMS-Talk:
 - Acq Era: https://cms-talk.web.cern.ch/t/t0-production-era-change-to-run2024e/41095
 - CMSSW: https://cms-talk.web.cern.ch/t/replay-testing-cmssw-14-0-7/41286
