### PR TITLE
CMSSW_16_0_7_patch1

### DIFF
--- a/etc/ProdOfflineConfiguration.py
+++ b/etc/ProdOfflineConfiguration.py
@@ -132,7 +132,7 @@ setPromptCalibrationConfig(tier0Config,
 # Defaults for CMSSW version
 # maxRunPreviousConfig = 402249
 defaultCMSSWVersion = {
-    'default': "CMSSW_16_0_6",
+    'default': "CMSSW_16_0_7_patch1",
     #'acqEra': {'Run2024F': "CMSSW_14_0_11"},
     # 'maxRun': {maxRunPreviousConfig: "CMSSW_16_0_2_patch1"}
 }


### PR DESCRIPTION
[https://cms-talk.web.cern.ch/t/t0-production-configuration-change-to-cmssw-16-0-7-patch1/144915](https://cms-talk.web.cern.ch/t/t0-production-configuration-change-to-cmssw-16-0-7-patch1/144915)