### PR TITLE
Update HIForwardX splitting parameters

### DIFF
--- a/etc/HIProdOfflineConfiguration.py
+++ b/etc/HIProdOfflineConfiguration.py
@@ -166,7 +166,7 @@ numberOfCores = 8
 
 # Splitting parameters for PromptReco
 defaultRecoSplitting = 750 * numberOfCores
-forwardRecoSplitting = 2000 * numberOfCores
+forwardRecoSplitting = 9000 * numberOfCores # 0.6ev/core/s * 4h = 9000ev/core
 hiRecoSplitting = 200 * numberOfCores
 alcarawSplitting = 20000 * numberOfCores
 
@@ -1605,7 +1605,7 @@ for dataset in DATASETS:
     addDataset(tier0Config, dataset,
                do_reco=True,
                #reco_delay=defaultRecoTimeout*100,
-               timePerEvent=1,
+               timePerEvent=0.2,
                raw_to_disk=False,
                aod_to_disk=True,
                write_nanoaod=False,
@@ -1640,7 +1640,7 @@ for dataset in DATASETS:
     addDataset(tier0Config, dataset,
                do_reco=True,
                #reco_delay=defaultRecoTimeout*100,
-               timePerEvent=1,
+               timePerEvent=0.2,
                raw_to_disk=False,
                aod_to_disk=True,
                write_nanoaod=False,

--- a/etc/HIReplayOfflineConfiguration.py
+++ b/etc/HIReplayOfflineConfiguration.py
@@ -155,7 +155,7 @@ numberOfCores = 8
 
 # Splitting parameters for PromptReco
 defaultRecoSplitting = 750 * numberOfCores
-forwardRecoSplitting = 2000 * numberOfCores
+forwardRecoSplitting = 9000 * numberOfCores
 hiRecoSplitting = 200 * numberOfCores
 alcarawSplitting = 20000 * numberOfCores
 
@@ -1532,7 +1532,7 @@ for dataset in DATASETS:
     addDataset(tier0Config, dataset,
                do_reco=True,
                #reco_delay=defaultRecoTimeout*100,
-               timePerEvent=1,
+               timePerEvent=0.2,
                raw_to_disk=False,
                aod_to_disk=True,
                write_nanoaod=False,
@@ -1558,7 +1558,7 @@ DATASETS = ["HIForward1", "HIForward2",
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,
                do_reco=True,
-               timePerEvent=1,
+               timePerEvent=0.2,
                raw_to_disk=False,
                aod_to_disk=True,
                write_nanoaod=False,


### PR DESCRIPTION
In 2023, the average HI job duration was well bellow 1h. These small jobs are computationally inefficient, and and put extra pressure on T0 Agent components. To avoid this situation in 2024, we are updating HIForward splitting to avoid the creation of too many short jobs. 

The new values are based in this data collected last year:
[HIForward Job Statistics HIRun2023A](https://monit-grafana.cern.ch/d/N98hKcw4z/cms-tier0-job-statistics?orgId=11&from=1694901600000&to=1700261999000&var-era=HIRun2023A&var-run_type=collisions_hi&var-request_type=PromptReco&var-job_type=Processing&var-stream_PD=HIForward0&var-stream_PD=HIForward1&var-stream_PD=HIForward10&var-stream_PD=HIForward11&var-stream_PD=HIForward12&var-stream_PD=HIForward13&var-stream_PD=HIForward14&var-stream_PD=HIForward15&var-stream_PD=HIForward16&var-stream_PD=HIForward3&var-stream_PD=HIForward2&var-stream_PD=HIForward19&var-stream_PD=HIForward18&var-stream_PD=HIForward17&var-stream_PD=HIForward4&var-stream_PD=HIForward5&var-stream_PD=HIForward6&var-stream_PD=HIForward7&var-stream_PD=HIForward8&var-stream_PD=HIForward9)

This shows an average 0.2s/event in 8-cores jobs (1.6s/ev/core). With a target job job duration of 4h, that means each core can take care of 9000 events. We are using this value to set `forwardRecoSplitting`, which is passed to [`EventAwareLumiBased`](https://github.com/dmwm/WMCore/blob/master/src/python/WMCore/JobSplitting/EventAwareLumiBased.py) as `events_per_job`.
