### PR TITLE
replay configuration for `CMSSW_14_0_12`

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -642,7 +642,7 @@ for dataset in DATASETS:
                write_dqm=True,
                alca_producers=["HcalCalIsoTrkProducerFilter", "TkAlJetHT", "HcalCalNoise"],
                dqm_sequences=["@common", "@jetmet", "@L1TMon", "@hcal"],
-               physics_skims=["EXOHighMET", "EXODelayedJetMET", "JetHTJetPlusHOFilter", "EXODisappTrk", "EXOSoftDisplacedVertices", "TeVJet", "LogError", "LogErrorMonitor"],
+               physics_skims=["EXOHighMET", "EXODelayedJetMET", "JetHTJetPlusHOFilter", "EXODisappTrk", "EXOSoftDisplacedVertices", "TeVJet", "LogError", "LogErrorMonitor", "EXOMONOPOLE"],
                timePerEvent=5.7,  # copied from JetHT - should be checked
                sizePerEvent=2250, # copied from JetHT - should be checked
                scenario=ppScenario)

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -110,7 +110,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_14_0_11"
+    'default': "CMSSW_14_0_12"
 }
 
 # Configure ScramArch


### PR DESCRIPTION
# Replay Request

**Requestor**  

ORM

**Describe the configuration**  
* Release: `CMSSW_14_0_12`
* Run: 382686, 382726
* GTs:
   * expressGlobalTag: `140X_dataRun3_Express_v3`
   * promptrecoGlobalTag: `40X_dataRun3_Prompt_v4`
* Additional changes: Include `EXOMONOPOLE` skim on `JetMET` PDs.

**Purpose of the test**  
 Test new release, `CMSSW_14_0_12` (announced [here](https://cms-talk.web.cern.ch/t/production-release-cmssw-14-0-12-now-available/44051)) needed for the next production era change (2024G)

**T0 Operations cmsTalk thread**  

https://cms-talk.web.cern.ch/t/cmssw-14-0-12-replay-request/44085
