### PR TITLE
CMSSW_15_0_10

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -147,7 +147,7 @@ setPromptCalibrationConfig(tier0Config,
 maxRunPreviousConfig = 392513 # Last run before era change 08/09/23
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_15_0_8",
+    'default': "CMSSW_15_0_10",
     #'acqEra': {'Run2024F': "CMSSW_14_0_11"},
     'maxRun': {maxRunPreviousConfig: "CMSSW_15_0_6"}
 }

--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -217,7 +217,7 @@ expressProcVersion = {
 expressGlobalTag = {
     'default': "150X_dataRun3_Express_v2"
     #'acqEra': {'Run2024B': "140X_dataRun3_Express_v2"}
-    #'maxRun': {nn: "132X_dataRun3_Express_v3"}
+    #'maxRun': {maxRunPreviousConfig: "132X_dataRun3_Express_v3"}
 }
 promptrecoGlobalTag = {
     'default': "150X_dataRun3_Prompt_v1",

--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -168,7 +168,7 @@ setPromptCalibrationConfig(tier0Config,
 defaultCMSSWVersion = {
     'default': "CMSSW_15_0_10",
     #'acqEra': {'Run2024F': "CMSSW_14_0_11"},
-    #'maxRun': {maxRunPreviousConf
+    #'maxRun': {maxRunPreviousConfig: "CMSSW_15_0_6"}
 }
 
 # Configure ScramArch

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -41,7 +41,7 @@ setConfigVersion(tier0Config, "replace with real version")
 # 382686 - Collisions, 43.3 pb-1, 23.9583 TB NEW
 # 386674  Cosmics ~40 minutes in Run2024I with occupancy issues
 
-setInjectRuns(tier0Config, [392204, 393274]) # 386925: 2024 Collisions, 390094: 2025 Cosmics, 390951: 2025 900 GeV Collisions
+setInjectRuns(tier0Config, [393274]) # 386925: 2024 Collisions, 390094: 2025 Cosmics, 390951: 2025 900 GeV Collisions
 
 # Use this in order to limit the number of lumisections to process
 #setInjectLimit(tier0Config, 10)
@@ -147,7 +147,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_15_0_8"
+    'default': "CMSSW_15_0_10"
 }
 
 # Configure ScramArch
@@ -181,7 +181,7 @@ alcarawProcVersion = dt
 # Defaults for GlobalTag
 
 
-expressGlobalTag = "150X_dataRun3_Express_v1"
+expressGlobalTag = "150X_dataRun3_Express_v2"
 promptrecoGlobalTag = "150X_dataRun3_Prompt_v1"
 repackGlobalTag = "150X_dataRun3_Prompt_v1_ParkingDoubleMuonLowMass_v2"
 


### PR DESCRIPTION
# Replay Request

**Requestor**  
ORM

**Describe the configuration**  
* Release: CMSSW_15_0_10
* Run: 393274
* GTs:
   * expressGlobalTag: 150X_dataRun3_Express_v2
   * promptrecoGlobalTag: 150X_dataRun3_Prompt_v1
* Additional changes:

**Purpose of the test**  
A replay test is costly, both in computational and human resources. Please describe the reason why this test is needed.

**T0 Operations cmsTalk thread**  
If necessary, provide a link to the cmsTalk thread announcing the test to the relevant groups. 
[Tier0 Operations cmsTalk Forum](https://cms-talk.web.cern.ch/c/offcomp/compops/tier0/210?)
