### PR TITLE
Production configuration for CMSSW_14_0_18

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -106,7 +106,7 @@ setPromptCalibrationConfig(tier0Config,
 # maxRunPreviousConfig = 999999 # Last run before era change 08/09/23
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_14_0_16",
+    'default': "CMSSW_14_0_18",
     #'acqEra': {'Run2024F': "CMSSW_14_0_11"},
     #'maxRun': {maxRunPreviousConfig: "CMSSW_13_2_2"}
 }
@@ -131,15 +131,15 @@ hiRawPrimeScenario = "ppEra_Run3_pp_on_PbPb_approxSiStripClusters_2023"
 
 # Defaults for processing version
 alcarawProcVersion = {
-    'default': 1
+    'default': 2
 }
 
 defaultProcVersionReco = {
-    'default': 1
+    'default': 2
 }
 
 expressProcVersion = {
-    'default': 1
+    'default': 2
 }
 
 # Defaults for GlobalTag

--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -42,10 +42,6 @@ setInjectMinRun(tier0Config, 9999999)
 # Set the max run number:
 setInjectMaxRun(tier0Config, 9999999)
 
-# Set streams to ignore by agent. These will not be injected by the MainAgent
-setHelperAgentStreams(tier0Config, {"SecondAgent" : [],
-                                      "ThirdAgent" : []})
-
 
 # Settings up sites
 processingSite = "T2_CH_CERN"
@@ -65,7 +61,7 @@ addSiteConfig(tier0Config, "T0_CH_CERN_Disk",
 #  Data type
 #  Processing site (where jobs run)
 #  PhEDEx locations
-setAcquisitionEra(tier0Config, "Run2024H")
+setAcquisitionEra(tier0Config, "Run2024I")
 setEmulationAcquisitionEra(tier0Config, "Emulation2024")
 setBaseRequestPriority(tier0Config, 251000)
 setBackfill(tier0Config, None)

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -39,8 +39,9 @@ setConfigVersion(tier0Config, "replace with real version")
 # Set run number to replay
 # 382726  Cosmics, 4 hours
 # 382686 - Collisions, 43.3 pb-1, 23.9583 TB NEW
+# 386674  Cosmics ~40 minutes in Run2024I with occupancy issues
 
-setInjectRuns(tier0Config, [382686, 382726])
+setInjectRuns(tier0Config, [382686, 382726, 386674])
 
 # Use this in order to limit the number of lumisections to process
 #setInjectLimit(tier0Config, 10)
@@ -116,7 +117,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_14_0_16"
+    'default': "CMSSW_14_0_18"
 }
 
 # Configure ScramArch

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -37,11 +37,10 @@ tier0Config = createTier0Config()
 setConfigVersion(tier0Config, "replace with real version")
 
 # Set run number to replay
-# 382726  Cosmics, 4 hours
 # 382686 - Collisions, 43.3 pb-1, 23.9583 TB NEW
 # 386674  Cosmics ~40 minutes in Run2024I with occupancy issues
 
-setInjectRuns(tier0Config, [382686, 382726, 386674])
+setInjectRuns(tier0Config, [382686, 386674])
 
 # Use this in order to limit the number of lumisections to process
 #setInjectLimit(tier0Config, 10)


### PR DESCRIPTION
Based on the successful output of the replay #5000 

https://cms-talk.web.cern.ch/t/replay-request-for-cmssw-14-0-18/52367/3 

I propose the update of the production configuration to CMSSW_14_0_18
The processing version is moved forward to 2, as there is a change in the behaviour of the cosmics processing, and the DQM output is also modified.