### PR TITLE
Allow express merge task to have configurable memory

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -268,6 +268,7 @@ addExpressConfig(tier0Config, "Express",
                  timePerEvent=4,
                  sizePerEvent=1700,
                  maxMemoryperCore=2000,
+                 mergeTaskMemory=3.0 * 1024,
                  dataset_lifetime=12*30*24*3600,#lifetime for container rules. Default 12 months
                  versionOverride=expressVersionOverride)
 

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -255,6 +255,7 @@ addExpressConfig(tier0Config, "Express",
                  timePerEvent=4,
                  sizePerEvent=1700,
                  maxMemoryperCore=2000,
+                 mergeTaskMemory=3.0 # Value in GiB, later changed to MiB in WMCore function addRuntimeMonitors()
                  dataset_lifetime=14*24*3600,#lifetime for container rules. Default 14 days
                  versionOverride=expressVersionOverride)
 

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -255,7 +255,7 @@ addExpressConfig(tier0Config, "Express",
                  timePerEvent=4,
                  sizePerEvent=1700,
                  maxMemoryperCore=2000,
-                 mergeTaskMemory=3.0 # Value in GiB, later changed to MiB in WMCore function addRuntimeMonitors()
+                 mergeTaskMemory=3.0 * 1024,
                  dataset_lifetime=14*24*3600,#lifetime for container rules. Default 14 days
                  versionOverride=expressVersionOverride)
 

--- a/src/python/T0/RunConfig/RunConfigAPI.py
+++ b/src/python/T0/RunConfig/RunConfigAPI.py
@@ -618,6 +618,7 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
                 specArguments['Multicore'] = streamConfig.Express.Multicore
                 specArguments['Memory'] += (streamConfig.Express.Multicore - 1) * streamConfig.Express.MaxMemoryperCore
 
+            specArguments['MergeTaskMemory'] = streamConfig.Express.mergeTaskMemory
             specArguments['Requestor'] = "Tier0"
             specArguments['RequestName'] = workflowName
             specArguments['RequestString'] = workflowName


### PR DESCRIPTION
This patch goes in hand with https://github.com/dmwm/WMCore/pull/12227 to allow configurable memory value in express merge tasks.
