### PR TITLE
Replay test of CMSSW_14_0_14

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -110,7 +110,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_14_0_13"
+    'default': "CMSSW_14_0_14"
 }
 
 # Configure ScramArch


### PR DESCRIPTION
# Replay Request

**Requestor**  
ORM

**Describe the configuration**  
* Release: CMSSW_14_0_14
* Run: 382686, 382726
* GTs: 
   * expressGlobalTag: 140X_dataRun3_Express_v3
   * promptrecoGlobalTag: 140X_dataRun3_Prompt_v4
* Additional changes:

**Purpose of the test**  
Test new release (see announcement https://cms-talk.web.cern.ch/t/production-release-cmssw-14-0-14-available/45423 ) with a few non critical updates discussed during last ORP

**T0 Operations cmsTalk thread**  
https://cms-talk.web.cern.ch/t/cmssw-14-0-14-replay-request/45445