### PR TITLE
Update OXYProdOfflineConfiguration.py

### DIFF
--- a/etc/OXYProdOfflineConfiguration.py
+++ b/etc/OXYProdOfflineConfiguration.py
@@ -101,16 +101,34 @@ acquisitionEra = {
                 }
 }
 """
-#maxRunPreviousEra = 1
+maxRunPreviousEra = 394031
 acquisitionEra = {
-    'default' : 'pORun2025',
-    #'maxRun' : {maxRunPreviousEra : ''}
+    'default' : 'OORun2025',
+    'maxRun' : {maxRunPreviousEra : 'pORun2025'}
 }
 setAcquisitionEra(tier0Config, acquisitionEra)
 setEmulationAcquisitionEra(tier0Config, "Emulation2025", repack=False)
 setBaseRequestPriority(tier0Config, 251000)
 setBackfill(tier0Config, None)
-setBulkDataType(tier0Config, "data")
+
+#
+# Basic Configuration:
+#  - The 'default' key sets the bulk data type for all runs unless overridden
+
+# Override Options (Choose ONE method):
+#   acqEra: Use acquisition era to specify data type (era-based configuration)
+#   maxRun: Use run thresholds to specify data type (run-based configuration)
+
+# IMPORTANT: You cannot use both acqEra and maxRun simultaneously
+# Choose either era-based OR run-based configuration, not both
+
+#maxRunPreviousBulkData = 388621
+bulkData = { 
+	'default' : "hidata", 
+	'acqEra' : {'pORun2025': "data",
+                'OORun2025': "hidata"}
+}
+setBulkDataType(tier0Config, bulkData)
 setProcessingSite(tier0Config, processingSite)
 setStreamerPNN(tier0Config, streamerPNN)
 setStorageSite(tier0Config, storageSite)
@@ -1646,3 +1664,4 @@ setHelperAgentStreams(tier0Config, {"SecondAgent" : [],
 
 if __name__ == '__main__':
     print(tier0Config)
+


### PR DESCRIPTION
The current production configuration file. Uses Era-by-run support and bulk-data by era support:

* Era by run: https://github.com/dmwm/T0/pull/5026
* bulk data by era: https://github.com/dmwm/T0/pull/5092