### PR TITLE
fix the default value for nano flavours

### DIFF
--- a/src/python/T0/RunConfig/Tier0Config.py
+++ b/src/python/T0/RunConfig/Tier0Config.py
@@ -626,7 +626,7 @@ def addDataset(config, datasetName, **settings):
     datasetConfig.AlcaSkims = settings.get("alca_producers", [])
     datasetConfig.PhysicsSkims = settings.get("physics_skims", [])
     datasetConfig.DqmSequences = settings.get("dqm_sequences", [])
-    datasetConfig.NanoFlavours = settings.get("nano_flavours", [])
+    datasetConfig.NanoFlavours = settings.get("nano_flavours", ['@PHYS','@L1'])
     
     if hasattr(datasetConfig, "MaxMemoryperCore"):
         datasetConfig.MaxMemoryperCore = settings.get("maxMemoryperCore", datasetConfig.MaxMemoryperCore)


### PR DESCRIPTION
The current setup of the nano flavours has the output nanoaod being written without L1 objects. This is due to a misconfiguration in the Tier0Config.py, where the nano flavours parameter is not picked up from the default dataset.