### PR TITLE
Replay test for CMSSW_14_0_15

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -110,7 +110,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_14_0_14"
+    'default': "CMSSW_14_0_15"
 }
 
 # Configure ScramArch


### PR DESCRIPTION
# Replay Request

**Requestor**  
ORM

**Describe the configuration**  
* Release: CMSSW_14_0_15
* Run: 382686, 382726
* GTs:
   * expressGlobalTag: 140X_dataRun3_Express_v3
   * promptrecoGlobalTag: 140X_dataRun3_Prompt_v4
* Additional changes:

**Purpose of the test**  
This test is needed to deploy CMSSW_14_0_15 on the Tier0 which was requested by HLT, and is needed for development of the heavy-ion menu

**T0 Operations cmsTalk thread**  

