### PR TITLE
Replay configuration for CMSSW_16_1_1

### DIFF
--- a/etc/HIReplayOfflineConfiguration.py
+++ b/etc/HIReplayOfflineConfiguration.py
@@ -110,7 +110,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_15_1_0_patch4"
+    'default': "CMSSW_16_1_1"
 }
 
 # Configure ScramArch
@@ -133,11 +133,11 @@ alcaPPSScenario = "AlCaPPS_Run3"
 hltScoutingScenario = "hltScoutingEra_Run3_2025"
 ppRefScenario = "ppEra_Run3_2024_ppRef"
 
-# Heavy Ion Scenarios 2024
+# Heavy Ion Scenarios 2026
 
-hiForwardScenario = "ppEra_Run3_2025_UPC"
-hiScenario = "ppEra_Run3_pp_on_PbPb_2025"
-hiRawPrimeScenario = "ppEra_Run3_pp_on_PbPb_approxSiStripClusters_2025"
+hiForwardScenario = "ppEra_Run3_2026_UPC"
+hiScenario = "ppEra_Run3_pp_on_PbPb_2026"
+hiRawPrimeScenario = "ppEra_Run3_pp_on_PbPb_approxSiStripClusters_2026"
 
 
 # Procesing version number replays


### PR DESCRIPTION
# Replay Request

**Requestor**  
ORM - 

**Describe the configuration**  
* Release:  CMSSW_16_1_1
* Run: 400007
* GTs:
   * expressGlobalTag: 
   * promptrecoGlobalTag:
* Additional changes:

**Purpose of the test**  
HI 2026 scenario
This release contains everything currently known to be needed for HI 2026 data taking
Details [here](https://github.com/cms-sw/cmssw/releases/CMSSW_16_1_1)


**T0 Operations cmsTalk thread**  
If necessary, provide a link to the cmsTalk thread announcing the test to the relevant groups. 
[Tier0 Operations cmsTalk Forum](https://cms-talk.web.cern.ch/c/offcomp/compops/tier0/210?)
