### PR TITLE
CMSSW_15_0_4 Replay

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -40,7 +40,7 @@ setConfigVersion(tier0Config, "replace with real version")
 # 382686 - Collisions, 43.3 pb-1, 23.9583 TB NEW
 # 386674  Cosmics ~40 minutes in Run2024I with occupancy issues
 
-setInjectRuns(tier0Config, [386925, 389831]) # 382726: 2024 Cosmics, 382686: Collisions, 389831: 2025 Cosmics
+setInjectRuns(tier0Config, [386925, 390094]) # 382726: 2024 Cosmics, 382686: Collisions, 389831: 2025 Cosmics
 
 # Use this in order to limit the number of lumisections to process
 #setInjectLimit(tier0Config, 10)
@@ -123,7 +123,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_15_0_3"
+    'default': "CMSSW_15_0_4"
 }
 
 # Configure ScramArch


### PR DESCRIPTION
# Replay Request

**Requestor**  
ORM

**Describe the configuration**  
* Release: CMSSW_15_0_4
* Run: 386925, 390094
* GTs:
   * expressGlobalTag: "150X_dataRun3_Express_v1"
   * promptrecoGlobalTag: "150X_dataRun3_Prompt_v1"
* Additional changes:

**Purpose of the test**  
Preparation for Run2025A.

**T0 Operations cmsTalk thread**  
If necessary, provide a link to the cmsTalk thread announcing the test to the relevant groups. 
[Tier0 Operations cmsTalk Forum](https://cms-talk.web.cern.ch/c/offcomp/compops/tier0/210?)
