### PR TITLE
Replay request for CMSSW_16_0_7_patch1

### DIFF
--- a/etc/ReplayOfflineConfiguration.py
+++ b/etc/ReplayOfflineConfiguration.py
@@ -160,7 +160,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_16_0_6"
+    'default': "CMSSW_16_0_7_patch1"
 }
 
 # Configure ScramArch


### PR DESCRIPTION
# Replay Request

**Requestor**  
ORM

**Describe the configuration**  
* Release: CMSSW_16_0_7_patch1
* Run: 402263
* GTs:
   * expressGlobalTag: 160X_dataRun3_Express_v2
   * promptrecoGlobalTag: 160X_dataRun3_Prompt_v1
* Additional changes: none

**Purpose of the test**  
Fix of CMSSW_16_0_7, that failed its replay, plus minor additions.

**T0 Operations cmsTalk thread**  
[https://cms-talk.web.cern.ch/t/replay-request-for-cmssw-16-0-7-patch1/144795](https://cms-talk.web.cern.ch/t/replay-request-for-cmssw-16-0-7-patch1/144795)
