### PR TITLE
write HIEmptyBX events at T2_CH_CERN

### DIFF
--- a/etc/HIProdOfflineConfiguration.py
+++ b/etc/HIProdOfflineConfiguration.py
@@ -1606,10 +1606,10 @@ for dataset in DATASETS:
                do_reco=True,
                write_nanoaod=False,
                write_dqm=True,
-               raw_to_disk=False,
-               aod_to_disk=False,
+               raw_to_disk=True,
+               aod_to_disk=True,
                tape_node="T0_CH_CERN_MSS",
-               disk_node="T2_US_Vanderbilt",
+               disk_node="T2_CH_CERN",
                dqm_sequences=["@common"],
                scenario=hiScenario)
 


### PR DESCRIPTION
Since the HIEmptyBX dataset is mainly used for commissioning, we would like to store the events at CERN's Tier-2 on disk directly for easier access and usage.
The rate of the triggers feeding this dataset will be carefully adjusted to tens of Hz and the prescales set to zero when needed.

Thank you!
Florian for HIN and HLT

FYI @mandrenguyen , @icali , cms-trigger-coordinator@cern.ch