### PR TITLE
Potential era change to HiRun2024B

### DIFF
--- a/etc/HIProdOfflineConfiguration.py
+++ b/etc/HIProdOfflineConfiguration.py
@@ -60,7 +60,7 @@ addSiteConfig(tier0Config, "T0_CH_CERN_Disk",
 #  Data type
 #  Processing site (where jobs run)
 #  PhEDEx locations
-setAcquisitionEra(tier0Config, "HIRun2024A")
+setAcquisitionEra(tier0Config, "HIRun2024B")
 setEmulationAcquisitionEra(tier0Config, "Emulation2024")
 setBaseRequestPriority(tier0Config, 251000)
 setBackfill(tier0Config, None)

--- a/etc/HIProdOfflineConfiguration.py
+++ b/etc/HIProdOfflineConfiguration.py
@@ -1817,30 +1817,10 @@ for dataset in DATASETS:
                scenario=hiRawPrimeScenario)
     
 
-DATASETS = ["HIPhysicsRawPrime2", "HIPhysicsRawPrime3", 
+DATASETS = [  "HIPhysicsRawPrime2", "HIPhysicsRawPrime3", 
               "HIPhysicsRawPrime4", "HIPhysicsRawPrime5", "HIPhysicsRawPrime6", "HIPhysicsRawPrime7", 
               "HIPhysicsRawPrime8", "HIPhysicsRawPrime9", "HIPhysicsRawPrime10", "HIPhysicsRawPrime11", 
-              "HIPhysicsRawPrime12", "HIPhysicsRawPrime13", "HIPhysicsRawPrime14"] 
-                                       
-for dataset in DATASETS:
-    addDataset(tier0Config, dataset,
-               do_reco=True,
-               raw_to_disk=False,
-               aod_to_disk=False,
-               timePerEvent=3,
-               write_nanoaod=False,
-               write_dqm=False,
-               tape_node="T0_CH_CERN_MSS",
-               disk_node="T2_US_Vanderbilt",
-               alca_producers=["EcalUncalZElectron", "EcalUncalWElectron", "EcalESAlign", "MuAlCalIsolatedMu", 
-                               "TkAlDiMuonAndVertex", "HcalCalHO", "HcalCalIsoTrkProducerFilter", "HcalCalHBHEMuonProducerFilter",
-                               "SiStripCalZeroBias", "HcalCalIsolatedBunchSelector", "HcalCalIterativePhiSym","HcalCalMinBias",
-                               "TkAlJpsiMuMu", "TkAlUpsilonMuMu","TkAlZMuMu","TkAlMuonIsolated"],
-               dqm_sequences=["@none"],
-               physics_skims=["PbPbEMu", "PbPbZEE", "PbPbZMu", "PbPbHighPtJets", "LogError", "LogErrorMonitor"],
-               scenario=hiRawPrimeScenario)
-
-DATASETS = [ "HIPhysicsRawPrime15", 
+              "HIPhysicsRawPrime12", "HIPhysicsRawPrime13", "HIPhysicsRawPrime14", "HIPhysicsRawPrime15", 
               "HIPhysicsRawPrime16", "HIPhysicsRawPrime17", "HIPhysicsRawPrime18", "HIPhysicsRawPrime19", 
               "HIPhysicsRawPrime20", "HIPhysicsRawPrime21", "HIPhysicsRawPrime22", "HIPhysicsRawPrime23", 
               "HIPhysicsRawPrime24", "HIPhysicsRawPrime25", "HIPhysicsRawPrime26", "HIPhysicsRawPrime27", 
@@ -1852,10 +1832,10 @@ DATASETS = [ "HIPhysicsRawPrime15",
               "HIPhysicsRawPrime48", "HIPhysicsRawPrime49", "HIPhysicsRawPrime50", "HIPhysicsRawPrime51", 
               "HIPhysicsRawPrime52", "HIPhysicsRawPrime53", "HIPhysicsRawPrime54", "HIPhysicsRawPrime55", 
               "HIPhysicsRawPrime56", "HIPhysicsRawPrime57", "HIPhysicsRawPrime58", "HIPhysicsRawPrime59"]
-
+                                  
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,
-               do_reco=False, #To be changed to False in HIRun2024B
+               do_reco=True,
                raw_to_disk=False,
                aod_to_disk=False,
                timePerEvent=3,


### PR DESCRIPTION
Potential era change to `HIRun2024B` in order to prompt reconstruct all HIPhysicsRawPrime datasets, which were not being reconstructed because of potential lack of disk space to handle all the data. With a week of HI gone by, we re-evaluate the situation and perhaps we can handle all of it. To be followed up on Thursday during the meeting.

@germanfgv @jeyserma 
