### PR TITLE
Remove GlobalTagTransaction from Express specs

### DIFF
--- a/src/python/T0/RunConfig/RunConfigAPI.py
+++ b/src/python/T0/RunConfig/RunConfigAPI.py
@@ -638,7 +638,6 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
             specArguments['RecoScramArch'] = streamConfig.Express.RecoScramArch
 
             specArguments['GlobalTag'] = streamConfig.Express.GlobalTag
-            specArguments['GlobalTagTransaction'] = "Express_%d" % run
             specArguments['GlobalTagConnect'] = streamConfig.Express.GlobalTagConnect
 
             specArguments['MaxInputRate'] = streamConfig.Express.MaxInputRate


### PR DESCRIPTION
Removal of GlobalTagTransaction in Express workflows. It was removed from CMSSW and subsequently from WMCore. We need to remove it also from Tier-0.

See discussion here: https://github.com/dmwm/WMCore/issues/12320