### PR TITLE
Configuration for CMSSW_14_0_16

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -123,7 +123,6 @@ alcaLumiPixelsScenario = "AlCaLumiPixels_Run3"
 alcaPPSScenario = "AlCaPPS_Run3"
 hiTestppScenario = "ppEra_Run3_pp_on_PbPb_2023"
 hiRawPrimeScenario = "ppEra_Run3_pp_on_PbPb_approxSiStripClusters_2023"
-hltScoutingScenario = "hltScoutingEra_Run3_2024"
 
 # Defaults for processing version
 alcarawProcVersion = {
@@ -1292,12 +1291,10 @@ for dataset in DATASETS:
 DATASETS = ["ScoutingPFRun3"]
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_aod=False,
-               write_miniaod=False,
+               do_reco=False,
                tape_node="T1_US_FNAL_MSS",
                disk_node="T1_US_FNAL_Disk",
-               scenario=hltScoutingScenario)
+               scenario=ppScenario)
 
 DATASETS = ["ParkingDoubleElectronLowMass","ParkingDoubleElectronLowMass0"]
 for dataset in DATASETS:

--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -101,7 +101,7 @@ setPromptCalibrationConfig(tier0Config,
 # maxRunPreviousConfig = 999999 # Last run before era change 08/09/23
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_14_0_15",
+    'default': "CMSSW_14_0_16",
     #'acqEra': {'Run2024F': "CMSSW_14_0_11"},
     #'maxRun': {maxRunPreviousConfig: "CMSSW_13_2_2"}
 }

--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -123,6 +123,7 @@ alcaLumiPixelsScenario = "AlCaLumiPixels_Run3"
 alcaPPSScenario = "AlCaPPS_Run3"
 hiTestppScenario = "ppEra_Run3_pp_on_PbPb_2023"
 hiRawPrimeScenario = "ppEra_Run3_pp_on_PbPb_approxSiStripClusters_2023"
+hltScoutingScenario = "hltScoutingEra_Run3_2024"
 
 # Defaults for processing version
 alcarawProcVersion = {
@@ -1291,10 +1292,10 @@ for dataset in DATASETS:
 DATASETS = ["ScoutingPFRun3"]
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,
-               do_reco=False,
+               do_reco=True,
                tape_node="T1_US_FNAL_MSS",
                disk_node="T1_US_FNAL_Disk",
-               scenario=ppScenario)
+               scenario=hltScoutingScenario)
 
 DATASETS = ["ParkingDoubleElectronLowMass","ParkingDoubleElectronLowMass0"]
 for dataset in DATASETS:

--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -1293,6 +1293,8 @@ DATASETS = ["ScoutingPFRun3"]
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,
                do_reco=True,
+               write_aod=False,
+               write_miniaod=False,
                tape_node="T1_US_FNAL_MSS",
                disk_node="T1_US_FNAL_Disk",
                scenario=hltScoutingScenario)

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -1188,6 +1188,8 @@ DATASETS = ["ScoutingPFRun3"]
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,
                do_reco=True,
