### PR TITLE
Replay request for CMSSW_16_0_7

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -160,7 +160,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_16_0_6"
+    'default': "CMSSW_16_0_7"
 }
 
 # Configure ScramArch


### PR DESCRIPTION
# Replay Request

**Requestor**  
ORM

**Describe the configuration**  
* Release: CMSSW_16_0_7
* Run: 402263
* GTs:
   * expressGlobalTag: 160X_dataRun3_Express_v2
   * promptrecoGlobalTag: 160X_dataRun3_Prompt_v1
* Additional changes: none

**Purpose of the test**  
Testing CMSSSW_16_0_7, contains updates for L1Scouting (possibly to be used during data taking in the next weeks)

**T0 Operations cmsTalk thread**  
[Replay request for CMSSW 16_0_7](https://cms-talk.web.cern.ch/t/replay-request-for-cmssw-16-0-7/144621)