### PR TITLE
Enable AgentStatusWatcher to monitor site resources

### DIFF
--- a/bin/00_pypi_resource_control.sh
+++ b/bin/00_pypi_resource_control.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 #Settings for using T0_CH_CERN_Disk
-manage execute-agent wmagent-resource-control --site-name=T2_CH_CERN --cms-name=T2_CH_CERN --pnn=T0_CH_CERN_Disk --ce-name=T2_CH_CERN --pending-slots=20000 --running-slots=20000 --plugin=SimpleCondorPlugin
-manage execute-agent wmagent-resource-control --site-name=T0_CH_CERN_Disk --cms-name=T0_CH_CERN_Disk --pnn=T2_CH_CERN --ce-name=T0_CH_CERN_Disk --pending-slots=20000 --running-slots=20000 --plugin=SimpleCondorPlugin
+manage execute-agent wmagent-resource-control --site-name=T0_CH_CERN_Disk --pnn=T2_CH_CERN --pending-slots=20000 --running-slots=20000 --plugin=SimpleCondorPlugin
+manage execute-agent wmagent-resource-control --site-name=T2_CH_CERN --pnn=T0_CH_CERN_Disk --pending-slots=20000 --running-slots=20000 --plugin=SimpleCondorPlugin
 manage execute-agent wmagent-resource-control --site-name=T2_CH_CERN --task-type=Processing --pending-slots=10000 --running-slots=10000
 manage execute-agent wmagent-resource-control --site-name=T2_CH_CERN --task-type=Merge --pending-slots=1000 --running-slots=1000
 manage execute-agent wmagent-resource-control --site-name=T2_CH_CERN --task-type=Cleanup --pending-slots=1000 --running-slots=1000
@@ -14,7 +14,7 @@ manage execute-agent wmagent-resource-control --site-name=T2_CH_CERN --task-type
 manage execute-agent wmagent-resource-control --site-name=T2_CH_CERN --task-type=Repack --pending-slots=5000 --running-slots=5000
 
 #Settings for using T2_CH_CERN_P5 (PromptReco)
-manage execute-agent wmagent-resource-control --site-name=T2_CH_CERN_P5 --cms-name=T2_CH_CERN_P5 --pnn=T2_CH_CERN_P5 --ce-name=T2_CH_CERN_P5 --pending-slots=20000 --running-slots=20000 --plugin=SimpleCondorPlugin
+manage execute-agent wmagent-resource-control --site-name=T2_CH_CERN_P5 --pnn=T2_CH_CERN_P5 --pending-slots=20000 --running-slots=20000 --plugin=SimpleCondorPlugin
 manage execute-agent wmagent-resource-control --site-name=T2_CH_CERN_P5 --task-type=Processing --pending-slots=10000 --running-slots=10000
 manage execute-agent wmagent-resource-control --site-name=T2_CH_CERN_P5 --task-type=Merge --pending-slots=1000 --running-slots=1000
 manage execute-agent wmagent-resource-control --site-name=T2_CH_CERN_P5 --task-type=Cleanup --pending-slots=1000 --running-slots=1000

--- a/bin/t0
+++ b/bin/t0
@@ -131,10 +131,8 @@ def addProcessingSite(site=None):
     _resourceControl_
     Adds site to the resource control
     """
-    command_1 = "manage execute-agent wmagent-resource-control --site-name={} --cms-name={} --pnn={} --ce-name={} --pending-slots=20000 --running-slots=20000 --plugin=SimpleCondorPlugin".format(site, site, site, site)
-    command_2 = "manage execute-agent wmagent-resource-control --site-name={} --task-type=Processing --pending-slots=10000 --running-slots=10000".format(site)
-    os.system(command_1)
-    os.system(command_2)
+    addSiteCmd = f"manage execute-agent wmagent-resource-control --pending-slots=10000 --running-slots=10000 --plugin=SimpleCondorPlugin --add-one-site {site}"
+    os.system(addSiteCmd)
 
 def modifyCodeFile(file=None):
     """

--- a/etc/Tier0Config.py
+++ b/etc/Tier0Config.py
@@ -54,7 +54,7 @@ config.AgentStatusWatcher.pendingSlotsTaskPercent = 30
 config.AgentStatusWatcher.pendingSlotsSitePercent = 40
 config.AgentStatusWatcher.runningExpressPercent = 25
 config.AgentStatusWatcher.runningRepackPercent = 10
-config.AgentStatusWatcher.enabled = False
+config.AgentStatusWatcher.enabled = True
 config.AgentStatusWatcher.onlySSB = False
 
 config.RucioInjector.blockRuleParams = {}


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/12121

Summary of changes are:
* Enable AgentStatusWatcher to monitor and automatically take actions on resources in the resource-control table;
* minor changes on how a site gets added to the resource-control
* remove no longer needed parameters when adding a new site to the resource control.

@germanfgv @LinaresToine on what concerns some specific tasks for the CERN sites, do you really have to set their thresholds to 1? Or is it potentially just a leftover? If that level of configuration is needed, then I don't think we can improve that.

Please let me know what you think about these changes. If you think they are looking good, then I would suggest to install an agent with these changes in and see how it behaves.