### PR TITLE
CMSSW_14_1_4_patch1

### DIFF
--- a/etc/HIProdOfflineConfiguration.py
+++ b/etc/HIProdOfflineConfiguration.py
@@ -95,7 +95,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_14_1_3",
+    'default': "CMSSW_14_1_4_patch1",
 }
 
 # Configure ScramArch

--- a/etc/HIReplayOfflineConfiguration.py
+++ b/etc/HIReplayOfflineConfiguration.py
@@ -111,7 +111,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_14_1_3"
+    'default': "CMSSW_14_1_4_patch1"
 }
 
 # Configure ScramArch

--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -101,7 +101,7 @@ setPromptCalibrationConfig(tier0Config,
 # maxRunPreviousConfig = 999999 # Last run before era change 08/09/23
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_14_1_3",
+    'default': "CMSSW_14_1_4_patch1",
     #'acqEra': {'Run2024F': "CMSSW_14_0_11"},
     #'maxRun': {maxRunPreviousConfig: "CMSSW_13_2_2"}
 }

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -111,7 +111,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_14_1_3"
+    'default': "CMSSW_14_1_4_patch1"
 }
 
 # Configure ScramArch


### PR DESCRIPTION
# Replay Request

**Requestor**  
ORM

**Describe the configuration** 
HI replay 
* Release: CMSSW_14_1_4_patch1
* Run: 374951, 375549
* GTs:
   * expressGlobalTag: 141X_dataRun3_Express_v3
   * promptrecoGlobalTag: 141X_dataRun3_Prompt_v3
* Additional changes: 

pp collisions for ppref replay
* Release: CMSSW_14_1_4_patch1
* Run: 382686, 386674
* GTs:
   * expressGlobalTag: 141X_dataRun3_Express_v3
   * promptrecoGlobalTag: 141X_dataRun3_Prompt_v3
* Additional changes: 

**Purpose of the test**  
Test CMSSW_14_1_4_patch1

**T0 Operations cmsTalk thread**  
If necessary, provide a link to the cmsTalk thread announcing the test to the relevant groups. 
[Tier0 Operations cmsTalk Forum](https://cms-talk.web.cern.ch/c/offcomp/compops/tier0/210?)
