### PR TITLE
First proposal to dual agents by filtering streams

### DIFF
--- a/etc/HIProdOfflineConfiguration.py
+++ b/etc/HIProdOfflineConfiguration.py
@@ -25,6 +25,7 @@ from T0.RunConfig.Tier0Config import setInjectMaxRun
 from T0.RunConfig.Tier0Config import setStreamerPNN
 from T0.RunConfig.Tier0Config import addSiteConfig
 from T0.RunConfig.Tier0Config import setStorageSite
+from T0.RunConfig.Tier0Config import setHelperAgentStreams
 
 # Create the Tier0 configuration object
 tier0Config = createTier0Config()
@@ -38,6 +39,11 @@ setInjectMinRun(tier0Config, 9999999)
 # Set the max run number:
 setInjectMaxRun(tier0Config, 9999999)
 
+# Define streams to ignore. These wont be injected by the MainAgent
+setHelperAgentStreams(tier0Config, {'SecondAgent': [],
+                                    'ThirdAgent' : []
+                                    })
+                                    
 # Settings up sites
 processingSite = "T2_CH_CERN"
 storageSite = "T0_CH_CERN_Disk"

--- a/etc/HIReplayOfflineConfiguration.py
+++ b/etc/HIReplayOfflineConfiguration.py
@@ -25,6 +25,7 @@ from T0.RunConfig.Tier0Config import setStreamerPNN
 from T0.RunConfig.Tier0Config import setEnableUniqueWorkflowName
 from T0.RunConfig.Tier0Config import addSiteConfig
 from T0.RunConfig.Tier0Config import setStorageSite
+from T0.RunConfig.Tier0Config import setHelperAgentStreams
 
 # Create the Tier0 configuration object
 tier0Config = createTier0Config()
@@ -41,6 +42,10 @@ setConfigVersion(tier0Config, "replace with real version")
 # 361694:361699,361779 - 2022 HI dry-run test runs
 setInjectRuns(tier0Config, [375820])
 
+# Define streams to ignore. These wont be injected by the MainAgent
+setHelperAgentStreams(tier0Config, {'SecondAgent': [],
+                                    'ThirdAgent' : []
+                                    })
 # Settings up sites
 processingSite = "T2_CH_CERN"
 storageSite = "T0_CH_CERN_Disk"

--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -28,7 +28,7 @@ from T0.RunConfig.Tier0Config import setStreamerPNN
 from T0.RunConfig.Tier0Config import addSiteConfig
 from T0.RunConfig.Tier0Config import setStorageSite
 from T0.RunConfig.Tier0Config import setExtraStreamDatasetMap
-
+from T0.RunConfig.Tier0Config import setSecondaryAgentStreams
 
 # Create the Tier0 configuration object
 tier0Config = createTier0Config()
@@ -41,6 +41,9 @@ setInjectMinRun(tier0Config, 9999999)
 
 # Set the max run number:
 setInjectMaxRun(tier0Config, 9999999)
+
+# Set streams to ignore by agent. These will not be injected
+setSecondaryAgentStreams(tier0Config, [])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"

--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -28,7 +28,7 @@ from T0.RunConfig.Tier0Config import setStreamerPNN
 from T0.RunConfig.Tier0Config import addSiteConfig
 from T0.RunConfig.Tier0Config import setStorageSite
 from T0.RunConfig.Tier0Config import setExtraStreamDatasetMap
-from T0.RunConfig.Tier0Config import setSecondaryAgentStreams
+from T0.RunConfig.Tier0Config import setMultipleAgentStreams
 
 # Create the Tier0 configuration object
 tier0Config = createTier0Config()
@@ -43,7 +43,8 @@ setInjectMinRun(tier0Config, 9999999)
 setInjectMaxRun(tier0Config, 9999999)
 
 # Set streams to ignore by agent. These will not be injected
