### PR TITLE
Trigger new release 3.4.0

### DIFF
--- a/src/python/T0/__init__.py
+++ b/src/python/T0/__init__.py
@@ -4,5 +4,5 @@ _T0_
 Core libraries for Workload Management Packages
 
 """
-__version__ = '3.4.0rc2'
+__version__ = '3.4.0'
 __all__ = []


### PR DESCRIPTION
@jeyserma this PR triggers a new release in pypi automatically once its merged. Please merge it after merging the ongoing [era_by_run](https://github.com/dmwm/T0/pull/5026) and [oxygen-runs](https://github.com/dmwm/T0/pull/5081). This way you will have a brand new release 3.4.0 to deploy production.

Also, please note that the patches file and deploy prod file were updated accordingly in https://github.com/dmwm/T0/pull/5090.  You will only need to use the master version scripts in the new production node when you deploy. No manual change required.

