### PR TITLE
Support dbs block metadata in t0datasvc

### DIFF
--- a/src/python/T0/WMBS/Oracle/T0DataSvc/GetDbsbufferBlocks.py
+++ b/src/python/T0/WMBS/Oracle/T0DataSvc/GetDbsbufferBlocks.py
@@ -1,0 +1,27 @@
+"""
+_GetDbsbufferBlocks_
+
+Oracle implementation of GetDbsbufferBlocks
+
+Returns all blocks and dbs status with their corresponding dataset and acquisition era
+
+"""
+
+from WMCore.Database.DBFormatter import DBFormatter
+
+class GetDbsbufferBlocks(DBFormatter):
+
+    def execute(self, conn = None, transaction = False):
+
+        sql = """SELECT dbsbuffer_block.blockname as block,
+                        dbsbuffer_dataset.acquisition_era as acq_era,
+                        dbsbuffer_block.status as status 
+                 FROM dbsbuffer_block
+                 INNER JOIN dbsbuffer_dataset ON dbsbuffer_dataset.id = dbsbuffer_block.dataset_id
+                 WHERE checkForZeroState(dbsbuffer_block.in_datasvc) = 0
+                 """
+
+        results = self.dbi.processData(sql, binds = {}, conn = conn,
+                                       transaction = transaction)
+
+        return self.formatDict(results)

--- a/src/python/T0/WMBS/Oracle/T0DataSvc/InsertDbsbufferBlocks.py
+++ b/src/python/T0/WMBS/Oracle/T0DataSvc/InsertDbsbufferBlocks.py
@@ -1,0 +1,28 @@
+"""
+_InsertDbsbufferBlocks_
+
+Oracle implementation of InsertExpressConfigs
+
+Insert dbs blocks into Tier0 Data Service
+
+"""
+
+from WMCore.Database.DBFormatter import DBFormatter
+
+class InsertDbsbufferBlocks(DBFormatter):
+
+    def execute(self, binds, conn = None, transaction = False):
+
+        sql = """MERGE INTO dbsbuffer_block
+                 USING DUAL ON ( block = :BLOCK )
+                 WHEN MATCHED THEN
+                   UPDATE SET status = :STATUS
+                 WHEN NOT MATCHED THEN
+                   INSERT (block, acq_era, status)
+                   VALUES (:BLOCK, :ACQ_ERA, :STATUS)
+                 """
+
+        self.dbi.processData(sql, binds, conn = conn,
+                             transaction = transaction)
+
+        return


### PR DESCRIPTION
This PR works in parallel to https://github.com/dmwm/t0wmadatasvc/pull/50 to provide the support requested in https://its.cern.ch/jira/browse/CMSTZDEV-812?filter=-1