### PR TITLE
Test TkAlV0s for the HIMinimumBias datasets

### DIFF
--- a/etc/HIProdOfflineConfiguration.py
+++ b/etc/HIProdOfflineConfiguration.py
@@ -1666,7 +1666,7 @@ for dataset in DATASETS:
                write_dqm=True,
                tape_node="T0_CH_CERN_MSS",
                disk_node="T2_US_Vanderbilt",
-               alca_producers=["SiStripCalZeroBias", "SiStripCalMinBias", "TkAlMinBias"],
+               alca_producers=["SiStripCalZeroBias", "SiStripCalMinBias", "TkAlMinBias", "TkAlV0s"],
                dqm_sequences=["@commonSiStripZeroBias"],
                scenario=hiScenario)
     
@@ -1689,7 +1689,7 @@ for dataset in DATASETS:
                write_dqm=True,
                tape_node="T0_CH_CERN_MSS",
                disk_node="T2_US_Vanderbilt",
-               alca_producers=["SiStripCalZeroBias"],
+               alca_producers=["SiStripCalZeroBias", "TkAlV0s"],
                dqm_sequences=["@commonSiStripZeroBias"],
                scenario=hiScenario)
 

--- a/etc/HIReplayOfflineConfiguration.py
+++ b/etc/HIReplayOfflineConfiguration.py
@@ -39,7 +39,7 @@ setConfigVersion(tier0Config, "3.2.3")
 # Set run number to replay
 # 374951:    HI 2023 3.8 TB
 # 387456:    Test HI 2024 with memory problems 3.1 TB
-setInjectRuns(tier0Config, [374951, 387456])
+setInjectRuns(tier0Config, [387963])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"
@@ -1580,7 +1580,7 @@ for dataset in DATASETS:
                raw_to_disk=False,
                write_nanoaod=False,
                write_dqm=True,
-               alca_producers=["SiStripCalZeroBias", "SiStripCalMinBias", "TkAlMinBias"],
+               alca_producers=["SiStripCalZeroBias", "SiStripCalMinBias", "TkAlMinBias", "TkAlV0s"],
                dqm_sequences=["@commonSiStripZeroBias"],
                scenario=hiScenario)
     
@@ -1596,7 +1596,7 @@ for dataset in DATASETS:
                raw_to_disk=False,
                write_nanoaod=False,
                write_dqm=True,
-               alca_producers=["SiStripCalZeroBias"],
+               alca_producers=["SiStripCalZeroBias", "TkAlV0s"],
                dqm_sequences=["@commonSiStripZeroBias"],
                scenario=hiScenario)
 


### PR DESCRIPTION
# Replay Request

**Requestor**  
AlCaSB

**Describe the configuration**  
* Release: CMSSW_14_1_4_patch5
* Run: 387963
* GTs:
   * expressGlobalTag: 141X_dataRun3_Express_v3
   * promptrecoGlobalTag: 141X_dataRun3_Prompt_v3
* Additional changes:
   * Add `TkAlV0s` as `alca_producer` to `HIMinimumBias` PDs 

**Purpose of the test**  
This AlCa skim will be necessary for HI Run calibration

**T0 Operations cmsTalk thread**  
[Tier0 Operations cmsTalk Forum](https://cms-talk.web.cern.ch/t/heavy-ion-preparation-replay-for-cmssw-14-1-3/54212/7?u=ggiraldo)
