### PR TITLE
Replay configuration for CMSSW_15_0_13_patch2

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -147,7 +147,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_15_0_13_patch1"
+    'default': "CMSSW_15_0_13_patch2"
 }
 
 # Configure ScramArch


### PR DESCRIPTION
# Replay Request

**Requestor**  
ORM

**Describe the configuration**  
* Release: 
* Run: 393274
* GTs:
   * expressGlobalTag: 
   * promptrecoGlobalTag:
* Additional changes:

**Purpose of the test**  
A replay test is costly, both in computational and human resources. Please describe the reason why this test is needed.
[Build CMSSW_15_0_13_patch2](https://github.com/cms-sw/cmssw/issues/48815) with updates for the pixel local reco.

**T0 Operations cmsTalk thread**  
If necessary, provide a link to the cmsTalk thread announcing the test to the relevant groups. 
[Tier0 Operations cmsTalk Forum](https://cms-talk.web.cern.ch/c/offcomp/compops/tier0/210?)
