### PR TITLE
trigger workflows only for pushes to master

### DIFF
--- a/.github/workflows/create_tag_and_release.yaml
+++ b/.github/workflows/create_tag_and_release.yaml
@@ -2,6 +2,8 @@ name: Tag and Release on Version Change
 
 on:
   push:
+    branches:
+      - master
     paths:
       - 'src/python/T0/__init__.py'
 

--- a/.github/workflows/pypi_build_publish_template.yaml
+++ b/.github/workflows/pypi_build_publish_template.yaml
@@ -2,6 +2,8 @@
 
 on:
   push:
+    branches:
+      - master
     paths:
       - 'src/python/T0/__init__.py'
 


### PR DESCRIPTION
Currently, workflows trigger on pushes to any existing branch.