### PR TITLE
Replay CMSSW_15_0_5

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -101,7 +101,7 @@ setPromptCalibrationConfig(tier0Config,
 # maxRunPreviousConfig = 999999 # Last run before era change 08/09/23
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_15_0_4_patch3",
+    'default': "CMSSW_15_0_5",
     #'acqEra': {'Run2024F': "CMSSW_14_0_11"},
     #'maxRun': {maxRunPreviousConfig: "CMSSW_13_2_2"}
 }

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -40,7 +40,7 @@ setConfigVersion(tier0Config, "replace with real version")
 # 382686 - Collisions, 43.3 pb-1, 23.9583 TB NEW
 # 386674  Cosmics ~40 minutes in Run2024I with occupancy issues
 
-setInjectRuns(tier0Config, [386925, 390094]) # 382726: 2024 Cosmics, 382686: Collisions, 389831: 2025 Cosmics
+setInjectRuns(tier0Config, [386925, 390094, 390951]) # 386925: 2024 Collisions, 390094: 2025 Cosmics, 390951: 2025 900 GeV Collisions
 
 # Use this in order to limit the number of lumisections to process
 #setInjectLimit(tier0Config, 10)
@@ -123,7 +123,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_15_0_4_patch3"
+    'default': "CMSSW_15_0_5"
 }
 
 # Configure ScramArch


### PR DESCRIPTION
# Replay Request

**Requestor**  
ORM

**Describe the configuration**  
* Release: CMSSW_15_0_5
* Run: 386925, 390094, 390951
* GTs:
   * expressGlobalTag = "150X_dataRun3_Express_v1"
   * promptrecoGlobalTag = "150X_dataRun3_Prompt_v1"
* Additional changes:

**Purpose of the test**  
New CMSSW Release

**T0 Operations cmsTalk thread**  
https://cms-talk.web.cern.ch/t/replay-for-cmssw-15-0-5/124340
