### PR TITLE
3.5.1

### DIFF
--- a/src/python/T0/__init__.py
+++ b/src/python/T0/__init__.py
@@ -4,5 +4,5 @@ _T0_
 Core libraries for Workload Management Packages
 
 """
-__version__ = '3.4.1'
+__version__ = '3.5.1'
 __all__ = []


### PR DESCRIPTION
With the merging of #5079 the deployment of the T0 agent is no longer possible with 3.4 versions, so I am creating version 3.5.1.

