### PR TITLE
Adding T0 pylint config

### DIFF
--- a/standards/.pylintrc
+++ b/standards/.pylintrc
@@ -1,0 +1,174 @@
+# lint Python modules using external checkers.
+#
+[MASTER]
+# Add <file> (may be a directory) to the black list. It should be a base name,
+# not a path. You may set this option multiple times.
+ignore=CVS
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+extension-pkg-whitelist=pycurl
+
+# Tells wether to display a full report or only the messages
+reports=yes
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note).You have access to the variables errors, warnings, statements which
+# respectivly contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (R0004).
+evaluation='10.0 - ((float(5 * error + warning) / statement) * 10)'
+
+
+[REPORTS]
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+#msg-template='[{msg_id} {symbol}] {msg} File: {path}, line {line}, in {obj}'
+msg-template='{msg_id} L{line}: {msg} ({symbol})'
+
+
+[MESSAGES CONTROL]
+# disable F0401 - could not import module
+# disable E1103 - Allows attachment of dbi, logger to threading.currentThread()
+
+disable=F0401, E1103
+
+
+# checks for :
+#     * doc strings
+#     * modules / classes / functions / methods / arguments / variables name
+#     * number of arguments, local variables, branchs, returns and statements in
+# functions, methods
+#     * required module attributes
+#     * dangerous default values as arguments
+#     * redefinition of function / method / class
+#     * uses of the global statement
+#
+[BASIC]
+
+# Maximum number of arguments for function / method
+max-args=7
+
+# Maximum number of locals for function / method body
+max-locals=30
+
+# Maximum number of return / yield for function / method body
+max-returns=15
+
+# Maximum number of statements in function / method body
+max-statements=100
+
+# Regular expression which should only match functions or classes name which do
+# not require a docstring
+no-docstring-rgx=__.*__
+
+# Regular expression which should only match correct module names
+module-rgx=[A-Z][a-zA-Z0-9]+$
+
+# Regular expression which should only match correct class names
+class-rgx=[A-Z][a-zA-Z0-9]+$
+
+# Regular expression which should only match correct function names
+function-rgx=([a-z][a-zA-Z0-9]*$)|([a-z][a-zA-Z0-9]*_$)
+
+# Regular expression which should only match correct method names
+method-rgx=([a-z][a-zA-Z0-9]*$)|([_]{2}[a-z]+[_]{2}$)|([a-z][a-zA-Z0-9]*_$)
+
+# Regular expression which should only match correct argument names
+argument-rgx=[a-z][a-zA-Z0-9]*$
+
+# Regular expression which should only match correct variable names
+variable-rgx=([a-z][a-zA-Z0-9]*$|^_$)
+
+# Regular expression which should only match correct class attr names
+attr-rgx=[a-z][a-zA-Z0-9]*$
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,j,k,ex,
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,bar,baz,toto,tutu,tata,kludge
+
+# checks for
+#     * external modules dependancies
+#     * relative / wildcard imports
+#     * cyclic imports
+#     * uses of deprecated modules
+#
+[IMPORTS]
+# Enable / disable this checker
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=regsub,string,TERMIOS,Bastion,rexec,UserDict,UserList
+
+
+
+# checks for
+#     * unused variables / imports
+#     * undefined variables
+#     * redefinition of variable from builtins or from an outer scope
+#     * use of variable before assigment
+#
+[VARIABLES]
+# Enable / disable this checker
+
+# Tells wether we should check for unused import in __init__ files.
+init-import=no
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+dummy-variables-rgx=(^dummy|^_$)
+
+# checks for :
+#     * methods without self as first argument
+#     * overriden methods signature
+#     * access only to existant members via self
+#     * attributes not defined in the __init__ method
+#     * supported interfaces implementation
+#     * unreachable code
+#
+[CLASSES]
+
+# Tells wether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+[FORMAT]
+# Maximum number of characters on a single line. Blame Wakefield for 160
+max-line-length=160
+
+# Maximum number of lines in a module
+max-module-lines=1000
+
+# String used as indentation unit. This is usually " " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+
+
+# checks for:
+#     * source code with non ascii characters but no encoding declaration (PEP
+#       263)
+#     * warning notes in the code like FIXME, XXX
+#
+[MISCELLANEOUS]
+# List of note tags to take in consideration, separated by a comma. Default to
+# FIXME, XXX, TODO
+notes=FIXME,XXX,TODO
+
+
+
+# does not check anything but gives some raw metrics :
+#     * total number of lines
+#     * total number of code lines
+#     * total number of docstring lines
+#     * total number of comments lines
+#     * total number of empty lines
+#
+[METRICS]
+# Enable / disable this checker
+


### PR DESCRIPTION
WMCore's pylint confic is no longer valit with Pylint3.X. This adds a Pylint configuration for the T0 repo.
