### PR TITLE
move to CMSSW_16_1_1_patch3 and add producers for HLT Alignment PCL

### DIFF
--- a/etc/HIProdOfflineConfiguration.py
+++ b/etc/HIProdOfflineConfiguration.py
@@ -101,7 +101,7 @@ setPromptCalibrationConfig(tier0Config,
 # maxRunPreviousConfig = 999999 # Last run before era change 08/09/23
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_16_1_1",
+    'default': "CMSSW_16_1_1_patch3",
     # 'acqEra': {'HIRun2025A': "CMSSW_15_1_0_patch3"},
     #'maxRun': {maxRunPreviousConfig: "CMSSW_13_2_2"}
 }
@@ -534,7 +534,7 @@ addExpressConfig(tier0Config, "HIHLTMonitor",
                  diskNode="T2_CH_CERN",
                  data_tiers=["FEVTHLTALL"],
                  write_dqm=True,
-                 alca_producers=[],
+                 alca_producers=["TkAlHLTTracks", "TkAlHLTTracksZMuMu", "PromptCalibProdSiPixelAliHLTHGC"],
                  dqm_sequences=["@HLTMon"],
                  reco_version=defaultCMSSWVersion,
                  multicore=numberOfCores,

--- a/etc/HIReplayOfflineConfiguration.py
+++ b/etc/HIReplayOfflineConfiguration.py
@@ -41,7 +41,7 @@ setConfigVersion(tier0Config, "3.2.3")
 # 374951:    HI 2023 3.8 TB
 # 387456:    Test HI 2024 with memory problems 3.1 TB
 # 388621:    Small HI for 2025 replay
-setInjectRuns(tier0Config, [400007])
+setInjectRuns(tier0Config, [404616])
 
 # Settings up sites
 processingSite = "T2_CH_CERN"
@@ -110,7 +110,7 @@ setPromptCalibrationConfig(tier0Config,
 
 # Defaults for CMSSW version
 defaultCMSSWVersion = {
-    'default': "CMSSW_16_1_1"
+    'default': "CMSSW_16_1_1_patch3"
 }
 
 # Configure ScramArch
@@ -524,7 +524,7 @@ addExpressConfig(tier0Config, "HIHLTMonitor",
                  diskNode="T0_CH_CERN_Disk",
                  data_tiers=["FEVTHLTALL"],
                  write_dqm=True,
-                 alca_producers=[],
+                 alca_producers=["TkAlHLTTracks", "TkAlHLTTracksZMuMu", "PromptCalibProdSiPixelAliHLTHGC"],
                  dqm_sequences=["@HLTMon"],
                  reco_version=defaultCMSSWVersion,
                  multicore=numberOfCores,


### PR DESCRIPTION
# Replay Request

**Requestor**  
ORM

**Describe the configuration**  
* Release: CMSSW_16_1_1_patch3 
* Run: 404616 (tentatively)
* GTs:
   * `161X_dataRun3_Express_v1`
   *  `161X_dataRun3_Prompt_v1`
* Additional changes:
   * add `"TkAlHLTTracks", "TkAlHLTTracksZMuMu", "PromptCalibProdSiPixelAliHLTHGC"` to the `HIHLTMonitor` PD.

**Purpose of the test**  
Test `PromptCalibProdSiPixelAliHLTHGC` in 2026 PbPb.

**T0 Operations cmsTalk thread**  

https://cms-talk.web.cern.ch/t/replay-request-for-cmssw-16-1-1-patch3/145648
