### PR TITLE
Acquisition era change to Run2024H

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -60,7 +60,7 @@ addSiteConfig(tier0Config, "T0_CH_CERN_Disk",
 #  Data type
 #  Processing site (where jobs run)
 #  PhEDEx locations
-setAcquisitionEra(tier0Config, "Run2024G")
+setAcquisitionEra(tier0Config, "Run2024H")
 setEmulationAcquisitionEra(tier0Config, "Emulation2024")
 setBaseRequestPriority(tier0Config, 251000)
 setBackfill(tier0Config, None)


### PR DESCRIPTION
Move Tier-0 production node to `Run2024H` as agreed upon in tha last JointOps meeting:
https://cms-talk.web.cern.ch/t/weekly-jointops-meeting-september-16th-2024-12h30-gva-unusual-time/48926