### PR TITLE
replay config for CMSSW 14_0_13

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -110,7 +110,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_14_0_12"
+    'default': "CMSSW_14_0_13"
 }
 
 # Configure ScramArch


### PR DESCRIPTION
# Replay Request

**Requestor**  
ORM

**Describe the configuration**  
* Release: CMSSW_14_0_13
* Run: 382686, 382726
* GTs:
   * expressGlobalTag: 140X_dataRun3_Express_v3
   * promptrecoGlobalTag: 40X_dataRun3_Prompt_v4
* Additional changes: None

**Purpose of the test**  
Test release 14_0_3, coming to fix the issue reported in https://github.com/cms-sw/cmssw/issues/45596

**T0 Operations cmsTalk thread**  
[Tier0 Operations cmsTalk Forum](https://cms-talk.web.cern.ch/t/organzing-a-replay-for-oncoming-cmssw-14-0-3/44755)
