### PR TITLE
Replay Request for 14_0_8

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -36,11 +36,10 @@ tier0Config = createTier0Config()
 setConfigVersion(tier0Config, "replace with real version")
 
 # Set run number to replay
-# 369998 - Collisions 2023 - 1800b - 1h long - ALL components in
 # 379070 - Cosmics 3.8T 2024 - 3h long - ALL components in
-# 378993 - 2024 13.6TeV Collisions run - 12b - 1h long - ALL components in
+# 380128 - 2024 13.6 TeV Collision run - 2340b - 2.5h long - ALL components in
 
-setInjectRuns(tier0Config, [369998, 379070, 378993])
+setInjectRuns(tier0Config, [379070, 380128])
 
 # Use this in order to limit the number of lumisections to process
 #setInjectLimit(tier0Config, 10)
@@ -111,7 +110,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_14_0_6_patch1"
+    'default': "CMSSW_14_0_8"
 }
 
 # Configure ScramArch


### PR DESCRIPTION
# Replay Request

**Requestor**  
Giovanni Petrucciani (ORM),

**Describe the configuration**  

Based on https://github.com/dmwm/T0/pull/4952 except for updated CMSSW release

* Release: CMSSW_14_0_8
* Run: `[379070, 380128]`
* GTs:
   * expressGlobalTag: `140X_dataRun3_Express_v3`  (unchanged)
   * promptrecoGlobalTag: `140X_dataRun3_Prompt_v2` (unchanged)

**Purpose of the test**  
As discussed in [today's JointOps meeting](https://indico.cern.ch/event/1425802/), the plan for is to have CMSSW_14_0_9 built, tested and deployed for the restart of the data taking towards end of this week. As a backup plan in case the tests with CMSSW_14_0_9 fail, we would like to have CMSSW_14_0_8 validated in order to be able to deploy minimal a patch release on top of it. 

**T0 Operations cmsTalk thread**  
not yet there

