### PR TITLE
Replay for CMSSW_15_0_15

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -147,7 +147,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_15_0_14"
+    'default': "CMSSW_15_0_15"
 }
 
 # Configure ScramArch


### PR DESCRIPTION
# Replay Request

**Requestor**  
ORM
(@prpalni)

**Describe the configuration**  
* Release: CMSSW_15_0_15
* Run:   
* GTs:
   * expressGlobalTag:  150X_dataRun3_Express_v2
   * promptrecoGlobalTag: 150X_dataRun3_Prompt_v1
* Additional changes:

**Purpose of the test**  

A test is necessary to validate the changes


**T0 Operations cmsTalk thread**  
If necessary, provide a link to the cmsTalk thread announcing the test to the relevant groups. 
[Tier0 Operations cmsTalk Forum](https://cms-talk.web.cern.ch/t/replay-request-for-cmssw-15-0-15/133279)
