### PR TITLE
Make Data as default setupLabel

### DIFF
--- a/src/python/T0/StorageManager/StorageManagerAPI.py
+++ b/src/python/T0/StorageManager/StorageManagerAPI.py
@@ -104,7 +104,10 @@ def injectNewData(dbInterfaceStorageManager,
     for run in sorted(list(newRuns)):
         (hltkey, cmssw) = getRunInfoDAO.execute(run = run, transaction = False)
         setupLabel = getRunSetup.execute(run = run, transaction = False)
-        logging.debug("StorageManagerAPI: run = %d, hltkey = %s, cmssw = %s", run, hltkey, cmssw)
+        if not setupLabel:
+            logging.warning(f"Cannot retrieve setup label for run {run}, use default Data")
+            setupLabel = "Data" # set default setupLabel to data
+        logging.info("StorageManagerAPI: run = %d, hltkey = %s, cmssw = %s, setupLabel = %s", run, hltkey, cmssw, setupLabel)
         if hltkey and cmssw:
             cmssw = '_'.join(cmssw.split('_')[0:4]) # only consider base release
             cmsswVersions.add(cmssw)

--- a/src/python/T0/StorageManager/StorageManagerAPI.py
+++ b/src/python/T0/StorageManager/StorageManagerAPI.py
@@ -107,7 +107,7 @@ def injectNewData(dbInterfaceStorageManager,
         if not setupLabel:
             logging.warning(f"Cannot retrieve setup label for run {run}, use default Data")
             setupLabel = "Data" # set default setupLabel to data
-        logging.info("StorageManagerAPI: run = %d, hltkey = %s, cmssw = %s, setupLabel = %s", run, hltkey, cmssw, setupLabel)
+        logging.debug("StorageManagerAPI: run = %d, hltkey = %s, cmssw = %s, setupLabel = %s", run, hltkey, cmssw, setupLabel)
         if hltkey and cmssw:
             cmssw = '_'.join(cmssw.split('_')[0:4]) # only consider base release
             cmsswVersions.add(cmssw)

--- a/src/python/T0/WMBS/Oracle/StorageManager/GetRunSetup.py
+++ b/src/python/T0/WMBS/Oracle/StorageManager/GetRunSetup.py
@@ -19,6 +19,7 @@ class GetRunSetup(DBFormatter):
                  WHERE CMS_STOMGR.RUNS.RUNNUMBER = :RUN
                  """
         results = self.dbi.processData(sql, binds, conn = conn,
-                                       transaction = transaction)
+                                       transaction = transaction)[0].fetchall()
 
-        return self.formatOne(results)[0]
+        if len(results) > 0:
+            setupLabel = results[0][0]

--- a/src/python/T0/WMBS/Oracle/StorageManager/GetRunSetup.py
+++ b/src/python/T0/WMBS/Oracle/StorageManager/GetRunSetup.py
@@ -21,5 +21,7 @@ class GetRunSetup(DBFormatter):
         results = self.dbi.processData(sql, binds, conn = conn,
                                        transaction = transaction)[0].fetchall()
 
+        setupLabel = None
         if len(results) > 0:
             setupLabel = results[0][0]
+        return setupLabel


### PR DESCRIPTION
On rare occasions, the setupLabel we fetch from SM does not exist in the SM database. This prevents further runs from being processed. With this PR, we set the default setupLabel to "Data" in case it does not exist in the SM DB.

More discussion: https://its.cern.ch/jira/browse/CMSTZ-1092