-setSecondaryAgentStreams(tier0Config, [])
+setMultipleAgentStreams(tier0Config, {"SecondAgent" : [],
+                                      "ThirdAgent" : []})
 
 # Settings up sites
 processingSite = "T2_CH_CERN"

--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -42,7 +42,7 @@ setInjectMinRun(tier0Config, 9999999)
 # Set the max run number:
 setInjectMaxRun(tier0Config, 9999999)
 
-# Set streams to ignore by agent. These will not be injected
+# Set streams to ignore by agent. These will not be injected by the MainAgent
 setHelperAgentStreams(tier0Config, {"SecondAgent" : [],
                                       "ThirdAgent" : []})
 
@@ -64,7 +64,7 @@ addSiteConfig(tier0Config, "T0_CH_CERN_Disk",
 #  Data type
 #  Processing site (where jobs run)
 #  PhEDEx locations
-setAcquisitionEra(tier0Config, "Run2024G")
+setAcquisitionEra(tier0Config, "Run2024H")
 setEmulationAcquisitionEra(tier0Config, "Emulation2024")
 setBaseRequestPriority(tier0Config, 251000)
 setBackfill(tier0Config, None)
@@ -105,7 +105,7 @@ setPromptCalibrationConfig(tier0Config,
 # maxRunPreviousConfig = 999999 # Last run before era change 08/09/23
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_14_0_14",
+    'default': "CMSSW_14_0_16",
     #'acqEra': {'Run2024F': "CMSSW_14_0_11"},
     #'maxRun': {maxRunPreviousConfig: "CMSSW_13_2_2"}
 }

--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -28,7 +28,7 @@ from T0.RunConfig.Tier0Config import setStreamerPNN
 from T0.RunConfig.Tier0Config import addSiteConfig
 from T0.RunConfig.Tier0Config import setStorageSite
 from T0.RunConfig.Tier0Config import setExtraStreamDatasetMap
-from T0.RunConfig.Tier0Config import setMultipleAgentStreams
+from T0.RunConfig.Tier0Config import setHelperAgentStreams
 
 # Create the Tier0 configuration object
 tier0Config = createTier0Config()
@@ -43,7 +43,7 @@ setInjectMinRun(tier0Config, 9999999)
 setInjectMaxRun(tier0Config, 9999999)
 
 # Set streams to ignore by agent. These will not be injected
-setMultipleAgentStreams(tier0Config, {"SecondAgent" : [],
+setHelperAgentStreams(tier0Config, {"SecondAgent" : [],
                                       "ThirdAgent" : []})
 
 # Settings up sites

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -28,6 +28,7 @@ from T0.RunConfig.Tier0Config import setEnableUniqueWorkflowName
 from T0.RunConfig.Tier0Config import addSiteConfig
 from T0.RunConfig.Tier0Config import setStorageSite
 from T0.RunConfig.Tier0Config import setExtraStreamDatasetMap
+from T0.RunConfig.Tier0Config import setSecondaryAgentStreams
 
 # Create the Tier0 configuration object
 tier0Config = createTier0Config()
@@ -43,6 +44,12 @@ setInjectRuns(tier0Config, [382686, 382726])
 
 # Use this in order to limit the number of lumisections to process
 #setInjectLimit(tier0Config, 10)
+
+# Define streams to ignore. These wont be injected
+setSecondaryAgentStreams(tier0Config, ["ScoutingPF", "L1ScoutingSelection", 
+                                       "L1Scouting", "Express", "Calibration",
+                                       "ExpressAlignment"
+                                       ])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -28,7 +28,7 @@ from T0.RunConfig.Tier0Config import setEnableUniqueWorkflowName
 from T0.RunConfig.Tier0Config import addSiteConfig
 from T0.RunConfig.Tier0Config import setStorageSite
 from T0.RunConfig.Tier0Config import setExtraStreamDatasetMap
-from T0.RunConfig.Tier0Config import setMultipleAgentStreams
+from T0.RunConfig.Tier0Config import setHelperAgentStreams
 
 # Create the Tier0 configuration object
 tier0Config = createTier0Config()
@@ -46,9 +46,9 @@ setInjectRuns(tier0Config, [382686, 382726])
 #setInjectLimit(tier0Config, 10)
 
 # Define streams to ignore. These wont be injected
-setMultipleAgentStreams(tier0Config, {'SecondAgent': ["ScoutingPF", "L1ScoutingSelection", "L1Scouting", "Express"],
-                                      'ThirdAgent' : ["Calibration", "HLTMonitor"]
-                                      })
+setHelperAgentStreams(tier0Config, {'SecondAgent': ["ScoutingPF", "L1ScoutingSelection", "L1Scouting", "Express"],
+                                    'ThirdAgent' : ["Calibration", "HLTMonitor"]
+                                    })
 
 # Settings up sites
 processingSite = "T2_CH_CERN"

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -28,7 +28,7 @@ from T0.RunConfig.Tier0Config import setEnableUniqueWorkflowName
 from T0.RunConfig.Tier0Config import addSiteConfig
 from T0.RunConfig.Tier0Config import setStorageSite
 from T0.RunConfig.Tier0Config import setExtraStreamDatasetMap
-from T0.RunConfig.Tier0Config import setSecondaryAgentStreams
+from T0.RunConfig.Tier0Config import setMultipleAgentStreams
 
 # Create the Tier0 configuration object
 tier0Config = createTier0Config()
@@ -46,10 +46,9 @@ setInjectRuns(tier0Config, [382686, 382726])
 #setInjectLimit(tier0Config, 10)
 
 # Define streams to ignore. These wont be injected
-setSecondaryAgentStreams(tier0Config, ["ScoutingPF", "L1ScoutingSelection", 
-                                       "L1Scouting", "Express", "Calibration",
-                                       "ExpressAlignment"
-                                       ])
+setMultipleAgentStreams(tier0Config, {'SecondAgent': ["ScoutingPF", "L1ScoutingSelection", "L1Scouting", "Express"],
+                                      'ThirdAgent' : ["Calibration", "HLTMonitor"]
+                                      })
 
 # Settings up sites
 processingSite = "T2_CH_CERN"

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -45,9 +45,9 @@ setInjectRuns(tier0Config, [382686, 382726])
 # Use this in order to limit the number of lumisections to process
 #setInjectLimit(tier0Config, 10)
 
-# Define streams to ignore. These wont be injected
-setHelperAgentStreams(tier0Config, {'SecondAgent': ["ScoutingPF", "L1ScoutingSelection", "L1Scouting", "Express"],
-                                    'ThirdAgent' : ["Calibration", "HLTMonitor"]
+# Define streams to ignore. These wont be injected by the MainAgent
+setHelperAgentStreams(tier0Config, {'SecondAgent': [],
+                                    'ThirdAgent' : []
                                     })
 
 # Settings up sites
@@ -116,7 +116,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_14_0_15"
+    'default': "CMSSW_14_0_16"
 }
 
 # Configure ScramArch

--- a/src/python/T0/RunConfig/Tier0Config.py
+++ b/src/python/T0/RunConfig/Tier0Config.py
@@ -286,7 +286,7 @@ def createTier0Config():
     tier0Config.Global.InjectMinRun = None
     tier0Config.Global.InjectMaxRun = None
     
-    tier0Config.Global.MultipleAgentStreams = {}
+    tier0Config.Global.HelperAgentStreams = {}
     tier0Config.Global.SpecifiedStreamNames = None
 
     tier0Config.Global.ScramArches = {}
@@ -858,13 +858,13 @@ def setInjectLimit(config, injectLimit):
     config.Global.InjectLimit = injectLimit
     return
 
-def setMultipleAgentStreams(config, multipleAgentStreams):
+def setHelperAgentStreams(config, helperAgentStreams):
     """
     _setSecondaryAgentStreams_
 
     Define which streams should not be injected by the agent (for dual agents)
     """
-    config.Global.MultipleAgentStreams = multipleAgentStreams
+    config.Global.HelperAgentStreams = helperAgentStreams
     return
 
 def setEnableUniqueWorkflowName(config):

--- a/src/python/T0/RunConfig/Tier0Config.py
+++ b/src/python/T0/RunConfig/Tier0Config.py
@@ -286,7 +286,7 @@ def createTier0Config():
     tier0Config.Global.InjectMinRun = None
     tier0Config.Global.InjectMaxRun = None
     
-    tier0Config.Global.SecondaryAgentStreams = []
+    tier0Config.Global.MultipleAgentStreams = {}
     tier0Config.Global.SpecifiedStreamNames = None
 
     tier0Config.Global.ScramArches = {}
@@ -858,13 +858,13 @@ def setInjectLimit(config, injectLimit):
     config.Global.InjectLimit = injectLimit
     return
 
-def setSecondaryAgentStreams(config, secondaryAgentStreams):
+def setMultipleAgentStreams(config, multipleAgentStreams):
     """
     _setSecondaryAgentStreams_
 
     Define which streams should not be injected by the agent (for dual agents)
     """
-    config.Global.SecondaryAgentStreams = secondaryAgentStreams
+    config.Global.MultipleAgentStreams = multipleAgentStreams
     return
 
 def setEnableUniqueWorkflowName(config):

--- a/src/python/T0/RunConfig/Tier0Config.py
+++ b/src/python/T0/RunConfig/Tier0Config.py
@@ -286,6 +286,7 @@ def createTier0Config():
     tier0Config.Global.InjectMinRun = None
     tier0Config.Global.InjectMaxRun = None
     
+    tier0Config.Global.SecondaryAgentStreams = []
     tier0Config.Global.SpecifiedStreamNames = None
 
     tier0Config.Global.ScramArches = {}
@@ -857,6 +858,14 @@ def setInjectLimit(config, injectLimit):
     config.Global.InjectLimit = injectLimit
     return
 
+def setSecondaryAgentStreams(config, secondaryAgentStreams):
+    """
+    _setSecondaryAgentStreams_
+
+    Define which streams should not be injected by the agent (for dual agents)
+    """
+    config.Global.SecondaryAgentStreams = secondaryAgentStreams
+    return
 
 def setEnableUniqueWorkflowName(config):
     """

--- a/src/python/T0/StorageManager/StorageManagerAPI.py
+++ b/src/python/T0/StorageManager/StorageManagerAPI.py
@@ -19,7 +19,9 @@ def injectNewData(dbInterfaceStorageManager,
                   minRun = None,
                   maxRun = None,
                   injectRun = None,
-                  injectLimit = None):
+                  injectLimit = None,
+                  isMainAgent = True,
+                  secondaryAgentStreams = []):
     """
     _injectNewData_
 
@@ -72,7 +74,15 @@ def injectNewData(dbInterfaceStorageManager,
                                     transaction = False)
 
     # remove already processed files
-    newData[:] = [newFile for newFile in newData if newFile['p5_id'] not in knownStreamers]
+    # Filtering streams for Main and Secondary agents before injecting
+    # Note that every agent is Main by default
+    # Note that the secondaryAgentStreams works as a specifyStreams if the agent is secondary
+    if isMainAgent:
+        logging.info("This is a Main Agent. The following streams will not be injected: {}".format(secondaryAgentStreams))
+        newData[:] = [newFile for newFile in newData if newFile['p5_id'] not in knownStreamers and newFile['stream'] not in secondaryAgentStreams]
+    else:
+        logging.info("This is a Secondary Agent. Only the following streams will be injected: {}".format(secondaryAgentStreams))
+        newData[:] = [newFile for newFile in newData if newFile['p5_id'] not in knownStreamers and newFile['stream'] in secondaryAgentStreams]
 
     logging.debug("StoragemanagerAPI: found %d new files", len(newData))
 
@@ -87,6 +97,7 @@ def injectNewData(dbInterfaceStorageManager,
 
         if run not in newRunStreams:
             newRunStreams[run] = set()
+        
         if stream not in newRunStreams[run]:
             newRunStreams[run].add(stream)
 

--- a/src/python/T0/StorageManager/StorageManagerAPI.py
+++ b/src/python/T0/StorageManager/StorageManagerAPI.py
@@ -20,8 +20,7 @@ def injectNewData(dbInterfaceStorageManager,
                   maxRun = None,
                   injectRun = None,
                   injectLimit = None,
-                  isMainAgent = True,
-                  secondaryAgentStreams = []):
+                  agentType = None):
     """
     _injectNewData_
 
@@ -77,15 +76,13 @@ def injectNewData(dbInterfaceStorageManager,
     # Filtering streams for Main and Secondary agents before injecting
     # Note that every agent is Main by default
     # Note that the secondaryAgentStreams works as a specifyStreams if the agent is secondary
-    if isMainAgent:
-        logging.info("This is a Main Agent. The following streams will not be injected: {}".format(secondaryAgentStreams))
-        newData[:] = [newFile for newFile in newData if newFile['p5_id'] not in knownStreamers and newFile['stream'] not in secondaryAgentStreams]
-    else:
-        logging.info("This is a Secondary Agent. Only the following streams will be injected: {}".format(secondaryAgentStreams))
-        newData[:] = [newFile for newFile in newData if newFile['p5_id'] not in knownStreamers and newFile['stream'] in secondaryAgentStreams]
 
+    newData[:] = [newFile for newFile in newData if newFile['p5_id'] not in knownStreamers]
     logging.debug("StoragemanagerAPI: found %d new files", len(newData))
 
+    if agentType:
+        newData = agentType.filterStreamerFiles(streamerFiles = newData)
+    
     newRuns = set()
     newRunStreams = {}
     for newFile in newData:

--- a/src/python/T0/StorageManager/StorageManagerAPI.py
+++ b/src/python/T0/StorageManager/StorageManagerAPI.py
@@ -81,6 +81,7 @@ def injectNewData(dbInterfaceStorageManager,
     logging.debug("StoragemanagerAPI: found %d new files", len(newData))
 
     if agentType:
+        logging.info("Filtering streamer files for %s", agentType.name)
         newData = agentType.filterStreamerFiles(streamerFiles = newData)
     
     newRuns = set()

--- a/src/python/T0/WMBS/Oracle/RunConfig/GetHLTConfig.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/GetHLTConfig.py
@@ -12,7 +12,7 @@ from WMCore.Database.DBFormatter import DBFormatter
 
 class GetHLTConfig(DBFormatter):
 
-    def execute(self, hltkey, conn = None, transaction = False):
+    def execute(self, hltkey, tier0Config = None, isMainAgent = True, conn = None, transaction = False):
 
         sql = """SELECT distinct a.name AS stream,   
                                  b.name AS dataset,   
@@ -78,6 +78,11 @@ class GetHLTConfig(DBFormatter):
         for result in self.formatDict(results):
 
             stream = result['stream']
+            if isMainAgent and stream in tier0Config.Global.SecondaryAgentStreams:
+                continue
+            if not isMainAgent and stream not in tier0Config.Global.SecondaryAgentStreams:
+                continue
+                
             dataset = result['dataset']
             path = result['path']
             process = result['process']

--- a/src/python/T0/WMBS/Oracle/RunConfig/GetHLTConfig.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/GetHLTConfig.py
@@ -12,7 +12,7 @@ from WMCore.Database.DBFormatter import DBFormatter
 
 class GetHLTConfig(DBFormatter):
 
-    def execute(self, hltkey, tier0Config = None, isMainAgent = True, conn = None, transaction = False):
+    def execute(self, hltkey, conn = None, transaction = False):
 
         sql = """SELECT distinct a.name AS stream,   
                                  b.name AS dataset,   
@@ -78,11 +78,6 @@ class GetHLTConfig(DBFormatter):
         for result in self.formatDict(results):
 
             stream = result['stream']
-            if isMainAgent and stream in tier0Config.Global.SecondaryAgentStreams:
-                continue
-            if not isMainAgent and stream not in tier0Config.Global.SecondaryAgentStreams:
-                continue
-                
             dataset = result['dataset']
             path = result['path']
             process = result['process']

--- a/src/python/T0Component/Tier0Feeder/MultipleAgents/BaseAgent.py
+++ b/src/python/T0Component/Tier0Feeder/MultipleAgents/BaseAgent.py
@@ -5,10 +5,11 @@ class BaseAgent(object):
     """
 
     def __init__(self, tier0Config):
+        
         object.__init__(self)
-        self.multipleAgentStreams = tier0Config.Global.multipleAgentStreams
+        self.helperAgentStreams = tier0Config.Global.HelperAgentStreams
 
-    def filterStreamerFiles (self, streamerFiles):
+    def filterStreamerFiles (self, streamerFiles = []):
         """
         _filterStreamerFiles_
 
@@ -16,7 +17,7 @@ class BaseAgent(object):
         """
         return 
 
-    def filterHltConfigStreams (self, hltConfig):
+    def filterHltConfigStreams (self, hltStreamMapping = {}):
         """
         _filterHltConfigStreams_
 

--- a/src/python/T0Component/Tier0Feeder/MultipleAgents/BaseAgent.py
+++ b/src/python/T0Component/Tier0Feeder/MultipleAgents/BaseAgent.py
@@ -1,0 +1,26 @@
+class BaseAgent(object):
+    """
+    Base agent. 
+
+    """
+
+    def __init__(self, tier0Config):
+        object.__init__(self)
+        self.multipleAgentStreams = tier0Config.Global.multipleAgentStreams
+
+    def filterStreamerFiles (self, streamerFiles):
+        """
+        _filterStreamerFiles_
+
+        When running multiple agents, filter out data from Storage Manager to avoid duplicates 
+        """
+        return 
+
+    def filterHltConfigStreams (self, hltConfig):
+        """
+        _filterHltConfigStreams_
+
+        When running multiple agents, populate databases with the streams information relevant to the given agent
+        """
+        return
+        

--- a/src/python/T0Component/Tier0Feeder/MultipleAgents/HelperAgent.py
+++ b/src/python/T0Component/Tier0Feeder/MultipleAgents/HelperAgent.py
@@ -1,3 +1,4 @@
+import logging
 from T0Component.Tier0Feeder.MultipleAgents.BaseAgent import BaseAgent
 
 class HelperAgent(BaseAgent):
@@ -7,16 +8,19 @@ class HelperAgent(BaseAgent):
 
     Use it with
     config.Tier0Feeder.AgentRole = "SecondAgent" (or "ThirdAgent" ..., follow the configuration file)
+    Note: if the helperName is none or unknown, returned values will be empty and no data is injected
     """
-    def __init__(self, tier0Config, helperRole = None):
+    def __init__(self, tier0Config, helperName = None):
+        
         BaseAgent.__init__(self, tier0Config)
-        self.role = helperRole
-
-        if self.role and self.role in self.MultipleAgentStreams:
-            self.streams = self.MultipleAgentStreams[self.role]
+        self.name = helperName
+        if self.name and self.name in self.helperAgentStreams:
+            self.streams = self.helperAgentStreams[self.name]
         else:
             self.streams = []
         
+        logging.info("This is a HelperAgent named {}. Processing streams {}".format(self.name, self.streams))
+
     def filterStreamerFiles (self, streamerFiles = []):
         """
         _filterStreamerFiles_
@@ -25,18 +29,18 @@ class HelperAgent(BaseAgent):
         Returns streamers the agent wants to process
         """
 
-        filteredStreamers = [streamer for streamer in streamerFiles if streamerFiles['stream'] in self.streams]
+        filteredStreamers = [streamer for streamer in streamerFiles if streamer['stream'] in self.streams]
 
         return filteredStreamers
 
-    def filterHltConfigStreams (self, hltConfig = {}):
+    def filterHltConfigStreams (self, hltStreamMapping = {}):
         """
         _filterHltConfigStreams_
 
         When running multiple agents, populate databases with the streams information relevant to the given agent
-        Returns modified hltConfig with streams that the agent wants
+        Returns modified hltStreamMapping with streams that the agent wants
         """
 
-        filteredHltConfig = {stream: hltConfig['mapping'][stream] for stream in hltConfig['mapping'] if stream in self.streams}
+        filteredHltStreamMapping = {stream: hltStreamMapping[stream] for stream in hltStreamMapping if stream in self.streams}
 
-        return filteredHltConfig
+        return filteredHltStreamMapping

--- a/src/python/T0Component/Tier0Feeder/MultipleAgents/HelperAgent.py
+++ b/src/python/T0Component/Tier0Feeder/MultipleAgents/HelperAgent.py
@@ -1,0 +1,42 @@
+from T0Component.Tier0Feeder.MultipleAgents.BaseAgent import BaseAgent
+
+class HelperAgent(BaseAgent):
+    """
+    Helper agent. The streams processed by this one are explicitely defined in the tier0Config. 
+    helperRole has to match
+
+    Use it with
+    config.Tier0Feeder.AgentRole = "SecondAgent" (or "ThirdAgent" ..., follow the configuration file)
+    """
+    def __init__(self, tier0Config, helperRole = None):
+        BaseAgent.__init__(self, tier0Config)
+        self.role = helperRole
+
+        if self.role and self.role in self.MultipleAgentStreams:
+            self.streams = self.MultipleAgentStreams[self.role]
+        else:
+            self.streams = []
+        
+    def filterStreamerFiles (self, streamerFiles = []):
+        """
+        _filterStreamerFiles_
+
+        When running multiple agents, filter out data from Storage Manager to avoid duplicates 
+        Returns streamers the agent wants to process
+        """
+
+        filteredStreamers = [streamer for streamer in streamerFiles if streamerFiles['stream'] in self.streams]
+
+        return filteredStreamers
+
+    def filterHltConfigStreams (self, hltConfig = {}):
+        """
+        _filterHltConfigStreams_
+
+        When running multiple agents, populate databases with the streams information relevant to the given agent
+        Returns modified hltConfig with streams that the agent wants
+        """
+
+        filteredHltConfig = {stream: hltConfig['mapping'][stream] for stream in hltConfig['mapping'] if stream in self.streams}
+
+        return filteredHltConfig

--- a/src/python/T0Component/Tier0Feeder/MultipleAgents/MainAgent.py
+++ b/src/python/T0Component/Tier0Feeder/MultipleAgents/MainAgent.py
@@ -1,16 +1,20 @@
+import logging
 from T0Component.Tier0Feeder.MultipleAgents.BaseAgent import BaseAgent
 
 class MainAgent(BaseAgent):
     """
     Main agent. The streams processed by this agent are implicitely defined in the tier0Config
     * This agent will process streams that are not defined in any of the other agents
-    * tier0Config.Global.MultipleAgentStreams = {'SecondAgent' : ["stream_1", "stream_2"],
+    * tier0Config.Global.HelperAgentStreams = {'SecondAgent' : ["stream_1", "stream_2"],
                                                  'ThirdAgent' : ["stream_3", "stream_4"]}
-
+    Note: This agent will ignore all streams in the helper agents, regardless of the helper agents status
     """
     def __init__(self, tier0Config):
+        
         BaseAgent.__init__(self, tier0Config)
-        self.rejectStreams = self.findUnwantedStreams()
+        self.name = "MainAgent"
+        self.findUnwantedStreams()
+        logging.info("This is a MainAgent. Ignoring streams {}".format(self.rejectStreams))
         
     def filterStreamerFiles (self, streamerFiles):
         """
@@ -19,19 +23,19 @@ class MainAgent(BaseAgent):
         When running multiple agents, filter out data from Storage Manager to avoid duplicates 
         Returns the streamers the agent want to process
         """
-        filteredStreamers = [streamer for streamer in streamerFiles if streamerFiles['stream'] not in self.rejectStreams]
+        filteredStreamers = [streamer for streamer in streamerFiles if streamer['stream'] not in self.rejectStreams]
 
         return filteredStreamers
 
-    def filterHltConfigStreams (self, hltConfig):
+    def filterHltConfigStreams (self, hltStreamMapping = {}):
         """
         _filterHltConfigStreams_
 
         When running multiple agents, populate databases with the streams information relevant to the given agent
         """
-        filteredHltConfig = {stream: hltConfig['mapping'][stream] for stream in hltConfig['mapping'] if stream not in self.rejectStreams}
+        filteredHltStreamMapping = {stream: hltStreamMapping[stream] for stream in hltStreamMapping if stream not in self.rejectStreams}
 
-        return
+        return filteredHltStreamMapping
 
     def findUnwantedStreams (self):
         """
@@ -40,7 +44,7 @@ class MainAgent(BaseAgent):
         Returns a list of streams that will not be processed by any other agent
         """
         self.rejectStreams = []
-        for agent in self.multipleAgentStreams.keys():
-            self.rejectStreams += self.multipleAgentStreams[agent]
+        for agent in self.helperAgentStreams.keys():
+            self.rejectStreams += self.helperAgentStreams[agent]
         
         return

--- a/src/python/T0Component/Tier0Feeder/MultipleAgents/MainAgent.py
+++ b/src/python/T0Component/Tier0Feeder/MultipleAgents/MainAgent.py
@@ -1,0 +1,46 @@
+from T0Component.Tier0Feeder.MultipleAgents.BaseAgent import BaseAgent
+
+class MainAgent(BaseAgent):
+    """
+    Main agent. The streams processed by this agent are implicitely defined in the tier0Config
+    * This agent will process streams that are not defined in any of the other agents
+    * tier0Config.Global.MultipleAgentStreams = {'SecondAgent' : ["stream_1", "stream_2"],
+                                                 'ThirdAgent' : ["stream_3", "stream_4"]}
+
+    """
+    def __init__(self, tier0Config):
+        BaseAgent.__init__(self, tier0Config)
+        self.rejectStreams = self.findUnwantedStreams()
+        
+    def filterStreamerFiles (self, streamerFiles):
+        """
+        _filterStreamerFiles_
+
+        When running multiple agents, filter out data from Storage Manager to avoid duplicates 
+        Returns the streamers the agent want to process
+        """
+        filteredStreamers = [streamer for streamer in streamerFiles if streamerFiles['stream'] not in self.rejectStreams]
+
+        return filteredStreamers
+
+    def filterHltConfigStreams (self, hltConfig):
+        """
+        _filterHltConfigStreams_
+
+        When running multiple agents, populate databases with the streams information relevant to the given agent
+        """
+        filteredHltConfig = {stream: hltConfig['mapping'][stream] for stream in hltConfig['mapping'] if stream not in self.rejectStreams}
+
+        return
+
+    def findUnwantedStreams (self):
+        """
+        _findUnwantedStreams_
+
+        Returns a list of streams that will not be processed by any other agent
+        """
+        self.rejectStreams = []
+        for agent in self.multipleAgentStreams.keys():
+            self.rejectStreams += self.multipleAgentStreams[agent]
+        
+        return

--- a/src/python/T0Component/Tier0Feeder/MultipleAgents/__init__.py
+++ b/src/python/T0Component/Tier0Feeder/MultipleAgents/__init__.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python
+
+__all__ = []


### PR DESCRIPTION
This PR attempts to add support to run 2 agents at the same time by adding two features:

* Define a list of streams to ignore and ignore them before the data is injected by the agent.
* Define a list of expected streams and a boolean parameter that configures an agent to process streams outside of that list or not

