### PR TITLE
importlib instead of imp

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,13 +4,12 @@ Build, clean and test the t0 package.
 """
 from __future__ import print_function
 
-import imp
+import importlib
 import os
 import os.path
 from distutils.core import Command, setup
 from os.path import join as pjoin
-
-from setup_build import BuildCommand, InstallCommand, get_path_to_t0_root, list_packages, list_static_files
+from setup_build import BuildCommand, InstallCommand, get_path_to_t0_root, list_packages, list_static_files, load_source
 
 
 class CleanCommand(Command):
@@ -99,8 +98,9 @@ DEFAULT_PACKAGES = list_packages(['src/python/T0',
 # depend on the python module resolution behavior to load the version.
 # Instead, we use the imp module to load the source file directly by
 # filename.
+
 t0_root = get_path_to_t0_root()
-t0_package = imp.load_source('temp_module', os.path.join(t0_root,
+t0_package = load_source('temp_module', os.path.join(t0_root,
                                                             'src',
                                                             'python',
                                                             'T0',

--- a/setup_build.py
+++ b/setup_build.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+import importlib
 from distutils.core import Command
 from distutils.command.build import build
 from distutils.command.install import install
@@ -6,6 +7,21 @@ from distutils.spawn import spawn
 import re, os, sys, os.path, shutil
 from glob import glob
 from setup_dependencies import dependencies
+
+def load_source(modname, filename):
+    """
+    This function is required as we move away from imp
+    imp is deprecated in python3.12
+    Further deails see https://docs.python.org/dev/whatsnew/3.12.html#imp
+    """
+    loader = importlib.machinery.SourceFileLoader(modname, filename)
+    spec = importlib.util.spec_from_file_location(modname, filename, loader=loader)
+    module = importlib.util.module_from_spec(spec)
+    # The module is always executed and not cached in sys.modules.
+    # Uncomment the following line to cache the module.
+    # sys.modules[module.__name__] = module
+    loader.exec_module(module)
+    return module
 
 def get_path_to_t0_root():
     """

--- a/setup_t0.py
+++ b/setup_t0.py
@@ -7,9 +7,9 @@
 from __future__ import print_function, division
 import os
 import sys
-import imp
+import importlib
 from setuptools import setup
-from setup_build import list_packages, list_static_files, get_path_to_t0_root
+from setup_build import list_packages, list_static_files, get_path_to_t0_root, load_source
 
 # Obnoxiously, there's a dependency cycle when building packages. We'd like
 # to simply get the current T0 version by using
@@ -19,7 +19,7 @@ from setup_build import list_packages, list_static_files, get_path_to_t0_root
 # Instead, we use the imp module to load the source file directly by
 # filename.
 t0_root = get_path_to_t0_root()
-t0_package = imp.load_source('temp_module', os.path.join(t0_root,
+t0_package = load_source('temp_module', os.path.join(t0_root,
                                                              'src',
                                                              'python',
                                                              'T0',

--- a/src/python/T0/__init__.py
+++ b/src/python/T0/__init__.py
@@ -4,5 +4,5 @@ _T0_
 Core libraries for Workload Management Packages
 
 """
-__version__ = '3.3.3'
+__version__ = '3.4.0rc1'
 __all__ = []


### PR DESCRIPTION
imp module is deprecated in python3.12. We need to use importlib instead. We currently only use imp in the building of the package, and we only use the `load_source` method. Instructions to adopt importlib is in https://docs.python.org/dev/whatsnew/3.12.html#imp
