### PR TITLE
Replay Request

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -160,7 +160,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_16_0_5_patch1"
+    'default': "CMSSW_16_0_6"
 }
 
 # Configure ScramArch


### PR DESCRIPTION
# Replay Request

**Requestor**  
ORM

**Describe the configuration**  
* Release: CMSSW_16_0_6
* Run: 402263
* GTs:
   * expressGlobalTag: "160X_dataRun3_Express_v2"
   * promptrecoGlobalTag: "160X_dataRun3_Prompt_v1"
* Additional changes:
-    *  Includes production of L1Scouting NANOAOD

**Purpose of the test**  
Test the new release

**T0 Operations cmsTalk thread**  
If necessary, provide a link to the cmsTalk thread announcing the test to the relevant groups. 
[Tier0 Operations cmsTalk Forum](https://cms-talk.web.cern.ch/c/offcomp/compops/tier0/210?)
