### PR TITLE
Change CMS HLT DB account

### DIFF
--- a/src/python/T0/StorageManager/StorageManagerAPI.py
+++ b/src/python/T0/StorageManager/StorageManagerAPI.py
@@ -45,10 +45,6 @@ def injectNewData(dbInterfaceStorageManager,
                                           logger = logging,
                                           dbinterface = dbInterfaceStorageManager)
 
-    daoFactoryHltConf = DAOFactory(package = "T0.WMBS",
-                                   logger = logging,
-                                   dbinterface = dbInterfaceHltConf)
-
     insertFileStatusDAO = None
     if dbInterfaceSMNotify:
         daoFactorySMNotify = DAOFactory(package = "T0.WMBS",
@@ -57,7 +53,7 @@ def injectNewData(dbInterfaceStorageManager,
         insertFileStatusDAO = daoFactorySMNotify(classname = "SMNotification.InsertOfflineFileStatus")
 
     getNewDataDAO = daoFactoryStorageManager(classname = "StorageManager.GetNewData")
-    getRunInfoDAO = daoFactoryHltConf(classname = "StorageManager.GetRunInfo")
+    getRunInfoDAO = daoFactoryStorageManager(classname = "StorageManager.GetRunInfo")
     getRunSetup = daoFactoryStorageManager(classname = "StorageManager.GetRunSetup")
     insertRunDAO = daoFactory(classname = "RunConfig.InsertRun")
     insertStreamDAO = daoFactory(classname = "RunConfig.InsertStream")


### PR DESCRIPTION
We have a new ```CMS_HLT_T0_R``` account to read the necessary info from the HLT database:

```
cms_hlt_gdr.u_streams
cms_hlt_gdr.u_datasets
cms_hlt_gdr.u_paths
cms_hlt_gdr.u_confversions
cms_hlt_gdr.u_pathid2strdst
cms_hlt_gdr.u_streamids
cms_hlt_gdr.u_datasetids
cms_hlt_gdr.u_pathids
cms_hlt_gdr.u_pathid2conf
cms_hlt_gdr.u_conf2strdst
```

Previously this account also reads the ```CMS_OMS``` and ```CMS_RUNINFO``` tables, but with this PR it is changed to the SMDB account which also has access to these tables.

We also need to update the SECRETS file in our agents with the new HLT credentials.