### PR TITLE
Revert "CosmicsHLTMonitor is Express PD"

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -312,31 +312,6 @@ addExpressConfig(tier0Config, "HLTMonitor",
                  diskNode="T2_CH_CERN",
                  data_tiers=["FEVTHLTALL"],
                  write_dqm=True,
-                 alca_producers=["TkAlHLTTracks", "TkAlHLTTracksZMuMu", "PromptCalibProdSiPixelAliHLTHGC"],
-                 dqm_sequences=["@HLTMon"],
-                 reco_version=defaultCMSSWVersion,
-                 multicore=numberOfCores,
-                 global_tag_connect=globalTagConnect,
-                 global_tag=expressGlobalTag,
-                 proc_ver=expressProcVersion,
-                 maxInputRate=23 * 1000,
-                 maxInputEvents=400,
-                 maxInputSize=2 * 1024 * 1024 * 1024,
-                 maxInputFiles=15,
-                 maxLatency=15 * 23,
-                 periodicHarvestInterval=20 * 60,
-                 blockCloseDelay=1200,
-                 timePerEvent=4, #I have to get some stats to set this properly
-                 sizePerEvent=1700, #I have to get some stats to set this properly
-                 maxMemoryperCore=2000,
-                 dataset_lifetime=3*30*24*3600,#lifetime for container rules. Default 3 months
-                 versionOverride=expressVersionOverride)
-
-addExpressConfig(tier0Config, "CosmicHLTMonitor",
-                 scenario=cosmicsScenario,
-                 diskNode="T2_CH_CERN",
-                 data_tiers=["FEVTHLTALL"],
-                 write_dqm=True,
                  alca_producers=[],
                  dqm_sequences=["@HLTMon"],
                  reco_version=defaultCMSSWVersion,
@@ -547,6 +522,21 @@ for dataset in DATASETS:
                write_dqm=True,
                alca_producers=["SiStripCalCosmics", "SiPixelCalCosmics", "TkAlCosmics0T", "MuAlGlobalCosmics", "SiStripCalCosmicsNano"],
                physics_skims=["CosmicSP", "CosmicTP", "LogError", "LogErrorMonitor"],
+               timePerEvent=0.5,
+               sizePerEvent=155,
+               scenario=cosmicsScenario)
+
+DATASETS = ["CosmicsHLTMonitor"]
+
+for dataset in DATASETS:
+    addDataset(tier0Config, dataset,
+               do_reco=True,
+               write_reco=False,
+               write_aod=True,
+               write_miniaod=False,
+               write_nanoaod=False,
+               write_dqm=True,
+               dqm_sequences=["@HLTMon"],
                timePerEvent=0.5,
                sizePerEvent=155,
                scenario=cosmicsScenario)

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -327,31 +327,6 @@ addExpressConfig(tier0Config, "HLTMonitor",
                  timePerEvent=4, #I have to get some stats to set this properly
                  sizePerEvent=1700, #I have to get some stats to set this properly
                  maxMemoryperCore=2000,
-                 dataset_lifetime=replayDatasetLifetime,#lifetime for container rules. Default 3 months
-                 versionOverride=expressVersionOverride)
-
-addExpressConfig(tier0Config, "CosmicHLTMonitor",
-                 scenario=cosmicsScenario,
-                 diskNode="T0_CH_CERN_Disk",
-                 data_tiers=["FEVTHLTALL"],
-                 write_dqm=True,
-                 alca_producers=[],
-                 dqm_sequences=["@HLTMon"],
-                 reco_version=defaultCMSSWVersion,
-                 multicore=numberOfCores,
-                 global_tag_connect=globalTagConnect,
-                 global_tag=expressGlobalTag,
-                 proc_ver=expressProcVersion,
-                 maxInputRate=23 * 1000,
-                 maxInputEvents=400,
-                 maxInputSize=2 * 1024 * 1024 * 1024,
-                 maxInputFiles=15,
-                 maxLatency=15 * 23,
-                 periodicHarvestInterval=20 * 60,
-                 blockCloseDelay=1200,
-                 timePerEvent=4, #I have to get some stats to set this properly
-                 sizePerEvent=1700, #I have to get some stats to set this properly
-                 maxMemoryperCore=2000,
                  dataset_lifetime=replayDatasetLifetime,#lifetime for container rules. Default 14 days
                  versionOverride=expressVersionOverride)
 
@@ -540,6 +515,21 @@ for dataset in DATASETS:
                write_dqm=True,
                alca_producers=["SiStripCalCosmics", "SiPixelCalCosmics", "TkAlCosmics0T", "MuAlGlobalCosmics", "SiStripCalCosmicsNano"],
                physics_skims=["CosmicSP", "CosmicTP", "LogError", "LogErrorMonitor"],
+               timePerEvent=0.5,
+               sizePerEvent=155,
+               scenario=cosmicsScenario)
+
+DATASETS = ["CosmicsHLTMonitor"]
+
+for dataset in DATASETS:
+    addDataset(tier0Config, dataset,
+               do_reco=True,
+               write_reco=False,
+               write_aod=True,
+               write_miniaod=False,
+               write_nanoaod=False,
+               write_dqm=True,
+               dqm_sequences=["@HLTMon"],
                timePerEvent=0.5,
                sizePerEvent=155,
                scenario=cosmicsScenario)


### PR DESCRIPTION
Reverts dmwm/T0#5049 until the addition of a new PD passes the test in [replay monitoring](https://monit-grafana.cern.ch/d/t_jr45h7k/cms-tier0-replayid-monitoring?orgId=11&refresh=1m&var-Bin=5m&var-ReplayID=250320235239&var-JobType=All&var-WorkflowType=All)

