### PR TITLE
Replay configuration for CMSSW_15_0_15_patch1

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -160,7 +160,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_15_0_15"
+    'default': "CMSSW_15_0_15_patch1"
 }
 
 # Configure ScramArch


### PR DESCRIPTION
# Replay Request

**Requestor**  
ORM

**Describe the configuration**  
* Release: 
* Run: 396421
* GTs:
   * expressGlobalTag: 
   * promptrecoGlobalTag:
* Additional changes:

**Purpose of the test**  
A replay test is costly, both in computational and human resources. Please describe the reason why this test is needed.

Changes since CMSSW_15_0_15:
https://github.com/cms-sw/cmssw/compare/CMSSW_15_0_15...CMSSW_15_0_15_patch1

https://github.com/cms-sw/cmssw/pull/49067 from https://github.com/CMSTrackerDPG: [15_0_X] Enabling SiPixel digi morphing from 2025 onward dqm operations ppd
https://github.com/cms-sw/cmssw/pull/48832 from https://github.com/CMSTrackerDPG: [15_0_X] Digi Morphing for HLT geometry reconstruction heterogeneous trk
CMSDIST Changes between Tags REL/CMSSW_15_0_15/el8_amd64_gcc12 and REL/CMSSW_15_0_15_patch1/el8_amd64_gcc12:
https://github.com/cms-sw/cmsdist/compare/REL/CMSSW_15_0_15/el8_amd64_gcc12...REL/CMSSW_15_0_15_patch1/el8_amd64_gcc12

The release notes of what changed with respect to CMSSW_15_0_15 can be found at:(https://github.com/cms-sw/cmssw/releases/CMSSW_15_0_15_patch1)

**T0 Operations cmsTalk thread**  
If necessary, provide a link to the cmsTalk thread announcing the test to the relevant groups. 
[Tier0 Operations cmsTalk Forum](https://cms-talk.web.cern.ch/c/offcomp/compops/tier0/210?)
