### PR TITLE
Replace Oracle SEQUENCE constraints used by GENERATE auto-increment

### DIFF
--- a/src/python/T0/WMBS/Oracle/RunConfig/InsertCMSSWVersion.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/InsertCMSSWVersion.py
@@ -22,8 +22,8 @@ class InsertCMSSWVersion(DBFormatter):
                    IF (cnt = 0)
                    THEN
                      INSERT INTO cmssw_version
-                     (ID, NAME)
-                     VALUES(cmssw_version_SEQ.nextval, :VERSION)
+                     (NAME)
+                     VALUES(:VERSION)
                      ;
                    END IF;
                  EXCEPTION

--- a/src/python/T0/WMBS/Oracle/RunConfig/InsertPrimaryDataset.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/InsertPrimaryDataset.py
@@ -12,8 +12,8 @@ class InsertPrimaryDataset(DBFormatter):
     def execute(self, binds, conn = None, transaction = False):
 
         sql = """INSERT INTO primary_dataset
-                 (ID, NAME)
-                 SELECT primary_dataset_SEQ.nextval, :PRIMDS
+                 (NAME)
+                 SELECT :PRIMDS
                  FROM DUAL
                  WHERE NOT EXISTS (
                    SELECT * FROM primary_dataset

--- a/src/python/T0/WMBS/Oracle/RunConfig/InsertStorageNode.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/InsertStorageNode.py
@@ -12,8 +12,8 @@ class InsertStorageNode(DBFormatter):
     def execute(self, binds, conn = None, transaction = False):
 
         sql = """INSERT INTO storage_node