+               write_aod=False,
+               write_miniaod=False,
                scenario=hltScoutingScenario)
 
 DATASETS = ["ParkingDoubleElectronLowMass0","ParkingDoubleElectronLowMass1","ParkingDoubleElectronLowMass2",

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -130,7 +130,7 @@ alcaLumiPixelsScenario = "AlCaLumiPixels_Run3"
 alcaPPSScenario = "AlCaPPS_Run3"
 hiTestppScenario = "ppEra_Run3_pp_on_PbPb_2023"
 hiRawPrimeScenario = "ppEra_Run3_pp_on_PbPb_approxSiStripClusters_2023"
-hltScoutingScenario = "hltScoutingEra_Run3_2024"
+
 # Procesing version number replays
 # Taking Replay processing ID from the last 8 digits of the DeploymentID
 dt = int(open("/data/tier0/DeploymentID.txt","r").read()[4:])
@@ -1187,10 +1187,8 @@ for dataset in DATASETS:
 DATASETS = ["ScoutingPFRun3"]
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,
-               do_reco=True,
-               write_aod=False,
-               write_miniaod=False,
-               scenario=hltScoutingScenario)
+               do_reco=False,
+               scenario=ppScenario)
 
 DATASETS = ["ParkingDoubleElectronLowMass0","ParkingDoubleElectronLowMass1","ParkingDoubleElectronLowMass2",
             "ParkingDoubleElectronLowMass3","ParkingDoubleElectronLowMass4","ParkingDoubleElectronLowMass5",

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -110,7 +110,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_14_0_15"
+    'default': "CMSSW_14_0_16"
 }
 
 # Configure ScramArch

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -130,7 +130,7 @@ alcaLumiPixelsScenario = "AlCaLumiPixels_Run3"
 alcaPPSScenario = "AlCaPPS_Run3"
 hiTestppScenario = "ppEra_Run3_pp_on_PbPb_2023"
 hiRawPrimeScenario = "ppEra_Run3_pp_on_PbPb_approxSiStripClusters_2023"
-
+hltScoutingScenario = "hltScoutingEra_Run3_2024"
 # Procesing version number replays
 # Taking Replay processing ID from the last 8 digits of the DeploymentID
 dt = int(open("/data/tier0/DeploymentID.txt","r").read()[4:])
@@ -1187,8 +1187,8 @@ for dataset in DATASETS:
 DATASETS = ["ScoutingPFRun3"]
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,
-               do_reco=False,
-               scenario=ppScenario)
+               do_reco=True,
+               scenario=hltScoutingScenario)
 
 DATASETS = ["ParkingDoubleElectronLowMass0","ParkingDoubleElectronLowMass1","ParkingDoubleElectronLowMass2",
             "ParkingDoubleElectronLowMass3","ParkingDoubleElectronLowMass4","ParkingDoubleElectronLowMass5",

--- a/src/python/T0/WMBS/Oracle/Create.py
+++ b/src/python/T0/WMBS/Oracle/Create.py
@@ -941,7 +941,8 @@ class Create(DBCreator):
                            48 : "ppEra_Run3_2023",
                            49 : "ppEra_Run3_pp_on_PbPb_2023",
                            50 : "ppEra_Run3_pp_on_PbPb_approxSiStripClusters_2023",
-                           51 : "ppEra_Run3_2023_repacked"
+                           51 : "ppEra_Run3_2023_repacked",
+                           52 : "hltScoutingEra_Run3_2024"
                          }
         for id, name in list(eventScenarios.items()):
             sql = """INSERT INTO event_scenario

--- a/src/python/T0/WMBS/Oracle/Create.py
+++ b/src/python/T0/WMBS/Oracle/Create.py
@@ -941,8 +941,7 @@ class Create(DBCreator):
                            48 : "ppEra_Run3_2023",
                            49 : "ppEra_Run3_pp_on_PbPb_2023",
                            50 : "ppEra_Run3_pp_on_PbPb_approxSiStripClusters_2023",
-                           51 : "ppEra_Run3_2023_repacked",
-                           52 : "hltScoutingEra_Run3_2024"
+                           51 : "ppEra_Run3_2023_repacked"
                          }
         for id, name in list(eventScenarios.items()):
             sql = """INSERT INTO event_scenario


### PR DESCRIPTION
# Replay Request

**Requestor**  
ORM

**Describe the configuration**  
* Release: CMSSW_14_0_16
* Run: 382686, 382726
* GTs: 
   * expressGlobalTag: 140X_dataRun3_Express_v3
   * promptrecoGlobalTag: 140X_dataRun3_Prompt_v4
* Additional changes:

**Purpose of the test**  
A replay test is costly, both in computational and human resources. Please describe the reason why this test is needed.

**T0 Operations cmsTalk thread**  
If necessary, provide a link to the cmsTalk thread announcing the test to the relevant groups. 
[Tier0 Operations cmsTalk Forum](https://cms-talk.web.cern.ch/c/offcomp/compops/tier0/210?)
