### PR TITLE
Commissioning2025-ProductionFile

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -60,7 +60,7 @@ addSiteConfig(tier0Config, "T0_CH_CERN_Disk",
 #  Data type
 #  Processing site (where jobs run)
 #  PhEDEx locations
-setAcquisitionEra(tier0Config, "Run2024J")
+setAcquisitionEra(tier0Config, "Commissioning2025")
 setEmulationAcquisitionEra(tier0Config, "Emulation2024")
 setBaseRequestPriority(tier0Config, 251000)
 setBackfill(tier0Config, None)
@@ -101,7 +101,7 @@ setPromptCalibrationConfig(tier0Config,
 # maxRunPreviousConfig = 999999 # Last run before era change 08/09/23
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_14_1_3",
+    'default': "CMSSW_14_1_5_patch1",
     #'acqEra': {'Run2024F': "CMSSW_14_0_11"},
     #'maxRun': {maxRunPreviousConfig: "CMSSW_13_2_2"}
 }


### PR DESCRIPTION
Era change to Commissioning2025.

Pending updates:
* CMSSW version
   * Currently CMSSW_14_1_3
   * To change to CMSSW_15_0_X after test
* Global tags to 15_0_X
* Scenarios to 2025
* Primary Dataset configurations
