### PR TITLE
Add support to enable/disable repacking of emulation runs

### DIFF
--- a/etc/HIProdOfflineConfiguration.py
+++ b/etc/HIProdOfflineConfiguration.py
@@ -61,7 +61,7 @@ addSiteConfig(tier0Config, "T0_CH_CERN_Disk",
 #  Processing site (where jobs run)
 #  PhEDEx locations
 setAcquisitionEra(tier0Config, "HIRun2024B")
-setEmulationAcquisitionEra(tier0Config, "Emulation2024")
+setEmulationAcquisitionEra(tier0Config, "Emulation2024", repack=False)
 setBaseRequestPriority(tier0Config, 251000)
 setBackfill(tier0Config, None)
 setBulkDataType(tier0Config, "hidata")

--- a/etc/HIReplayOfflineConfiguration.py
+++ b/etc/HIReplayOfflineConfiguration.py
@@ -7,6 +7,7 @@ from __future__ import print_function
 from T0.RunConfig.Tier0Config import addDataset
 from T0.RunConfig.Tier0Config import createTier0Config
 from T0.RunConfig.Tier0Config import setAcquisitionEra
+from T0.RunConfig.Tier0Config import setEmulationAcquisitionEra
 from T0.RunConfig.Tier0Config import setDefaultScramArch
 from T0.RunConfig.Tier0Config import setScramArch
 from T0.RunConfig.Tier0Config import setBaseRequestPriority
@@ -65,6 +66,7 @@ addSiteConfig(tier0Config, "EOS_PILOT",
 #  Processing site (where jobs run)
 #  PhEDEx locations
 setAcquisitionEra(tier0Config, "Tier0_HIREPLAY_2024")
+setEmulationAcquisitionEra(tier0Config, "Tier0_HIREPLAY_2024", repack=False)
 setBaseRequestPriority(tier0Config, 260000)
 setBackfill(tier0Config, 1)
 setBulkDataType(tier0Config, "hidata")

--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -61,7 +61,7 @@ addSiteConfig(tier0Config, "T0_CH_CERN_Disk",
 #  Processing site (where jobs run)
 #  PhEDEx locations
 setAcquisitionEra(tier0Config, "Run2025C")
-setEmulationAcquisitionEra(tier0Config, "Emulation2025")
+setEmulationAcquisitionEra(tier0Config, "Emulation2025", repack=False)
 setBaseRequestPriority(tier0Config, 251000)
 setBackfill(tier0Config, None)
 setBulkDataType(tier0Config, "data")

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -7,6 +7,7 @@ from __future__ import print_function
 from T0.RunConfig.Tier0Config import addDataset
 from T0.RunConfig.Tier0Config import createTier0Config
 from T0.RunConfig.Tier0Config import setAcquisitionEra
+from T0.RunConfig.Tier0Config import setEmulationAcquisitionEra
 from T0.RunConfig.Tier0Config import setDefaultScramArch
 from T0.RunConfig.Tier0Config import setScramArch
 from T0.RunConfig.Tier0Config import setBaseRequestPriority
@@ -81,6 +82,7 @@ addSiteConfig(tier0Config, "EOS_PILOT",
 #  Processing site (where jobs run)
 #  PhEDEx locations
 setAcquisitionEra(tier0Config, "Tier0_REPLAY_2025")
+setEmulationAcquisitionEra(tier0Config, "Emulation2025", repack=False)
 setBaseRequestPriority(tier0Config, 260000)
 setBackfill(tier0Config, 1)
 setBulkDataType(tier0Config, "data")

--- a/src/python/T0/RunConfig/Tier0Config.py
+++ b/src/python/T0/RunConfig/Tier0Config.py
@@ -37,6 +37,7 @@ Tier0Configuration - Global configuration object
 | |       |--> AcquisitionEra - The acquisition era for the run
 | |       |
 | |       |--> EmulationAcquisitionEra - The acquisition era for emulated runs
+| |       |--> EmulationRepack - switch on/off repack for emulation runs
 | |       |
 | |       |--> Backfill - The backfill mode, can be None, 1 or 2
 | |       |
@@ -649,13 +650,14 @@ def setAcquisitionEra(config, acquisitionEra):
     config.Global.AcquisitionEra = acquisitionEra
     return
 
-def setEmulationAcquisitionEra(config, emulationAcquisitionEra):
+def setEmulationAcquisitionEra(config, emulationAcquisitionEra, repack):
     """
     _setEmulationAcquisitionEra_
 
     Set the acquisition era for emulated data.
     """
     config.Global.EmulationAcquisitionEra = emulationAcquisitionEra
+    config.Global.EmulationRepack = repack
     return
 
 

--- a/src/python/T0/StorageManager/StorageManagerAPI.py
+++ b/src/python/T0/StorageManager/StorageManagerAPI.py
@@ -20,7 +20,8 @@ def injectNewData(dbInterfaceStorageManager,
                   maxRun = None,
                   injectRun = None,
                   injectLimit = None,
-                  agentType = None):
+                  agentType = None,
+                  emulationRepack = None):
     """
     _injectNewData_
 
@@ -107,6 +108,12 @@ def injectNewData(dbInterfaceStorageManager,
         if not setupLabel:
             logging.warning(f"Cannot retrieve setup label for run {run}, use default Data")
             setupLabel = "Data" # set default setupLabel to data
+
+        if setupLabel == "Emulation" and not emulationRepack:
+            newRuns.remove(run)
+            logging.info(f"Discard emulation run {run}")
+            continue
+
         logging.debug("StorageManagerAPI: run = %d, hltkey = %s, cmssw = %s, setupLabel = %s", run, hltkey, cmssw, setupLabel)
         if hltkey and cmssw:
             cmssw = '_'.join(cmssw.split('_')[0:4]) # only consider base release

--- a/src/python/T0Component/Tier0Feeder/Tier0FeederPoller.py
+++ b/src/python/T0Component/Tier0Feeder/Tier0FeederPoller.py
@@ -184,7 +184,8 @@ class Tier0FeederPoller(BaseWorkerThread):
                                                     streamerPNN = tier0Config.Global.StreamerPNN,
                                                     minRun = tier0Config.Global.InjectMinRun,
                                                     maxRun = tier0Config.Global.InjectMaxRun,
-                                                    agentType = self.agentType)
+                                                    agentType = self.agentType,
+                                                    emulationRepack = tier0Config.Global.EmulationRepack)
                 else:
                     injectRuns = set()
                     for injectRun in tier0Config.Global.InjectRuns:
@@ -197,7 +198,8 @@ class Tier0FeederPoller(BaseWorkerThread):
                                                         streamerPNN = tier0Config.Global.StreamerPNN,
                                                         injectRun = injectRun,
                                                         injectLimit= tier0Config.Global.InjectLimit,
-                                                        agentType = self.agentType)
+                                                        agentType = self.agentType,
+                                                        emulationRepack = tier0Config.Global.EmulationRepack)
                         self.injectedRuns.add(injectRun)
             except:
                 # shouldn't happen, just a catch all insurance


### PR DESCRIPTION
Up to now, any emulation run (test runs from SM) is repacked by default. This is not always desired as it consumes CPU and storage resources. This PR implements a flag that enables or disables the repacking of emulation runs. By default, emulation runs are not repacked.