### PR TITLE
Support L1Scout NANOAOD

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -161,6 +161,7 @@ hiRawPrimeScenario = "ppEra_Run3_pp_on_PbPb_approxSiStripClusters_2023"
 hltScoutingScenario = "hltScoutingEra_Run3_2025"
 AlCaHcalIsoTrkScenario = "AlCaHcalIsoTrk_Run3"
 OXYScenario = "ppEra_Run3_2025_OXY"
+L1ScoutNanoScenario = "l1ScoutingEra_Run3_2026"
 
 # Heavy Ion Scenarios 2024
 
@@ -1568,10 +1569,27 @@ for dataset in DATASETS:
 ### Parking and Scouting PDs                         ###
 ########################################################
 
-DATASETS = ["L1Scouting","L1ScoutingSelection"]
+DATASETS = ["L1Scouting"]
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,
-               do_reco=False)
+               do_reco=True,
+               cmssw_version={'default': 'CMSSW_16_0_5'},                         
+               write_aod=False,
+               write_miniaod=False,
+               write_dqm=False,
+               nano_flavours=['@L1Scout'],
+               scenario=L1ScoutNanoScenario)
+
+DATASETS = ["L1ScoutingSelection"]
+for dataset in DATASETS:
+    addDataset(tier0Config, dataset,
+               do_reco=True,
+               cmssw_version={'default': 'CMSSW_16_0_5'},
+               write_aod=False,
+               write_miniaod=False,
+               write_dqm=False,
+               nano_flavours=['@L1ScoutSelect'],
+               scenario=L1ScoutNanoScenario)
 
 DATASETS = ["ScoutingPF0", "ScoutingPF1"] # From stream ScoutingPF --> Repacked to HLTSCOUT
 for dataset in DATASETS:

--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -160,7 +160,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_16_0_4"
+    'default': "CMSSW_16_0_5"
 }
 
 # Configure ScramArch
@@ -184,6 +184,7 @@ hiTestppScenario = "ppEra_Run3_pp_on_PbPb_2023"
 hiRawPrimeScenario = "ppEra_Run3_pp_on_PbPb_approxSiStripClusters_2023"
 hltScoutingScenario = "hltScoutingEra_Run3_2025"
 AlCaHcalIsoTrkScenario = "AlCaHcalIsoTrk_Run3"
+l1ScoutingScenario = "l1ScoutingEra_Run3_2026"
 
 # Procesing version number replays
 # Taking Replay processing ID from the last 8 digits of the DeploymentID
@@ -1268,12 +1269,20 @@ for dataset in DATASETS:
 DATASETS = ["L1Scouting"]
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,
-               do_reco=False)
+               do_reco=True,
+               write_aod=False,
+               write_miniaod=False,
+               nano_flavours=['@L1Scout'],
+               scenario=l1ScoutingScenario)
 
 DATASETS = ["L1ScoutingSelection"]
 for dataset in DATASETS:
     addDataset(tier0Config, dataset,
-               do_reco=False)
+               do_reco=True,                         
+               write_aod=False,
+               write_miniaod=False,
+               nano_flavours=['@L1ScoutSelect'],
+               scenario=l1ScoutingScenario)
 
 DATASETS = ["ScoutingPF0", "ScoutingPF1"] # From stream ScoutingPF --> Repacked to HLTSCOUT
 


### PR DESCRIPTION
For all details regarding these changes, please see https://its.cern.ch/jira/browse/CMSTZ-1100?filter=-2

These changes depend on two other PRs:
* WMCore: https://github.com/dmwm/WMCore/pull/12485
* CMSSW: https://github.com/cms-sw/cmssw/pull/50511

This configuration was tested with WMCore patch mentioned above. CMSSW_16_0_5 includes the CMSSW patch mentioned above. The output NANOAOD remains to be validated.

As far as I am concerned, we are ready