-                 (ID, NAME)
-                 SELECT storage_node_SEQ.nextval, :NODE
+                 (NAME)
+                 SELECT :NODE
                  FROM DUAL
                  WHERE NOT EXISTS (
                    SELECT * FROM storage_node

--- a/src/python/T0/WMBS/Oracle/RunConfig/InsertStream.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/InsertStream.py
@@ -22,8 +22,8 @@ class InsertStream(DBFormatter):
                    IF (cnt = 0)
                    THEN
                      INSERT INTO stream
-                     (ID, NAME)
-                     VALUES(stream_SEQ.nextval, :STREAM)
+                     (NAME)
+                     VALUES(:STREAM)
                      ;
                    END IF;
                  EXCEPTION

--- a/src/python/T0/WMBS/Oracle/RunConfig/InsertStreamFileset.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/InsertStreamFileset.py
@@ -14,11 +14,11 @@ class InsertStreamFileset(DBFormatter):
 
         sql = """INSERT ALL
                    INTO wmbs_fileset
-                     (ID, NAME, LAST_UPDATE, OPEN)
-                     VALUES (wmbs_fileset_SEQ.nextval, :NAME, :TIME, 1)
+                     (NAME, LAST_UPDATE, OPEN)
+                     VALUES (:NAME, :TIME, 1)
                    INTO run_stream_fileset_assoc
-                     (RUN_ID, STREAM_ID, FILESET)
-                     VALUES (:RUN, stream_id, wmbs_fileset_SEQ.nextval)
+                     (RUN_ID, STREAM_ID)
+                     VALUES (:RUN, stream_id)
                  SELECT id AS stream_id
                  FROM stream
                  WHERE name = :STREAM

--- a/src/python/T0/WMBS/Oracle/RunConfig/InsertStreamFileset.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/InsertStreamFileset.py
@@ -12,16 +12,23 @@ class InsertStreamFileset(DBFormatter):
 
     def execute(self, run, stream, name, conn = None, transaction = False):
 
-        sql = """INSERT ALL
-                   INTO wmbs_fileset
+        sql = """DECLARE
+                   fileset_id NUMBER;
+                   stream_id NUMBER;
+                 BEGIN
+                   SELECT id INTO stream_id
+                   FROM stream
+                   WHERE name = :STREAM;
+
+                   INSERT INTO wmbs_fileset
                      (NAME, LAST_UPDATE, OPEN)
                      VALUES (:NAME, :TIME, 1)
-                   INTO run_stream_fileset_assoc
-                     (RUN_ID, STREAM_ID)
-                     VALUES (:RUN, stream_id)
-                 SELECT id AS stream_id
-                 FROM stream
-                 WHERE name = :STREAM
+                     RETURNING id INTO fileset_id;
+
+                   INSERT INTO run_stream_fileset_assoc
+                     (RUN_ID, STREAM_ID, FILESET)
+                     VALUES (:RUN, stream_id, fileset_id);
+                 END;
                  """
 
         binds = { 'RUN' : run,

--- a/src/python/T0/WMBS/Oracle/RunConfig/InsertStreamer.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/InsertStreamer.py
@@ -13,31 +13,37 @@ class InsertStreamer(DBFormatter):
 
         sql = """DECLARE
                    cnt NUMBER(1);
+                   file_id NUMBER;
+                   stream_id NUMBER;
                  BEGIN
                    SELECT COUNT(*)
                    INTO cnt
                    FROM wmbs_file_details
                    WHERE lfn = :LFN
                    ;
+
+                   SELECT id INTO stream_id
+                   FROM stream
+                   WHERE name = :STREAM;
+
                    IF (cnt = 0)
                    THEN
-                     INSERT ALL
-                       INTO wmbs_file_details
-                         (LFN, FILESIZE, EVENTS, MERGED)
-                         VALUES (:LFN, :FILESIZE, :EVENTS, '0')
-                       INTO wmbs_file_runlumi_map
-                         (RUN, LUMI)
-                         VALUES (:RUN, :LUMI)
-                       INTO wmbs_file_location
-                         (PNN)
-                         VALUES ((SELECT id FROM wmbs_pnns WHERE pnn = '%s'))
-                       INTO streamer
-                         (P5_ID, RUN_ID, STREAM_ID, LUMI_ID, INSERT_TIME)
-                         VALUES (:P5_ID, :RUN, stream_id, :LUMI, :TIME)
-                     SELECT id AS stream_id
-                     FROM stream
-                     WHERE name = :STREAM
-                     ;
+                     INSERT INTO wmbs_file_details
+                       (LFN, FILESIZE, EVENTS, MERGED)
+                       VALUES (:LFN, :FILESIZE, :EVENTS, '0')
+                       RETURNING id INTO file_id;
+
+                     INSERT INTO wmbs_file_runlumi_map
+                       (FILEID, RUN, LUMI)
+                       VALUES (file_id, :RUN, :LUMI);
+
+                     INSERT INTO wmbs_file_location
+                       (FILEID, PNN)
+                       VALUES (file_id, (SELECT id FROM wmbs_pnns WHERE pnn = '%s'));
+
+                     INSERT INTO streamer
+                       (ID, P5_ID, RUN_ID, STREAM_ID, LUMI_ID, INSERT_TIME)
+                       VALUES (file_id, :P5_ID, :RUN, stream_id, :LUMI, :TIME);
                    END IF;
                  EXCEPTION
                    WHEN DUP_VAL_ON_INDEX THEN NULL;

--- a/src/python/T0/WMBS/Oracle/RunConfig/InsertStreamer.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/InsertStreamer.py
@@ -23,17 +23,17 @@ class InsertStreamer(DBFormatter):
                    THEN
                      INSERT ALL
                        INTO wmbs_file_details
-                         (ID, LFN, FILESIZE, EVENTS, MERGED)
-                         VALUES (wmbs_file_details_SEQ.nextval, :LFN, :FILESIZE, :EVENTS, '0')
+                         (LFN, FILESIZE, EVENTS, MERGED)
+                         VALUES (:LFN, :FILESIZE, :EVENTS, '0')
                        INTO wmbs_file_runlumi_map
-                         (FILEID, RUN, LUMI)
-                         VALUES (wmbs_file_details_SEQ.nextval, :RUN, :LUMI)
+                         (RUN, LUMI)
+                         VALUES (:RUN, :LUMI)
                        INTO wmbs_file_location
-                         (FILEID, PNN)
-                         VALUES (wmbs_file_details_SEQ.nextval, (SELECT id FROM wmbs_pnns WHERE pnn = '%s'))
+                         (PNN)
+                         VALUES ((SELECT id FROM wmbs_pnns WHERE pnn = '%s'))
                        INTO streamer
-                         (ID, P5_ID, RUN_ID, STREAM_ID, LUMI_ID, INSERT_TIME)
-                         VALUES (wmbs_file_details_SEQ.nextval, :P5_ID, :RUN, stream_id, :LUMI, :TIME)
+                         (P5_ID, RUN_ID, STREAM_ID, LUMI_ID, INSERT_TIME)
+                         VALUES (:P5_ID, :RUN, stream_id, :LUMI, :TIME)
                      SELECT id AS stream_id
                      FROM stream
                      WHERE name = :STREAM

--- a/src/python/T0/WMBS/Oracle/RunConfig/InsertTrigger.py
+++ b/src/python/T0/WMBS/Oracle/RunConfig/InsertTrigger.py
@@ -12,8 +12,8 @@ class InsertTrigger(DBFormatter):
     def execute(self, binds, conn = None, transaction = False):
 
         sql = """INSERT INTO trigger_label
-                 (ID, NAME)
-                 SELECT trigger_label_SEQ.nextval, :TRIG
+                 (NAME)
+                 SELECT :TRIG
                  FROM DUAL
                  WHERE NOT EXISTS (
                    SELECT * FROM trigger_label

--- a/test/python/T0Component_t/Tier0Feeder_t/Tier0Feeder_t.py
+++ b/test/python/T0Component_t/Tier0Feeder_t/Tier0Feeder_t.py
@@ -1046,8 +1046,8 @@ class Tier0FeederTest(unittest.TestCase):
         """
         myThread = threading.currentThread()
 
-        myThread.dbi.processData("""INSERT INTO wmbs_pnns (id, pnn)
-                                    VALUES (wmbs_pnns_SEQ.nextval, '%s')
+        myThread.dbi.processData("""INSERT INTO wmbs_pnns (pnn)
+                                    VALUES ('%s')
                                     """ % pnn, transaction = False)
 
         return

--- a/test/python/T0_t/WMBS_t/RunConfig_t/RunConfig_t.py
+++ b/test/python/T0_t/WMBS_t/RunConfig_t/RunConfig_t.py
@@ -1081,8 +1081,8 @@ class RunConfigTest(unittest.TestCase):
         """
         myThread = threading.currentThread()
 
-        myThread.dbi.processData("""INSERT INTO wmbs_pnns (id, pnn)
-                                    VALUES (wmbs_pnns_SEQ.nextval, '%s')
+        myThread.dbi.processData("""INSERT INTO wmbs_pnns (pnn)
+                                    VALUES ('%s')
                                     """ % pnn, transaction = False)
 
         return


### PR DESCRIPTION
With the SQL database schema isolation and streamline, proposed in https://github.com/dmwm/WMCore/pull/12341, we need to stop using Oracle SEQUENCE constraints within the Tier0 CRUD SQL statements, as columns are now defined with the auto-increment `GENERATED BY DEFAULT AS IDENTITY` clause.

When executing a replay to test all this SQL schema separation, we need to change the T0 agent deployment to consider:
* new schema coming from https://github.com/amaltaro/wmcoredb
* same new schema above, but temporarily copied under https://github.com/dmwm/WMCore/pull/12341 as well (to be able to run Jenkins unit tests)
* in addition, WMCore codebase changes provided in the same PR above https://github.com/dmwm/WMCore/pull/12341
* lastly, the changes provided in this PR

@LinaresToine the only difference from what we have already been doing is this patch. Can you please apply it to that replay test that you started last week? Or just start a new deployment and ensure that the agent is patched with this PR. Thank you in advance!