### PR TITLE
Keep lifetime at 3 months

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -284,7 +284,7 @@ addDataset(tier0Config, "Default",
            timePerEvent=5,
            sizePerEvent=1500,
            maxMemoryperCore=2000,
-           dataset_lifetime=15*24*3600,#lifetime for container rules. Default 2 weeks
+           dataset_lifetime=3*30*24*3600, #lifetime for container rules. Default 3 months
            scenario=ppScenario)
 
 #############################


### PR DESCRIPTION
We decided to leave the lifetime at 3 months, in order to avoid new data from not being transferred in the case that the destination container rule is removed.