### PR TITLE
Allow harvesting jobs have configurable memory

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -329,6 +329,7 @@ addExpressConfig(tier0Config, "Express",
                  timePerEvent=4,
                  sizePerEvent=1700,
                  maxMemoryperCore=2000,
+                 harvestingMemory=3000,
                  dataset_lifetime=12*30*24*3600,#lifetime for container rules. Default 12 months
                  versionOverride=expressVersionOverride)
 

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -305,6 +305,7 @@ addExpressConfig(tier0Config, "Express",
                  timePerEvent=4,
                  sizePerEvent=1700,
                  maxMemoryperCore=2000,
+                 harvestingMemory=3000,
                  dataset_lifetime=7*24*3600,#lifetime for container rules. Default 14 days
                  versionOverride=expressVersionOverride)
 

--- a/src/python/T0/RunConfig/RunConfigAPI.py
+++ b/src/python/T0/RunConfig/RunConfigAPI.py
@@ -665,6 +665,7 @@ def configureRunStream(tier0Config, run, stream, specDirectory, dqmUploadProxy):
             specArguments['SizePerEvent'] = streamConfig.Express.SizePerEvent
 
             specArguments['Memory'] = streamConfig.Express.MaxMemoryperCore
+            specArguments["HarvestingMemory"] = streamConfig.Express.HarvestingMemory
             if streamConfig.Express.Multicore:
                 specArguments['Multicore'] = streamConfig.Express.Multicore
                 specArguments['Memory'] += (streamConfig.Express.Multicore - 1) * streamConfig.Express.MaxMemoryperCore

--- a/src/python/T0/RunConfig/Tier0Config.py
+++ b/src/python/T0/RunConfig/Tier0Config.py
@@ -1102,6 +1102,7 @@ def addExpressConfig(config, streamName, **options):
 
     streamConfig.Express.BlockCloseDelay = options.get("blockCloseDelay", 3600)
 
+    streamConfig.Express.HarvestingMemory = options.get("harvestingMemory", 2300)
     if hasattr(streamConfig.Express, "MaxMemoryperCore"):
         streamConfig.Express.MaxMemoryperCore = options.get("maxMemoryperCore", streamConfig.Express.MaxMemoryperCore)
     else:


### PR DESCRIPTION
Allow harvesting jobs to have configurable memory

This PR works together with https://github.com/dmwm/WMCore/pull/12404