### PR TITLE
cscMonitor sequence test

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -253,7 +253,7 @@ addExpressConfig(tier0Config, "Express",
                                  "PromptCalibProdSiPixelLA", "PromptCalibProdSiStripHitEff", "PromptCalibProdSiPixelAliHG",
                                  "PromptCalibProdSiPixelAliHGComb"
                                 ],
-                 dqm_sequences=["@standardDQMExpress"],
+                 dqm_sequences=["@standardDQMExpress+cscMonitor"],
                  reco_version=defaultCMSSWVersion,
                  multicore=numberOfCores,
                  global_tag_connect=globalTagConnect,

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -46,7 +46,7 @@ setInjectRuns(tier0Config, [382686, 386674])
 #setInjectLimit(tier0Config, 10)
 
 # Define streams to ignore. These wont be injected by the MainAgent
-setHelperAgentStreams(tier0Config, {'SecondAgent': [],
+setHelperAgentStreams(tier0Config, {'SecondAgent': ["Express"],
                                     'ThirdAgent' : []
                                     })
 
@@ -246,7 +246,7 @@ addExpressConfig(tier0Config, "Express",
                                  "PromptCalibProdSiPixelLA", "PromptCalibProdSiStripHitEff", "PromptCalibProdSiPixelAliHG",
                                  "PromptCalibProdSiPixelAliHGComb"
                                 ],
-                 dqm_sequences=["@standardDQMExpress"],
+                 dqm_sequences=["@standardDQMExpress+cscMonitor"],
                  reco_version=defaultCMSSWVersion,
                  multicore=numberOfCores,
                  global_tag_connect=globalTagConnect,


### PR DESCRIPTION
# Replay Request

**Requestor**  
ORM @fabiocos 

**Describe the configuration**  
* Release: 
* Run: 
* GTs:
   * expressGlobalTag: 
   * promptrecoGlobalTag:
* Additional changes:

**Purpose of the test**  
A replay test is costly, both in computational and human resources. Please describe the reason why this test is needed.

**T0 Operations cmsTalk thread**  
If necessary, provide a link to the cmsTalk thread announcing the test to the relevant groups. 
[Tier0 Operations cmsTalk Forum](https://cms-talk.web.cern.ch/c/offcomp/compops/tier0/210?)
