### PR TITLE
bug closing runs due to schema change

### DIFF
--- a/src/python/T0Component/Tier0Feeder/Tier0FeederPoller.py
+++ b/src/python/T0Component/Tier0Feeder/Tier0FeederPoller.py
@@ -425,9 +425,8 @@ class Tier0FeederPoller(BaseWorkerThread):
                     self.updateClosedState(workflowName, workflowId)
                 else :
                     # Check if fileset (which you already know) is closed or not
-                    # FIXME: No better way to do it? what comes from the DAO is a string, casting bool or int doesn't help much.
                     # Works like that :
-                    if filesetOpen == '0':
+                    if filesetOpen == 0:
                         self.updateClosedState(workflowName, workflowId)
 
         return


### PR DESCRIPTION
With the change in sql schema described in https://github.com/dmwm/WMCore/issues/12339, T0 was struggling to close runs because the Tier0Feeder was expecting a string of value `0` in [L430](https://github.com/dmwm/T0/blob/master/src/python/T0Component/Tier0Feeder/Tier0FeederPoller.py#L427-L430)

The new schema features this `wmbs_fileset.open` value as an integer:
* Old wmbs_fileset table: [create.py](https://github.com/dmwm/wmcoredb/blob/main/src/python/db/wmbs/oracle/create.py#L59)
* New wmbs_fileset table: [create_wmbs_tables.py](https://github.com/dmwm/wmcoredb/blob/main/src/wmcoredb/sql/oracle/wmbs/create_wmbs_tables.sql#L7)