### PR TITLE
nano flavour in datasvc

### DIFF
--- a/src/python/T0/WMBS/Oracle/T0DataSvc/GetRecoConfigs.py
+++ b/src/python/T0/WMBS/Oracle/T0DataSvc/GetRecoConfigs.py
@@ -20,6 +20,7 @@ class GetRecoConfigs(DBFormatter):
                         reco_config.alca_skim AS alca_skim,
                         reco_config.physics_skim AS physics_skim,
                         reco_config.dqm_seq AS dqm_seq,
+                        reco_config.nano_flavour AS nano_flavour,
                         reco_config.global_tag AS global_tag,
                         event_scenario.name AS scenario,
                         reco_config.proc_version AS proc_version,

--- a/src/python/T0/WMBS/Oracle/T0DataSvc/InsertRecoConfigs.py
+++ b/src/python/T0/WMBS/Oracle/T0DataSvc/InsertRecoConfigs.py
@@ -21,6 +21,7 @@ class InsertRecoConfigs(DBFormatter):
                               alca_skim = :ALCA_SKIM,
                               physics_skim = :PHYSICS_SKIM,
                               dqm_seq = :DQM_SEQ,
+                              nano_flavour = :NANO_FLAVOUR,
                               global_tag = :GLOBAL_TAG,
                               scenario = :SCENARIO,
                               proc_version = :PROC_VERSION,
@@ -32,11 +33,11 @@ class InsertRecoConfigs(DBFormatter):
                               write_nanoaod = :WRITE_NANOAOD
                  WHEN NOT MATCHED THEN
                    INSERT (run, primds, cmssw, scram_arch, alca_skim,
-                           physics_skim, dqm_seq, global_tag, scenario, proc_version,
+                           physics_skim, dqm_seq, nano_flavour, global_tag, scenario, proc_version,
                            multicore, write_reco, write_dqm,
                            write_aod, write_miniaod, write_nanoaod)
                    VALUES (:RUN, :PRIMDS, :CMSSW, :SCRAM_ARCH, :ALCA_SKIM,
-                           :PHYSICS_SKIM, :DQM_SEQ, :GLOBAL_TAG, :SCENARIO, :PROC_VERSION,
+                           :PHYSICS_SKIM, :DQM_SEQ, :NANO_FLAVOUR, :GLOBAL_TAG, :SCENARIO, :PROC_VERSION,
                            :MULTICORE, :WRITE_RECO, :WRITE_DQM,
                            :WRITE_AOD, :WRITE_MINIAOD, :WRITE_NANOAOD)
                  """

--- a/src/python/T0Component/Tier0Feeder/Tier0FeederPoller.py
+++ b/src/python/T0Component/Tier0Feeder/Tier0FeederPoller.py
@@ -578,6 +578,7 @@ class Tier0FeederPoller(BaseWorkerThread):
                                       'ALCA_SKIM' : config['alca_skim'],
                                       'PHYSICS_SKIM' : config['physics_skim'],
                                       'DQM_SEQ' : config['dqm_seq'],
+                                      'NANO_FLAVOUR' : config['nano_flavour'],
                                       'GLOBAL_TAG' : config['global_tag'][:50],
                                       'SCENARIO' : config['scenario'],
                                       'PROC_VERSION' : config['proc_version'],


### PR DESCRIPTION
The development of the nano flavours requires modification of the datasvc in order to keep track of the nano flavour configuration we have.

Related PR: https://github.com/dmwm/t0wmadatasvc/pull/51