### PR TITLE
cache 5000 jobs

### DIFF
--- a/etc/Tier0Config.py
+++ b/etc/Tier0Config.py
@@ -20,6 +20,7 @@ config.JobSubmitter.LsfPluginResourceReq = "select[type==SLC5_64] rusage[pool=10
 config.JobSubmitter.LsfPluginJobGroup = "/groups/tier0/wmagent_testing"
 config.JobSubmitter.LsfPluginBatchOutput = "None"
 config.JobSubmitter.pollInterval = 30
+config.JobSubmitter.maxJobsToCache = 5000
 
 config.RetryManager.section_("PauseAlgo")
 config.RetryManager.PauseAlgo.section_("default")


### PR DESCRIPTION
At T0 we want to load only 5000 jobs instead of 100000. The reason for this is to force the agent to prioritize older jobs over new jobs.

Question to consider:
* Would this imply that old prompt reco jobs are submitted before new Express jobs?
