### PR TITLE
Preparing configuration for CMSSW 150X

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -123,7 +123,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_14_1_5_patch1"
+    'default': "CMSSW_15_0_0"
 }
 
 # Configure ScramArch
@@ -155,8 +155,8 @@ alcarawProcVersion = dt
 
 # Defaults for GlobalTag
 
-expressGlobalTag = "141X_dataRun3_Express_v3"
-promptrecoGlobalTag = "141X_dataRun3_Express_v3"
+expressGlobalTag = "150X_dataRun3_Express_v1"
+promptrecoGlobalTag = "150X_dataRun3_Prompt_v1"
 
 
 # Mandatory for CondDBv2
@@ -310,7 +310,7 @@ addExpressConfig(tier0Config, "HLTMonitor",
                  diskNode="T0_CH_CERN_Disk",
                  data_tiers=["FEVTHLTALL"],
                  write_dqm=True,
-                 alca_producers=[],
+                 alca_producers=["TkAlHLTTracks", "TkAlHLTTracksZMuMu", "PromptCalibProdSiPixelAliHLTHGC"],
                  dqm_sequences=["@HLTMon"],
                  reco_version=defaultCMSSWVersion,
                  multicore=numberOfCores,


### PR DESCRIPTION
With T0 replay configuration reverted to 141X in https://github.com/dmwm/T0/pull/5033, this PR keeps track of the tested alca producers specified in [Replay CMSSW_15_0_0_pre1](https://cms-talk.web.cern.ch/t/replay-request-in-cmssw-15-0-0-pre1/93422), as well as the global tags mentioned in [replay CMSSW_15_0_0_pre1 comment](https://github.com/dmwm/T0/pull/5029#discussion_r1922509066).


